### PR TITLE
feat: add TypeScript type inference for ListComponent props

### DIFF
--- a/.changeset/fair-crabs-tell.md
+++ b/.changeset/fair-crabs-tell.md
@@ -1,0 +1,23 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+feat: add TypeScript type inference for ListComponent props
+
+The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
+
+```tsx
+import { FlashList } from '@shopify/flash-list';
+
+function App() {
+  return (
+    <GestureImageViewer
+      data={images}
+      ListComponent={FlashList}
+      listProps={{
+        // ✅ FlashList props autocompletion
+      }}
+    />
+  );
+}
+```

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -16,7 +16,7 @@ React Native에서 이미지 갤러리나 콘텐츠 뷰어를 구현할 때, 복
 - ✅ **외부 제어 API** - 버튼이나 다른 컴포넌트에서 프로그래밍 방식으로 제어
 - ✅ **다중 인스턴스 관리** - ID 기반으로 여러 뷰어를 독립적으로 관리
 - ✅ **유연한 통합** - FlatList, FlashList, Expo Image, FastImage 등 원하는 컴포넌트 사용
-- ✅ **TypeScript 완전 지원** - 타입 안정성과 개발자 경험 향상
+- ✅ **완벽한 TypeScript 지원** - 스마트 타입 추론으로 향상된 개발 경험
 - ✅ **크로스 플랫폼** - iOS, Android, Web 모든 플랫폼 지원
 - ✅ **사용하기 쉬운 API** - 직관적이고 간단한 구현, 복잡한 설정 불필요
 - ✅ **다양한 환경 지원** - Expo Go, New Architecture 지원
