### PR TITLE
docs(readme): fix typo `renderImage` to `renderItem` props

### DIFF
--- a/.changeset/breezy-dancers-see.md
+++ b/.changeset/breezy-dancers-see.md
@@ -1,0 +1,5 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+docs(readme): fix typo `renderImage` to `renderItem` props

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ function App() {
 
 #### Content Components
 
-You can inject various types of content components like `expo-image`, `FastImage`, etc., through the `renderImage` prop to use gestures.
+You can inject various types of content components like `expo-image`, `FastImage`, etc., through the `renderItem` prop to use gestures.
 
 ```tsx
 import { GestureViewer } from 'react-native-gesture-image-viewer';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the README to accurately reference the prop name as renderItem instead of renderImage when customizing content components. No functional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->