### PR TITLE
fix: prevent multiple `onIndexChange` calls during initialization

### DIFF
--- a/.changeset/major-areas-mix.md
+++ b/.changeset/major-areas-mix.md
@@ -1,0 +1,14 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+fix: prevent multiple `onIndexChange` calls during initialization
+
+- Remove redundant currentIndex state to avoid duplicate callbacks
+- Use manager subscription as single source of truth for index changes
+- Implement ref pattern for `onIndexChange` to prevent stale closures
+- Ensure `onIndexChange` only fires on actual user interactions, not internal state changes
+
+Now `onIndexChange` correctly fires only once during initialization.
+
+Fixes #67

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -58,6 +58,7 @@ export const useGestureViewer = <T = any>({
   const listRef = useRef<any>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
   const onIndexChangeRef = useRef<((index: number) => void) | null>(null);
+  const lastEmittedIndexRef = useRef<number>(null);
 
   const initialTranslateY = useSharedValue(0);
   const initialTranslateX = useSharedValue(0);
@@ -130,9 +131,7 @@ export const useGestureViewer = <T = any>({
   );
 
   useEffect(() => {
-    if (onIndexChange) {
-      onIndexChangeRef.current = onIndexChange;
-    }
+    onIndexChangeRef.current = onIndexChange ?? null;
   });
 
   useEffect(() => {
@@ -148,9 +147,14 @@ export const useGestureViewer = <T = any>({
 
       setManager(manager);
 
+      lastEmittedIndexRef.current = null;
+
       if (manager) {
         unsubscribeRef.current = manager.subscribe((state) => {
-          onIndexChangeRef.current?.(state.currentIndex);
+          if (lastEmittedIndexRef.current !== state.currentIndex) {
+            lastEmittedIndexRef.current = state.currentIndex;
+            onIndexChangeRef.current?.(state.currentIndex);
+          }
         });
         return;
       }
@@ -244,7 +248,7 @@ export const useGestureViewer = <T = any>({
         scrollTo(jumpToIndex, false);
       }
 
-      const currentIndex = manager?.getState() || 0;
+      const currentIndex = manager?.getState() ?? 0;
 
       if (realIndex !== currentIndex && realIndex >= 0 && realIndex < dataLength) {
         if (manager) {

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -53,10 +53,11 @@ export const useGestureViewer = <T = any>({
 
   const [isZoomed, setIsZoomed] = useState(false);
   const [isRotated, setIsRotated] = useState(false);
-  const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [manager, setManager] = useState<GestureViewerManager | null>(null);
 
+  const listRef = useRef<any>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
+  const onIndexChangeRef = useRef<((index: number) => void) | null>(null);
 
   const initialTranslateY = useSharedValue(0);
   const initialTranslateX = useSharedValue(0);
@@ -67,8 +68,6 @@ export const useGestureViewer = <T = any>({
   const scale = useSharedValue(1);
   const backdropOpacity = useSharedValue(1);
   const rotation = useSharedValue(0);
-
-  const listRef = useRef<any>(null);
 
   const dataLength = data?.length || 0;
 
@@ -131,6 +130,18 @@ export const useGestureViewer = <T = any>({
   );
 
   useEffect(() => {
+    if (onIndexChange) {
+      onIndexChangeRef.current = onIndexChange;
+    }
+  });
+
+  useEffect(() => {
+    return () => {
+      onIndexChangeRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
     const handleManagerChange = (manager: GestureViewerManager | null) => {
       unsubscribeRef.current?.();
       unsubscribeRef.current = null;
@@ -138,14 +149,11 @@ export const useGestureViewer = <T = any>({
       setManager(manager);
 
       if (manager) {
-        setCurrentIndex(manager.getState().currentIndex);
         unsubscribeRef.current = manager.subscribe((state) => {
-          setCurrentIndex(state.currentIndex);
+          onIndexChangeRef.current?.(state.currentIndex);
         });
         return;
       }
-
-      setCurrentIndex(0);
     };
 
     const unsubscribeFromRegistry = registry.subscribeToManager(id, handleManagerChange);
@@ -195,10 +203,6 @@ export const useGestureViewer = <T = any>({
   }, [manager]);
 
   useEffect(() => {
-    onIndexChange?.(currentIndex);
-  }, [currentIndex, onIndexChange]);
-
-  useEffect(() => {
     translateY.value = 0;
     translateX.value = 0;
     scale.value = 1;
@@ -240,10 +244,11 @@ export const useGestureViewer = <T = any>({
         scrollTo(jumpToIndex, false);
       }
 
+      const currentIndex = manager?.getState() || 0;
+
       if (realIndex !== currentIndex && realIndex >= 0 && realIndex < dataLength) {
         if (manager) {
           manager.setCurrentIndex(realIndex);
-          setCurrentIndex(realIndex);
           manager.notifyStateChange();
         }
 
@@ -259,7 +264,6 @@ export const useGestureViewer = <T = any>({
     [
       scrollTo,
       manager,
-      currentIndex,
       dataLength,
       width,
       itemSpacing,
@@ -492,7 +496,6 @@ export const useGestureViewer = <T = any>({
   }, [manager]);
 
   return {
-    currentIndex,
     dataLength,
     translateY,
     listRef,


### PR DESCRIPTION
- Remove redundant currentIndex state to avoid duplicate callbacks
- Use manager subscription as single source of truth for index changes
- Implement ref pattern for `onIndexChange` to prevent stale closures
- Ensure `onIndexChange` only fires on actual user interactions, not internal state changes

Now `onIndexChange` correctly fires only once during initialization.

Fixes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the onIndexChange callback was triggered multiple times during initialization. It now fires exactly once, ensuring accurate event handling for index changes.

* **Refactor**
  * Improved internal logic to prevent duplicate callback invocations and ensure onIndexChange is only called on genuine user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->