### PR TITLE
refactor: rename GestureImageViewer to GestureViewer for broader use cases

### DIFF
--- a/.changeset/tender-queens-agree.md
+++ b/.changeset/tender-queens-agree.md
@@ -1,0 +1,27 @@
+---
+"react-native-gesture-image-viewer": major
+---
+
+refactor: rename GestureImageViewer to GestureViewer for broader use cases
+
+#### Changed
+- **BREAKING CHANGE**: Renamed `GestureImageViewer` to `GestureViewer` for broader use cases
+- **BREAKING CHANGE**: Renamed `useImageViewerController` hook to `useGestureViewerController`
+- **BREAKING CHANGE**: Renamed `renderImage` prop to `renderItem` in `GestureViewer`
+
+#### Migration Guide
+```tsx
+// Before
+import { GestureImageViewer, useImageViewerController } from 'react-native-gesture-image-viewer';
+
+<GestureImageViewer 
+  renderImage={(item) => <Image source={item} />}
+/>
+
+// After  
+import { GestureViewer, useGestureViewerController } from 'react-native-gesture-image-viewer';
+
+<GestureViewer 
+  renderItem={(item) => <Image source={item} />}
+/>
+```

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -15,7 +15,7 @@ React Native에서 이미지 갤러리나 콘텐츠 뷰어를 구현할 때, 복
 - ✅ **완전한 커스터마이징** - 컴포넌트, 스타일, 동작 모든 것을 사용자 정의 가능
 - ✅ **외부 제어 API** - 버튼이나 다른 컴포넌트에서 프로그래밍 방식으로 제어
 - ✅ **다중 인스턴스 관리** - ID 기반으로 여러 뷰어를 독립적으로 관리