@@ -169,16 +169,18 @@ function App() {
 #### 리스트 컴포넌트
 
 `ListComponent` props를 통해 `ScrollView`, `FlatList`, `FlashList` 등 원하는 리스트를 지원합니다.   
-또한, `listProps`를 통해 기본적으로 지원하는 각각의 리스트 컴포넌트의 props를 커스텀할 수 있습니다.
+`listProps`는 **선택한 리스트 컴포넌트에 맞는 타입 추론**을 제공하여, IDE에서 정확한 자동완성과 타입 안전성을 보장합니다.
 
 ```tsx
+import { FlashList } from '@shopify/flash-list';
+
 function App() {
   return (
     <GestureImageViewer
       data={images}
-      ListComponent={FlatList}
+      ListComponent={FlashList}
       listProps={{
-        // ....
+        // ✅ FlashList props 자동완성
       }}
     />
   );

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Existing libraries often have limited customization options or performance issue
 - ✅ **External Control API** - Programmatic control from buttons or other components
 - ✅ **Multi-Instance Management** - ID-based independent management of multiple viewers
 - ✅ **Flexible Integration** - Use with FlatList, FlashList, Expo Image, FastImage, and more
-- ✅ **Full TypeScript Support** - Type safety and enhanced developer experience
+- ✅ **Full TypeScript Support** - Enhanced developer experience with smart type inference
 - ✅ **Cross-Platform** - iOS, Android, and Web support
 - ✅ **Easy-to-Use API** - Intuitive and simple implementation without complex setup
 - ✅ **Various Environment Support** - Expo Go and New Architecture support
@@ -168,17 +168,19 @@ function App() {
 
 #### List Components
 
-Support for `ScrollView`, `FlatList`, `FlashList`, and other list components through the `ListComponent` prop.   
-You can also customize the props of each supported list component through `listProps`.
+Support for any list component like `ScrollView`, `FlatList`, `FlashList` through the `ListComponent` prop.   
+The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
 
 ```tsx
+import { FlashList } from '@shopify/flash-list';
+
 function App() {
   return (
     <GestureImageViewer
       data={images}
-      ListComponent={FlatList}
+      ListComponent={FlashList}
       listProps={{
-        // ....
+        // ✅ FlashList props autocompletion
       }}
     />
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,19 @@
-import type { StyleProp, ViewStyle } from 'react-native';
-import type { SharedValue } from 'react-native-reanimated';
+import type React from 'react';
+import type { FlatList as RNFlatList, ScrollView as RNScrollView, StyleProp, ViewStyle } from 'react-native';
+import type { FlatList as GHFlatList, ScrollView as GHScrollView } from 'react-native-gesture-handler';
 
-export interface GestureImageViewerProps<T = any> {
+export type FlatListComponent = typeof RNFlatList | typeof GHFlatList;
+export type ScrollViewComponent = typeof RNScrollView | typeof GHScrollView;
+
+type GetComponentProps<T> = T extends React.ComponentType<infer P> ? P : any;
+
+type ConditionalListProps<LC> = LC extends FlatListComponent
+  ? React.ComponentProps<FlatListComponent>
+  : LC extends ScrollViewComponent
+    ? React.ComponentProps<ScrollViewComponent>
+    : GetComponentProps<LC>;
+
+export interface GestureImageViewerProps<T = any, LC = typeof RNFlatList> {
   id?: string;
   data: T[];
   initialIndex?: number;
@@ -9,15 +21,15 @@ export interface GestureImageViewerProps<T = any> {
   onDismiss?: () => void;
   renderImage: (item: T, index: number) => React.ReactElement;
   renderContainer?: (children: React.ReactElement) => React.ReactElement;
-  ListComponent?: any; // FlatList, FlashList 등
+  ListComponent: LC;
   width?: number;
   dismissThreshold?: number;
-  swipeThreshold?: number;
-  velocityThreshold?: number;
+  // swipeThreshold?: number;
+  // velocityThreshold?: number;
   enableDismissGesture?: boolean;
   enableSwipeGesture?: boolean;
   resistance?: number;
-  listProps?: any; // FlatList, FlashList에 전달할 추가 props
+  listProps?: Partial<ConditionalListProps<LC>>;
   backdropStyle?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
   animateBackdrop?: boolean;
@@ -26,11 +38,4 @@ export interface GestureImageViewerProps<T = any> {
   enableDoubleTapGesture?: boolean;
   maxZoomScale?: number;
   itemSpacing?: number;
-}
-
-export interface GestureState {
-  currentIndex: number;
-  translateY: SharedValue<number>;
-  isGestureActive: boolean;
-  lockDirection: 'horizontal' | 'vertical' | null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,12 @@ import type { FlatList as GHFlatList, ScrollView as GHScrollView } from 'react-n
 export type FlatListComponent = typeof RNFlatList | typeof GHFlatList;
 export type ScrollViewComponent = typeof RNScrollView | typeof GHScrollView;
 
-type GetComponentProps<T> = T extends React.ComponentType<infer P> ? P : any;
+type GetComponentProps<T> = T extends React.ComponentType<infer P> ? P : never;
 
 type ConditionalListProps<LC> = LC extends FlatListComponent
-  ? React.ComponentProps<FlatListComponent>
+  ? React.ComponentProps<LC>
   : LC extends ScrollViewComponent
-    ? React.ComponentProps<ScrollViewComponent>
+    ? React.ComponentProps<LC>
     : GetComponentProps<LC>;
 
 export interface GestureImageViewerProps<T = any, LC = typeof RNFlatList> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,20 @@
 import { FlatList as RNFlatList, ScrollView as RNScrollView } from 'react-native';
 import { FlatList as GestureFlatList, ScrollView as GestureScrollView } from 'react-native-gesture-handler';
+import type { FlatListComponent, ScrollViewComponent } from './types';
 
-export const isScrollViewLike = (component: any): component is typeof RNScrollView => {
+export const isScrollViewLike = (component: any): component is ScrollViewComponent => {
   return component === RNScrollView || component === GestureScrollView;
 };
 
-export const isFlatListLike = (component: any): component is typeof RNFlatList => {
+export const isFlatListLike = (component: any): component is FlatListComponent => {
+  if (component === RNFlatList || component === GestureFlatList || isFlashListLike(component)) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isFlashListLike = (component: any): component is any => {
   try {
     const FlashList = require('@shopify/flash-list')?.FlashList;
 
@@ -14,10 +23,6 @@ export const isFlatListLike = (component: any): component is typeof RNFlatList =
     }
   } catch {
     // do nothing
-  }
-
-  if (component === RNFlatList || component === GestureFlatList) {
-    return true;
   }
 
   return component?.name === 'FlashList';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript type inference for list component props in the image viewer, enabling accurate autocompletion and type safety with custom list components like FlashList.
  * Enhanced support for any list-like component by generalizing list component handling and conditionally applying props based on the list type.

* **Documentation**
  * Updated English and Korean documentation to clarify enhanced TypeScript support and provide examples using FlashList, highlighting improved prop type inference and IDE autocompletion.

* **Bug Fixes**
  * Ensured that certain props are only passed to compatible list components, preventing unintended prop usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->