### PR TITLE
feat: add useSnap mode with paging as default

### DIFF
--- a/.changeset/short-kids-hammer.md
+++ b/.changeset/short-kids-hammer.md
@@ -1,0 +1,10 @@
+---
+"react-native-gesture-image-viewer": minor
+---
+
+feat: add useSnap mode with paging as default
+
+- Add useSnap boolean prop to toggle between paging and snap modes
+- Add itemSpacing prop for spacing control in snap mode
+- Set paging mode as default behavior (useSnap: false)
+- Add comprehensive TypeScript documentation

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -261,7 +261,6 @@ function App() {
     <GestureViewer
       animateBackdrop={false}
       width={400}
-      itemSpacing={20}
       containerStyle={{ /* ... */ }}
       backdropStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.90)' }}
       renderContainer={(children) => <View style={{ flex: 1 }}>{children}</View>}
@@ -274,7 +273,6 @@ function App() {
 |:--:|:-----|:--:|
 |`animateBackdrop`|기본적으로 아래로 슬라이드 제스처 시 배경의 `opacity` 값이 1부터 0까지 서서히 감소합니다. `false` 시 이러한 애니메이션을 비활성화합니다.|`true`|
 |`width`|콘텐츠 아이템의 너비 값입니다. 기본값은 window 너비입니다.|`Dimensions width`|
-|`itemSpacing`|콘텐츠 아이템 사이의 값을 지정할 수 있습니다.|`0`|
 |`containerStyle`|리스트 컴포넌트를 감싸고 있는 컨테이너 스타일을 커스텀하게 수정할 수 있습니다.|`flex: 1`|
 |`backdropStyle`|뷰어 배경의 스타일을 커스터마이징할 수 있습니다.|`backgroundColor: black; StyleSheet.absoluteFill;`|
 |`renderContainer`|`<GestureViewer />`를 감싸는 래퍼 컴포넌트를 커스텀하여 적용할 수 있습니다.||
@@ -327,6 +325,41 @@ function App() {
   return (
     <GestureViewer
       onIndexChange={setCurrentIndex}
+    />
+  );
+}
+```
+
+#### `useSnap`
+스크롤 동작 모드를 설정합니다. `false`(기본값)는 페이징 모드, `true`는 스냅 모드를 사용합니다.
+
+```tsx
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+ return (
+   <GestureViewer
+     data={data}
+     renderItem={renderItem}
+     useSnap={true}
+   />
+ );
+}
+```
+
+#### `itemSpacing`
+아이템 간의 간격을 픽셀 단위로 설정합니다. `useSnap`이 `true`일 때만 적용됩니다.
+
+```tsx
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      data={data}
+      renderItem={renderItem}
+      useSnap={true}
+      itemSpacing={16} // 16px spacing between items
     />
   );
 }

--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ function App() {
     <GestureViewer
       animateBackdrop={false}
       width={400}
-      itemSpacing={20}
       containerStyle={{ /* ... */ }}
       backdropStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.90)' }}
       renderContainer={(children) => <View style={{ flex: 1 }}>{children}</View>}
@@ -274,7 +273,6 @@ function App() {
 |:--:|:-----|:--:|
 |`animateBackdrop`|By default, the background `opacity` gradually decreases from 1 to 0 during downward swipe gestures. When `false`, this animation is disabled.|`true`|
 |`width`|The width of content items. Default is window width.|`Dimensions width`|
-|`itemSpacing`|Specifies the spacing between list items.|`0`|
 |`containerStyle`|Allows custom styling of the container that wraps the list component.|`flex: 1`|
 |`backdropStyle`|Allows customization of the viewer's background style.|`backgroundColor: black; StyleSheet.absoluteFill;`|
 |`renderContainer`|Allows custom wrapper component around `<GestureViewer />`.||
@@ -327,6 +325,41 @@ function App() {
   return (
     <GestureViewer
       onIndexChange={setCurrentIndex}
+    />
+  );
+}
+```
+
+#### `useSnap`
+Sets the scroll behavior mode. `false` (default) uses paging mode, `true` uses snap mode.
+
+```tsx
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      data={data}
+      renderItem={renderItem}
+      useSnap={true}
+    />
+  );
+}
+```
+
+#### `itemSpacing`
+Sets the spacing between items in pixels. Only applied when `useSnap` is `true`.
+
+```tsx
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      data={data}
+      renderItem={renderItem}
+      useSnap={true}
+      itemSpacing={16} // 16px spacing between items
     />
   );
 }

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -20,13 +20,14 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
   containerStyle,
   initialIndex = 0,
   itemSpacing = 0,
