### PR TITLE
docs: add expo snack embed example

### DIFF
--- a/docs/components/ExpoSnackEmbed.tsx
+++ b/docs/components/ExpoSnackEmbed.tsx
@@ -12,15 +12,20 @@ export function ExpoSnackEmbed({ snackId, platform = 'web', preview = true, heig
 
   useEffect(() => {
     const loadAndInitialize = async () => {
-      if (!document.querySelector('script[src="https://snack.expo.dev/embed.js"]')) {
-        const script = document.createElement('script');
-        script.src = 'https://snack.expo.dev/embed.js';
-        script.async = true;
-        document.head.appendChild(script);
+      try {
+        if (!document.querySelector('script[src="https://snack.expo.dev/embed.js"]')) {
+          const script = document.createElement('script');
+          script.src = 'https://snack.expo.dev/embed.js';
+          script.async = true;
+          document.head.appendChild(script);
 
-        await new Promise((resolve) => {
-          script.onload = resolve;
-        });
+          await new Promise((resolve, reject) => {
+            script.onload = resolve;
+            script.onerror = reject;
+          });
+        }
+      } catch (error) {
+        console.error('Failed to load Expo Snack embed:', error);
       }
 
       setTimeout(() => {

--- a/docs/components/ExpoSnackEmbed.tsx
+++ b/docs/components/ExpoSnackEmbed.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+
+type Props = {
+  snackId: string;
+  platform?: 'web' | 'ios' | 'android';
+  preview?: boolean;
+  height?: number | `${number}px`;
+};
+
+export function ExpoSnackEmbed({ snackId, platform = 'web', preview = true, height = '505px' }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const loadAndInitialize = async () => {
+      if (!document.querySelector('script[src="https://snack.expo.dev/embed.js"]')) {
+        const script = document.createElement('script');
+        script.src = 'https://snack.expo.dev/embed.js';
+        script.async = true;
+        document.head.appendChild(script);
+
+        await new Promise((resolve) => {
+          script.onload = resolve;
+        });
+      }
+
+      setTimeout(() => {
+        if (window.ExpoSnack && containerRef.current) {
+          const existingEmbed = containerRef.current.querySelector('iframe');
+
+          if (existingEmbed) {
+            existingEmbed.remove();
+          }
+
+          if (window.ExpoSnack?.initialize) {
+            window.ExpoSnack?.initialize?.();
+          }
+        }
+      }, 100);
+    };
+
+    loadAndInitialize();
+  }, [snackId]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-snack-id={snackId}
+      data-snack-platform={platform}
+      data-snack-preview={preview}
+      data-snack-theme="dark"
+      style={{
+        overflow: 'hidden',
+        border: '1px solid #282c34',
+        borderRadius: '8px',
+        height,
+        width: '100%',
+      }}
+    />
+  );
+}

--- a/docs/docs/en/guide/getting-started/quick-start.mdx
+++ b/docs/docs/en/guide/getting-started/quick-start.mdx
@@ -1,14 +1,17 @@
 import { PackageManagerTabs } from '@theme';
+import { ExpoSnackEmbed } from '../../../../components/ExpoSnackEmbed';
 
 # Quick Start
+
+<div style={{ width: '100%', alignItems: 'center', display: 'flex', justifyContent: 'center' }}>
+  <img src="https://raw.githubusercontent.com/saseungmin/react-native-gesture-image-viewer/main/assets/example.gif" width="600" alt="Demo of react-native-gesture-image-viewer gestures" />
+</div>
 
 ## Examples & Demo
 - [📁 Example Project](https://github.com/saseungmin/react-native-gesture-image-viewer/tree/main/example) - Real implementation code with various use cases
 - [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-gesture-image-viewer) - Try it instantly on Snack Expo
 
-<div style={{ width: '100%', alignItems: 'center', display: 'flex', justifyContent: 'center' }}>
-  <img src="https://raw.githubusercontent.com/saseungmin/react-native-gesture-image-viewer/main/assets/example.gif" width="600" alt="Demo of react-native-gesture-image-viewer gestures" />
-</div>
+<ExpoSnackEmbed snackId="@harang/react-native-gesture-image-viewer" height="635px" />
 
 ## Installation
 

--- a/docs/docs/ko/guide/getting-started/quick-start.mdx
+++ b/docs/docs/ko/guide/getting-started/quick-start.mdx
@@ -1,12 +1,16 @@
+import { ExpoSnackEmbed } from '../../../../components/ExpoSnackEmbed';
+
 # 빠른 시작
+
+<div style={{ width: '100%', alignItems: 'center', display: 'flex', justifyContent: 'center' }}>
+  <img src="https://raw.githubusercontent.com/saseungmin/react-native-gesture-image-viewer/main/assets/example.gif" width="600" alt="Demo of react-native-gesture-image-viewer gestures" />
+</div>
 
 ## 예제 및 데모
 - [📁 예제 프로젝트](https://github.com/saseungmin/react-native-gesture-image-viewer/tree/main/example) - 실제 구현 코드와 다양한 사용 사례
 - [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-gesture-image-viewer) - Snack Expo에서 바로 체험
 
-<div style={{ width: '100%', alignItems: 'center', display: 'flex', justifyContent: 'center' }}>
-  <img src="https://raw.githubusercontent.com/saseungmin/react-native-gesture-image-viewer/main/assets/example.gif" width="600" alt="Demo of react-native-gesture-image-viewer gestures" />
-</div>
+<ExpoSnackEmbed snackId="@harang/react-native-gesture-image-viewer" height="635px" />
 
 ## 기본 사용법
 

--- a/docs/expo-snack.d.ts
+++ b/docs/expo-snack.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    ExpoSnack?: {
+      initialize?: () => void;
+      embed?: (element: HTMLElement) => void;
+      reload?: () => void;
+    };
+  }
+}
+
+export {};

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -13,7 +13,7 @@
     "useDefineForClassFields": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["docs", "theme", "rspress.config.ts"],
+  "include": ["docs", "theme", "rspress.config.ts", "component", "expo-snack.d.ts"],
   "mdx": {
     "checkMdx": true
   }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -13,7 +13,7 @@
     "useDefineForClassFields": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["docs", "theme", "rspress.config.ts", "component", "expo-snack.d.ts"],
+  "include": ["docs", "theme", "rspress.config.ts", "components", "expo-snack.d.ts"],
   "mdx": {
     "checkMdx": true
   }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,7 @@ pre-commit:
       run: npx biome format --write {staged_files}
     types:
       glob: "*.{js,ts,jsx,tsx}"
+      exclude: "docs/" 
       run: npx tsc
 commit-msg:
   parallel: true

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["example", "lib"]
+  "exclude": ["example", "lib", "docs"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,8 @@
     "strict": true,
     "target": "ESNext",
     "verbatimModuleSyntax": true
-  }
+  },
+  "exclude": [
+    "docs/**/*",
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive Expo Snack embed to the documentation, allowing users to try out examples directly within the docs.

* **Documentation**
  * Reorganized the quick start guides to display interactive demos in place of static images for both English and Korean documentation.
  * Improved visual presentation by centering demo images and updating example sections.

* **Chores**
  * Updated TypeScript configurations to exclude documentation files from compilation.
  * Adjusted pre-commit hooks to skip type checks on documentation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->