### PR TITLE
fix: remove key prop from list item children for better performance

### DIFF
--- a/.changeset/tender-cows-flow.md
+++ b/.changeset/tender-cows-flow.md
@@ -1,0 +1,12 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+fix: remove key prop from list item children for better performance
+
+- Remove key prop from View children when using FlatList/FlashList
+- Keep key prop only for ScrollView children
+- Improves FlashList performance by allowing proper item reuse
+- Follows FlashList official performance guidelines
+
+Refs: https://shopify.github.io/flash-list/docs/fundamentals/performance#remove-key-prop

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -35,6 +35,8 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
 
   const loopData = useMemo(() => createLoopData(dataRef, enableLoop), [enableLoop]);
 
+  const isScrollView = isScrollViewLike(Component);
+
   const {
     listRef,
     isZoomed,
@@ -71,7 +73,7 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
     ({ item, index }: { item: T; index: number }) => {
       return (
         <View
-          key={keyExtractor(item, index)}
+          key={isScrollView ? keyExtractor(item, index) : undefined}
           style={[
             {
               width,
@@ -86,7 +88,7 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
         </View>
       );
     },
-    [width, itemSpacing, renderItemProp, keyExtractor],
+    [width, itemSpacing, renderItemProp, keyExtractor, isScrollView],
   );
 
   const getItemLayout = useCallback(
@@ -141,7 +143,7 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
             {...(Platform.OS === 'web' &&
               isFlashListLike(Component) && { dataSet: { 'flash-list-paging-enabled-fix': true } })}
           >
-            {isScrollViewLike(Component) ? (
+            {isScrollView ? (
               <Component ref={listRef} {...commonProps} {...listProps}>
                 {loopData.map((item, index) => renderItem({ item, index }))}
               </Component>


### PR DESCRIPTION
- Remove key prop from View children when using FlatList/FlashList
- Keep key prop only for ScrollView children
- Improves FlashList performance by allowing proper item reuse
- Follows FlashList official performance guidelines

Refs: https://shopify.github.io/flash-list/docs/fundamentals/performance#remove-key-prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance when using FlashList or FlatList in the image viewer by removing unnecessary key props from list item children, following official guidelines.
* **Refactor**
  * Optimized internal logic for determining scrollable components, enhancing rendering efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->