+  useSnap = false,
   ...props
 }: GestureViewerProps<T, LC>) {
   const Component = ListComponent as React.ComponentType<any>;
 
   const { width: screenWidth } = useWindowDimensions();
 
-  const width = customWidth || screenWidth;
+  const width = useSnap ? customWidth || screenWidth : screenWidth;
 
   const { listRef, isZoomed, dismissGesture, zoomGesture, onMomentumScrollEnd, animatedStyle, backdropStyle } =
     useGestureViewer({
@@ -35,6 +36,7 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
       width,
       initialIndex,
       itemSpacing,
+      useSnap,
       ...props,
     });
 
@@ -45,7 +47,7 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
           key={typeof item === 'string' ? item : index}
           style={[
             {
-              width: width,
+              width,
               height: '100%',
               justifyContent: 'center',
               alignItems: 'center',
@@ -90,13 +92,19 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
       scrollEnabled: !isZoomed,
       showsHorizontalScrollIndicator: false,
       onMomentumScrollEnd: onMomentumScrollEnd,
-      snapToInterval: width + itemSpacing,
-      snapToAlignment: 'center',
-      decelerationRate: 'fast',
+      ...(useSnap
+        ? {
+            snapToInterval: width + itemSpacing,
+            snapToAlignment: 'center',
+            decelerationRate: 'fast',
+          }
+        : {
+            pagingEnabled: true,
+          }),
       scrollEventThrottle: 16,
       removeClippedSubviews: true,
     }),
-    [width, itemSpacing, isZoomed, onMomentumScrollEnd],
+    [width, itemSpacing, isZoomed, onMomentumScrollEnd, useSnap],
   );
 
   const listComponent = (
@@ -121,7 +129,6 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
                   data={data}
                   renderItem={renderItem}
                   initialScrollIndex={initialIndex}
-                  style={{ height: '100%' }}
                   keyExtractor={keyExtractor}
                   windowSize={3}
                   maxToRenderPerBatch={3}

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,20 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
    */
   width?: number;
   /**
+   * Enables snap scrolling mode.
+   *
+   * @remark
+   * **`false` (default)**: Paging mode (`pagingEnabled: true`)
+   * - Scrolls by full screen size increments
+   *
+   * **`true`**: Snap mode (`snapToInterval` auto-calculated)
+   * - `snapToInterval` is automatically calculated based on `width` and `itemSpacing` values
+   * - Use this option when you need item spacing
+   * @default false
+   *
+   */
+  useSnap?: boolean;
+  /**
    * `dismissThreshold` controls when `onDismiss` is called by applying a threshold value during vertical gestures.
    * @default 80
    */
@@ -122,7 +136,8 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
    */
   maxZoomScale?: number;
   /**
-   * The spacing between items.
+   * The spacing between items in pixels.
+   * @remark Only applied when `useSnap` is `true`.
    * @default 0
    */
   itemSpacing?: number;

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -43,10 +43,11 @@ export const useGestureViewer = <T = any>({
   enableZoomPanGesture = true,
   maxZoomScale = 2,
   itemSpacing = 0,
+  useSnap = false,
   id = 'default',
 }: UseGestureViewerProps<T>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
-  const width = customWidth || screenWidth;
+  const width = useSnap ? customWidth || screenWidth : screenWidth;
 
   const [isZoomed, setIsZoomed] = useState(false);
 


### PR DESCRIPTION
- Add useSnap boolean prop to toggle between paging and snap modes
- Add itemSpacing prop for spacing control in snap mode
- Set paging mode as default behavior (useSnap: false)
- Add comprehensive TypeScript documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new prop to enable snap scrolling mode in the image viewer, allowing users to toggle between paging and snap behaviors.
  * Introduced an option to adjust item spacing when snap mode is enabled.

* **Documentation**
  * Updated guides and examples to explain the new scroll behavior options and clarify how to use the new props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->