### PR TITLE
chore: include src folder in package.json files

### DIFF
--- a/.changeset/solid-pears-stand.md
+++ b/.changeset/solid-pears-stand.md
@@ -1,0 +1,9 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+chore: include src folder in package.json files
+
+- Add src to files array for better debugging experience
+- Enables accurate source maps and stack traces for library users
+- Follows React Native library best practices

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "lib",
+    "src",
     "android",
     "ios",
     "cpp",


### PR DESCRIPTION
- Add src to files array for better debugging experience
- Enables accurate source maps and stack traces for library users
- Follows React Native library best practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to include the "src" folder, improving debugging with more accurate source maps and stack traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->