-- ✅ **유연한 통합** - FlatList, FlashList, Expo Image, FastImage 등 원하는 컴포넌트 사용
+- ✅ **유연한 통합** - Modal, [React Native Modal](https://www.npmjs.com/package/react-native-modal), ScrollView, FlatList, [FlashList](https://www.npmjs.com/package/@shopify/flash-list), [Expo Image](https://www.npmjs.com/package/expo-image), [FastImage](https://github.com/DylanVann/react-native-fast-image) 등 원하는 컴포넌트 사용
 - ✅ **완벽한 TypeScript 지원** - 스마트 타입 추론으로 향상된 개발 경험
 - ✅ **크로스 플랫폼** - iOS, Android, Web 모든 플랫폼 지원
 - ✅ **사용하기 쉬운 API** - 직관적이고 간단한 구현, 복잡한 설정 불필요
@@ -115,7 +115,7 @@ bun add react-native-gesture-image-viewer
 
 ```tsx
 import { Image, Modal } from 'react-native';
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 
 function App() {
   const images = [...];
@@ -128,9 +128,9 @@ function App() {
 
   return (
     <Modal visible={visible} onRequestClose={() => setVisible(false)}>
-      <GestureImageViewer
+      <GestureViewer
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
         onDismiss={() => setVisible(false)}
       />
     </Modal>
@@ -145,9 +145,9 @@ function App() {
 ```tsx
 function App() {
   return (
-    <GestureImageViewer
+    <GestureViewer
       data={images}
-      renderImage={renderImage}
+      renderItem={renderImage}
       enableDismissGesture
       enableSwipeGesture
       enableZoomGesture
@@ -180,7 +180,7 @@ import { FlashList } from '@shopify/flash-list';
 
 function App() {
   return (
-    <GestureImageViewer
+    <GestureViewer
       data={images}
       ListComponent={FlashList}
       listProps={{
@@ -193,10 +193,10 @@ function App() {
 
 #### 콘텐츠 컴포넌트
 
-`renderImage` props를 통해 `expo-image`, `FastImage` 등 다양한 종류의 콘텐츠 컴포넌트를 주입하여 제스처를 사용할 수 있습니다.
+`renderItem` props를 통해 `expo-image`, `FastImage` 등 다양한 종류의 콘텐츠 컴포넌트를 주입하여 제스처를 사용할 수 있습니다.
 
 ```tsx
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 import { Image } from 'expo-image';
 
 function App() {
@@ -205,9 +205,9 @@ function App() {
   }, []);
 
   return (
-    <GestureImageViewer
+    <GestureViewer
       data={images}
-      renderImage={renderImage}
+      renderItem={renderImage}
     />
   );
 }
@@ -218,16 +218,16 @@ function App() {
 `react-native-gesture-image-viewer`는 강력한 기능으로 버튼이나 다른 컴포넌트에서 프로그래밍 방식으로 제어할 수 있는 hook을 지원합니다.
 
 ```tsx
-import { GestureImageViewer, useImageViewerController } from 'react-native-gesture-image-viewer';
+import { GestureViewer, useGestureViewerController } from 'react-native-gesture-image-viewer';
 
 function App() {
-  const { goToIndex, goToPrevious, goToNext, currentIndex, totalCount } = useImageViewerController();
+  const { goToIndex, goToPrevious, goToNext, currentIndex, totalCount } = useGestureViewerController();
 
   return (
     <View>
-      <GestureImageViewer
+      <GestureViewer
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
       />
       <View
         style={{
@@ -251,14 +251,14 @@ function App() {
 
 ### 스타일 커스터마이징
 
-`GestureImageViewer`의 스타일을 커스터마이징할 수 있습니다.
+`GestureViewer`의 스타일을 커스터마이징할 수 있습니다.
 
 ```tsx
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 
 function App() {
   return (
-    <GestureImageViewer
+    <GestureViewer
       animateBackdrop={false}
       width={400}
       itemSpacing={20}
@@ -277,36 +277,36 @@ function App() {
 |`itemSpacing`|콘텐츠 아이템 사이의 값을 지정할 수 있습니다.|`0`|
 |`containerStyle`|리스트 컴포넌트를 감싸고 있는 컨테이너 스타일을 커스텀하게 수정할 수 있습니다.|`flex: 1`|
 |`backdropStyle`|뷰어 배경의 스타일을 커스터마이징할 수 있습니다.|`backgroundColor: black; StyleSheet.absoluteFill;`|
-|`renderContainer`|`<GestureImageViewer />`를 감싸는 래퍼 컴포넌트를 커스텀하여 적용할 수 있습니다.||
+|`renderContainer`|`<GestureViewer />`를 감싸는 래퍼 컴포넌트를 커스텀하여 적용할 수 있습니다.||
 
 ### 다중 인스턴스 관리
 
-여러 개의 `GestureImageViewer` 인스턴스를 효율적으로 관리하고 싶은 경우 `id` 값을 적용하면 여러 개의 `GestureImageViewer`를 사용할 수 있습니다.   
-`GestureImageViewer`는 컴포넌트가 언마운트되면 메모리에서 자동으로 인스턴스가 제거되어 메모리 관리를 수동으로 할 필요가 없습니다.   
+여러 개의 `GestureViewer` 인스턴스를 효율적으로 관리하고 싶은 경우 `id` 값을 적용하면 여러 개의 `GestureViewer`를 사용할 수 있습니다.   
+`GestureViewer`는 컴포넌트가 언마운트되면 메모리에서 자동으로 인스턴스가 제거되어 메모리 관리를 수동으로 할 필요가 없습니다.   
 
 > `id` 기본값은 `default`입니다.
 
 ```tsx
-import { GestureImageViewer, useImageViewerController } from 'react-native-gesture-image-viewer';
+import { GestureViewer, useGestureViewerController } from 'react-native-gesture-image-viewer';
 
 const firstViewerId = 'firstViewerId';
 const secondViewerId = 'secondViewerId';
 
 function App() {
-  const { currentIndex: firstCurrentIndex, totalCount: firstTotalCount } = useImageViewerController(firstViewerId);
-  const { currentIndex: secondCurrentIndex, totalCount: secondTotalCount } = useImageViewerController(secondViewerId);
+  const { currentIndex: firstCurrentIndex, totalCount: firstTotalCount } = useGestureViewerController(firstViewerId);
+  const { currentIndex: secondCurrentIndex, totalCount: secondTotalCount } = useGestureViewerController(secondViewerId);
 
   return (
     <View>
-      <GestureImageViewer
+      <GestureViewer
         id={firstViewerId}
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
       />
-      <GestureImageViewer
+      <GestureViewer
         id={secondViewerId}
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
       />
     </View>
   );
@@ -319,13 +319,13 @@ function App() {
 `index` 값이 변경될 때 `onIndexChange` 콜백함수가 호출됩니다.
 
 ```tsx
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 
 function App() {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   return (
-    <GestureImageViewer
+    <GestureViewer
       onIndexChange={setCurrentIndex}
     />
   );
@@ -346,7 +346,7 @@ function App() {
 
 ## 성능 최적화 팁
 
-- `renderImage` 함수는 `useCallback`으로 감싸서 불필요한 리렌더링을 방지하세요.
+- `renderItem` 함수는 `useCallback`으로 감싸서 불필요한 리렌더링을 방지하세요.
 - 대용량 이미지의 경우 `FastImage`나 `expo-image` 사용을 권장합니다.
 - 많은 수의 이미지를 다룰 때는 `FlashList` 사용을 권장합니다.
 - 디바이스에서 테스트하세요. (시뮬레이터에서는 성능이 제한될 수 있습니다.)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Existing libraries often have limited customization options or performance issue
 - ✅ **Full Customization** - Complete control over components, styles, and behaviors
 - ✅ **External Control API** - Programmatic control from buttons or other components
 - ✅ **Multi-Instance Management** - ID-based independent management of multiple viewers
-- ✅ **Flexible Integration** - Use with FlatList, FlashList, Expo Image, FastImage, and more
+- ✅ **Flexible Integration** - Use with Modal, [React Native Modal](https://www.npmjs.com/package/react-native-modal), ScrollView, FlatList, [FlashList](https://www.npmjs.com/package/@shopify/flash-list), [Expo Image](https://www.npmjs.com/package/expo-image), [FastImage](https://github.com/DylanVann/react-native-fast-image), and more
 - ✅ **Full TypeScript Support** - Enhanced developer experience with smart type inference
 - ✅ **Cross-Platform** - iOS, Android, and Web support
 - ✅ **Easy-to-Use API** - Intuitive and simple implementation without complex setup
@@ -115,7 +115,7 @@ You can create a viewer using any `Modal` of your choice as shown below:
 
 ```tsx
 import { Image, Modal } from 'react-native';
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 
 function App() {
   const images = [...];
@@ -128,9 +128,9 @@ function App() {
 
   return (
     <Modal visible={visible} onRequestClose={() => setVisible(false)}>
-      <GestureImageViewer
+      <GestureViewer
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
         onDismiss={() => setVisible(false)}
       />
     </Modal>
@@ -145,9 +145,9 @@ function App() {
 ```tsx
 function App() {
   return (
-    <GestureImageViewer
+    <GestureViewer
       data={images}
-      renderImage={renderImage}
+      renderItem={renderImage}
       enableDismissGesture
       enableSwipeGesture
       enableZoomGesture
@@ -180,7 +180,7 @@ import { FlashList } from '@shopify/flash-list';
 
 function App() {
   return (
-    <GestureImageViewer
+    <GestureViewer
       data={images}
       ListComponent={FlashList}
       listProps={{
@@ -196,7 +196,7 @@ function App() {
 You can inject various types of content components like `expo-image`, `FastImage`, etc., through the `renderImage` prop to use gestures.
 
 ```tsx
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 import { Image } from 'expo-image';
 
 function App() {
@@ -205,9 +205,9 @@ function App() {
   }, []);
 
   return (
-    <GestureImageViewer
+    <GestureViewer
       data={images}
-      renderImage={renderImage}
+      renderItem={renderImage}
     />
   );
 }
@@ -218,16 +218,16 @@ function App() {
 `react-native-gesture-image-viewer` provides powerful hooks for programmatic control from buttons or other components.
 
 ```tsx
-import { GestureImageViewer, useImageViewerController } from 'react-native-gesture-image-viewer';
+import { GestureViewer, useGestureViewerController } from 'react-native-gesture-image-viewer';
 
 function App() {
-  const { goToIndex, goToPrevious, goToNext, currentIndex, totalCount } = useImageViewerController();
+  const { goToIndex, goToPrevious, goToNext, currentIndex, totalCount } = useGestureViewerController();
 
   return (
     <View>
-      <GestureImageViewer
+      <GestureViewer
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
       />
       <View
         style={{
@@ -251,14 +251,14 @@ function App() {
 
 ### Style Customization
 
-You can customize the styling of `GestureImageViewer`.
+You can customize the styling of `GestureViewer`.
 
 ```tsx
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 
 function App() {
   return (
-    <GestureImageViewer
+    <GestureViewer
       animateBackdrop={false}
       width={400}
       itemSpacing={20}
@@ -277,36 +277,36 @@ function App() {
 |`itemSpacing`|Specifies the spacing between list items.|`0`|
 |`containerStyle`|Allows custom styling of the container that wraps the list component.|`flex: 1`|
 |`backdropStyle`|Allows customization of the viewer's background style.|`backgroundColor: black; StyleSheet.absoluteFill;`|
-|`renderContainer`|Allows custom wrapper component around `<GestureImageViewer />`.||
+|`renderContainer`|Allows custom wrapper component around `<GestureViewer />`.||
 
 ### Multi-Instance Management
 
-When you want to efficiently manage multiple `GestureImageViewer` instances, you can use the `id` prop to use multiple `GestureImageViewer` components.   
-`GestureImageViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.   
+When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.   
+`GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.   
 
 > The default `id` value is `default`.
 
 ```tsx
-import { GestureImageViewer, useImageViewerController } from 'react-native-gesture-image-viewer';
+import { GestureViewer, useGestureViewerController } from 'react-native-gesture-image-viewer';
 
 const firstViewerId = 'firstViewerId';
 const secondViewerId = 'secondViewerId';
 
 function App() {
-  const { currentIndex: firstCurrentIndex, totalCount: firstTotalCount } = useImageViewerController(firstViewerId);
-  const { currentIndex: secondCurrentIndex, totalCount: secondTotalCount } = useImageViewerController(secondViewerId);
+  const { currentIndex: firstCurrentIndex, totalCount: firstTotalCount } = useGestureViewerController(firstViewerId);
+  const { currentIndex: secondCurrentIndex, totalCount: secondTotalCount } = useGestureViewerController(secondViewerId);
 
   return (
     <View>
-      <GestureImageViewer
+      <GestureViewer
         id={firstViewerId}
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
       />
-      <GestureImageViewer
+      <GestureViewer
         id={secondViewerId}
         data={images}
-        renderImage={renderImage}
+        renderItem={renderImage}
       />
     </View>
   );
@@ -319,13 +319,13 @@ function App() {
 The `onIndexChange` callback function is called when the `index` value changes.
 
 ```tsx
-import { GestureImageViewer } from 'react-native-gesture-image-viewer';
+import { GestureViewer } from 'react-native-gesture-image-viewer';
 
 function App() {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   return (
-    <GestureImageViewer
+    <GestureViewer
       onIndexChange={setCurrentIndex}
     />
   );
@@ -346,7 +346,7 @@ Controls the maximum zoom scale multiplier.
 
 ## Performance Optimization Tips
 
-- Wrap the `renderImage` function with `useCallback` to prevent unnecessary re-renders.
+- Wrap the `renderItem` function with `useCallback` to prevent unnecessary re-renders.
 - For large images, we recommend using `FastImage` or `expo-image`.
 - For handling many images, we recommend using `FlashList`.
 - Test on actual devices (performance may be limited in simulators).

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -3,7 +3,7 @@ import { FlashList } from '@shopify/flash-list';
 import { Image } from 'expo-image';
 import { useCallback, useState } from 'react';
 import { Button, Modal, StyleSheet, Text, View } from 'react-native';
-import { GestureImageViewer, useImageViewerController } from 'react-native-gesture-image-viewer';
+import { GestureViewer, useGestureViewerController } from 'react-native-gesture-image-viewer';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const images = [
@@ -17,7 +17,7 @@ const images = [
 function Example() {
   const [visible, setVisible] = useState(false);
 
-  const { goToIndex, goToPrevious, goToNext, currentIndex, totalCount } = useImageViewerController();
+  const { goToIndex, goToPrevious, goToNext, currentIndex, totalCount } = useGestureViewerController();
 
   const insets = useSafeAreaInsets();
 
@@ -30,12 +30,12 @@ function Example() {
       <Button title="Open" onPress={() => setVisible(true)} />
       <Modal visible={visible} onRequestClose={() => setVisible(false)}>
         <View style={{ flex: 1 }}>
-          <GestureImageViewer
+          <GestureViewer
             data={images}
             initialIndex={0}
             onDismiss={() => setVisible(false)}
             ListComponent={FlashList}
-            renderImage={renderImage}
+            renderItem={renderImage}
             backdropStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.90)' }}
             renderContainer={(children) => <View style={{ flex: 1 }}>{children}</View>}
           />

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -2,16 +2,16 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { type FlatList, Platform, type ScrollViewProps, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
-import { registry } from './ImageViewerRegistry';
-import type { GestureImageViewerProps } from './types';
-import { useGestureImageViewer } from './useGestureImageViewer';
+import { registry } from './GestureViewerRegistry';
+import type { GestureViewerProps } from './types';
+import { useGestureViewer } from './useGestureViewer';
 import { isFlashListLike, isFlatListLike, isScrollViewLike } from './utils';
 import WebPagingFixStyle from './WebPagingFixStyle';
 
-export function GestureImageViewer<T = any, LC = typeof FlatList>({
+export function GestureViewer<T = any, LC = typeof FlatList>({
   id = 'default',
   data,
-  renderImage,
+  renderItem: renderItemProp,
   renderContainer,
   ListComponent,
   width: customWidth,
@@ -21,7 +21,7 @@ export function GestureImageViewer<T = any, LC = typeof FlatList>({
   initialIndex = 0,
   itemSpacing = 0,
   ...props
-}: GestureImageViewerProps<T, LC>) {
+}: GestureViewerProps<T, LC>) {
   const Component = ListComponent as React.ComponentType<any>;
 
   const { width: screenWidth } = useWindowDimensions();
@@ -29,7 +29,7 @@ export function GestureImageViewer<T = any, LC = typeof FlatList>({
   const width = customWidth || screenWidth;
 
   const { listRef, isZoomed, dismissGesture, zoomGesture, onMomentumScrollEnd, animatedStyle, backdropStyle } =
-    useGestureImageViewer({
+    useGestureViewer({
       id,
       data,
       width,
@@ -53,11 +53,11 @@ export function GestureImageViewer<T = any, LC = typeof FlatList>({
             },
           ]}
         >
-          {renderImage(item, index)}
+          {renderItemProp(item, index)}
         </View>
       );
     },
-    [width, itemSpacing, renderImage],
+    [width, itemSpacing, renderItemProp],
   );
 
   const getItemLayout = useCallback(

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -1,15 +1,15 @@
-export type ImageViewerManagerState = {
+export type GestureViewerManagerState = {
   currentIndex: number;
   dataLength: number;
 };
 
-class ImageViewerManager {
+class GestureViewerManager {
   private currentIndex = 0;
   private dataLength = 0;
   private width = 0;
   private listRef: any | null = null;
   private enableSwipeGesture = true;
-  private listeners = new Set<(state: ImageViewerManagerState) => void>();
+  private listeners = new Set<(state: GestureViewerManagerState) => void>();
 
   // private updateState(newState: Partial<any>) {
   //   Object.assign(this, newState);
@@ -22,7 +22,7 @@ class ImageViewerManager {
     this.listeners.forEach((listener) => listener(state));
   }
 
-  subscribe(listener: (state: ImageViewerManagerState) => void) {
+  subscribe(listener: (state: GestureViewerManagerState) => void) {
     this.listeners.add(listener);
 
     return () => {
@@ -100,4 +100,4 @@ class ImageViewerManager {
   }
 }
 
-export default ImageViewerManager;
+export default GestureViewerManager;

--- a/src/GestureViewerRegistry.ts
+++ b/src/GestureViewerRegistry.ts
@@ -1,10 +1,10 @@
-import ImageViewerManager from './ImageViewerManager';
+import GestureViewerManager from './GestureViewerManager';
 
-class ImageViewerRegistry {
-  private managers = new Map<string, ImageViewerManager>();
-  private subscribers = new Map<string, Set<(manager: ImageViewerManager | null) => void>>();
+class GestureViewerRegistry {
+  private managers = new Map<string, GestureViewerManager>();
+  private subscribers = new Map<string, Set<(manager: GestureViewerManager | null) => void>>();
 
-  subscribeToManager(id: string, callback: (manager: ImageViewerManager | null) => void) {
+  subscribeToManager(id: string, callback: (manager: GestureViewerManager | null) => void) {
     if (!this.subscribers.has(id)) {
       this.subscribers.set(id, new Set());
     }
@@ -26,12 +26,12 @@ class ImageViewerRegistry {
     };
   }
 
-  createManager(id: string): ImageViewerManager | null {
+  createManager(id: string): GestureViewerManager | null {
     if (this.managers.has(id)) {
       return this.managers.get(id) || null;
     }
 
-    const manager = new ImageViewerManager();
+    const manager = new GestureViewerManager();
     this.managers.set(id, manager);
 
     this.notifySubscribers(id, manager);
@@ -39,7 +39,7 @@ class ImageViewerRegistry {
     return manager;
   }
 
-  getManager(id: string): ImageViewerManager | null {
+  getManager(id: string): GestureViewerManager | null {
     return this.managers.get(id) || null;
   }
 
@@ -54,7 +54,7 @@ class ImageViewerRegistry {
     }
   }
 
-  notifySubscribers(id: string, manager: ImageViewerManager | null) {
+  notifySubscribers(id: string, manager: GestureViewerManager | null) {
     const listeners = this.subscribers.get(id);
 
     if (listeners) {
@@ -63,4 +63,4 @@ class ImageViewerRegistry {
   }
 }
 
-export const registry = new ImageViewerRegistry();
+export const registry = new GestureViewerRegistry();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,3 @@
-export { GestureImageViewer } from './GestureImageViewer';
-export type { GestureImageViewerProps } from './types';
-export { useImageViewerController } from './useImageViewerController';
+export { GestureViewer } from './GestureViewer';
+export type { GestureViewerProps } from './types';
+export { useGestureViewerController } from './useGestureViewerController';

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,13 +13,13 @@ type ConditionalListProps<LC> = LC extends FlatListComponent
     ? React.ComponentProps<LC>
     : GetComponentProps<LC>;
 
-export interface GestureImageViewerProps<T = any, LC = typeof RNFlatList> {
+export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   id?: string;
   data: T[];
   initialIndex?: number;
   onIndexChange?: (index: number) => void;
   onDismiss?: () => void;
-  renderImage: (item: T, index: number) => React.ReactElement;
+  renderItem: (item: T, index: number) => React.ReactElement;
   renderContainer?: (children: React.ReactElement) => React.ReactElement;
   ListComponent: LC;
   width?: number;

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -16,16 +16,16 @@ import {
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
-import type ImageViewerManager from './ImageViewerManager';
-import { registry } from './ImageViewerRegistry';
-import type { GestureImageViewerProps } from './types';
+import type GestureViewerManager from './GestureViewerManager';
+import { registry } from './GestureViewerRegistry';
+import type { GestureViewerProps } from './types';
 
-type UseGestureImageViewerProps<T = any> = Omit<
-  GestureImageViewerProps<T>,
-  'renderImage' | 'renderContainer' | 'ListComponent' | 'listProps' | 'containerStyle' | 'backdropStyle'
+type UseGestureViewerProps<T = any> = Omit<
+  GestureViewerProps<T>,
+  'renderItem' | 'renderContainer' | 'ListComponent' | 'listProps' | 'containerStyle' | 'backdropStyle'
 >;
 
-export const useGestureImageViewer = <T = any>({
+export const useGestureViewer = <T = any>({
   data,
   initialIndex = 0,
   onIndexChange,
@@ -44,14 +44,14 @@ export const useGestureImageViewer = <T = any>({
   maxZoomScale = 2,
   itemSpacing = 0,
   id = 'default',
-}: UseGestureImageViewerProps<T>) => {
+}: UseGestureViewerProps<T>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const width = customWidth || screenWidth;
 
   const [isZoomed, setIsZoomed] = useState(false);
 
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
-  const [manager, setManager] = useState<ImageViewerManager | null>(null);
+  const [manager, setManager] = useState<GestureViewerManager | null>(null);
 
   const unsubscribeRef = useRef<(() => void) | null>(null);
 
@@ -76,7 +76,7 @@ export const useGestureImageViewer = <T = any>({
   );
 
   useEffect(() => {
-    const handleManagerChange = (manager: ImageViewerManager | null) => {
+    const handleManagerChange = (manager: GestureViewerManager | null) => {
       unsubscribeRef.current?.();
       unsubscribeRef.current = null;
 

--- a/src/useGestureViewerController.ts
+++ b/src/useGestureViewerController.ts
@@ -1,19 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type ImageViewerManager from './ImageViewerManager';
-import type { ImageViewerManagerState } from './ImageViewerManager';
-import { registry } from './ImageViewerRegistry';
+import type GestureViewerManager from './GestureViewerManager';
+import type { GestureViewerManagerState } from './GestureViewerManager';
+import { registry } from './GestureViewerRegistry';
 
-export const useImageViewerController = (id = 'default') => {
-  const [state, setState] = useState<ImageViewerManagerState>({
+export const useGestureViewerController = (id = 'default') => {
+  const [state, setState] = useState<GestureViewerManagerState>({
     currentIndex: 0,
     dataLength: 0,
   });
 
-  const [manager, setManager] = useState<ImageViewerManager | null>(null);
+  const [manager, setManager] = useState<GestureViewerManager | null>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    const handleManagerChange = (newManager: ImageViewerManager | null) => {
+    const handleManagerChange = (newManager: GestureViewerManager | null) => {
       unsubscribeRef.current?.();
       unsubscribeRef.current = null;
 


### PR DESCRIPTION
- Rename GestureImageViewer → GestureViewer
- Rename useImageViewerController → useGestureViewerController
- Rename renderImage prop → renderItem prop
- Makes component more generic to handle various content types beyond images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the main component from `GestureImageViewer` to `GestureViewer` for broader use cases.
  * Renamed the hook `useImageViewerController` to `useGestureViewerController`.
  * Changed the prop `renderImage` to `renderItem` to support more generic rendering.
  * Updated all related types, classes, and documentation to reflect these new names.
  * Expanded documentation to list additional supported components and provided migration guidance.

* **Documentation**
  * Updated usage examples, integration guides, and performance tips in both English and Korean documentation to match new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->