### PR TITLE
fix(useGestureViewerController): prevent tearing and optimize rendering

### DIFF
--- a/.changeset/curvy-bottles-fold.md
+++ b/.changeset/curvy-bottles-fold.md
@@ -1,0 +1,9 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+fix(useGestureViewerController): Prevent tearing and optimize rendering
+
+- Refactors `useGestureViewerController` to use [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore).
+- This change resolves a potential tearing bug that can occur in concurrent mode by ensuring the hook's state is always synchronized with the external store.
+- Optimized the update logic to prevent unnecessary re-renders when currentIndex or totalCount remain unchanged, improving performance.

--- a/src/useGestureViewerController.ts
+++ b/src/useGestureViewerController.ts
@@ -64,7 +64,10 @@ export const useGestureViewerController = (id = 'default'): GestureViewerControl
       stateRef.current.currentIndex !== newState.currentIndex ||
       stateRef.current.totalCount !== newState.totalCount
     ) {
-      stateRef.current = newState;
+      stateRef.current = {
+        currentIndex: newState.currentIndex,
+        totalCount: newState.totalCount,
+      };
       onStoreChange();
     }
   }, []);
@@ -74,6 +77,8 @@ export const useGestureViewerController = (id = 'default'): GestureViewerControl
       let unsubscribeFromManager: (() => void) | null = null;
 
       const unsubscribeFromRegistry = registry.subscribeToManager(id, (newManager) => {
+        unsubscribeFromManager?.();
+        unsubscribeFromManager = null;
         managerRef.current = newManager;
 
         if (newManager) {
@@ -102,16 +107,35 @@ export const useGestureViewerController = (id = 'default'): GestureViewerControl
 
   const state = useSyncExternalStore(subscribe, getSnapshot);
 
-  const noopFunction = useMemo(() => () => {}, []);
+  const controller = useMemo<Omit<GestureViewerController, 'currentIndex' | 'totalCount'>>(
+    () => ({
+      goToIndex: (index) => {
+        managerRef.current?.goToIndex(index);
+      },
+      goToPrevious: () => {
+        managerRef.current?.goToPrevious();
+      },
+      goToNext: () => {
+        managerRef.current?.goToNext();
+      },
+      zoomIn: (multiplier) => {
+        managerRef.current?.zoomIn(multiplier);
+      },
+      zoomOut: (multiplier) => {
+        managerRef.current?.zoomOut(multiplier);
+      },
+      resetZoom: (scale) => {
+        managerRef.current?.resetZoom(scale);
+      },
+      rotate: (angle, clockwise) => {
+        managerRef.current?.rotate(angle, clockwise);
+      },
+    }),
+    [],
+  );
 
   return {
-    goToIndex: managerRef.current?.goToIndex || noopFunction,
-    goToPrevious: managerRef.current?.goToPrevious || noopFunction,
-    goToNext: managerRef.current?.goToNext || noopFunction,
-    zoomIn: managerRef.current?.zoomIn || noopFunction,
-    zoomOut: managerRef.current?.zoomOut || noopFunction,
-    resetZoom: managerRef.current?.resetZoom || noopFunction,
-    rotate: managerRef.current?.rotate || noopFunction,
+    ...controller,
     ...state,
   };
 };

--- a/src/useGestureViewerController.ts
+++ b/src/useGestureViewerController.ts
@@ -82,11 +82,11 @@ export const useGestureViewerController = (id = 'default'): GestureViewerControl
         managerRef.current = newManager;
 
         if (newManager) {
-          updateState(newManager.getState(), onStoreChange);
-
           unsubscribeFromManager = newManager.subscribe((newState) => {
             updateState(newState, onStoreChange);
           });
+
+          updateState(newManager.getState(), onStoreChange);
           return;
         }
 

--- a/src/useGestureViewerController.ts
+++ b/src/useGestureViewerController.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
 import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
 import type { GestureViewerController, GestureViewerControllerState } from './types';
@@ -56,48 +56,62 @@ import type { GestureViewerController, GestureViewerControllerState } from './ty
  * ```
  */
 export const useGestureViewerController = (id = 'default'): GestureViewerController => {
-  const [state, setState] = useState<GestureViewerControllerState>({
-    currentIndex: 0,
-    totalCount: 0,
-  });
+  const managerRef = useRef<GestureViewerManager | null>(null);
+  const stateRef = useRef<GestureViewerControllerState>({ currentIndex: 0, totalCount: 0 });
 
-  const [manager, setManager] = useState<GestureViewerManager | null>(null);
-  const unsubscribeRef = useRef<(() => void) | null>(null);
+  const updateState = useCallback((newState: GestureViewerControllerState, onStoreChange: () => void) => {
+    if (
+      stateRef.current.currentIndex !== newState.currentIndex ||
+      stateRef.current.totalCount !== newState.totalCount
+    ) {
+      stateRef.current = newState;
+      onStoreChange();
+    }
+  }, []);
 
-  useEffect(() => {
-    const handleManagerChange = (newManager: GestureViewerManager | null) => {
-      unsubscribeRef.current?.();
-      unsubscribeRef.current = null;
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      let unsubscribeFromManager: (() => void) | null = null;
 
-      setManager(newManager);
+      const unsubscribeFromRegistry = registry.subscribeToManager(id, (newManager) => {
+        managerRef.current = newManager;
 
-      if (newManager) {
-        setState(newManager.getState());
-        unsubscribeRef.current = newManager.subscribe(setState);
-        return;
-      }
+        if (newManager) {
+          updateState(newManager.getState(), onStoreChange);
 
-      setState({ currentIndex: 0, totalCount: 0 });
-    };
+          unsubscribeFromManager = newManager.subscribe((newState) => {
+            updateState(newState, onStoreChange);
+          });
+          return;
+        }
 
-    const unsubscribeFromRegistry = registry.subscribeToManager(id, handleManagerChange);
+        updateState({ currentIndex: 0, totalCount: 0 }, onStoreChange);
+      });
 
-    return () => {
-      unsubscribeFromRegistry();
-      unsubscribeRef.current?.();
-    };
-  }, [id]);
+      return () => {
+        unsubscribeFromRegistry();
+        unsubscribeFromManager?.();
+      };
+    },
+    [id, updateState],
+  );
+
+  const getSnapshot = useCallback(() => {
+    return stateRef.current;
+  }, []);
+
+  const state = useSyncExternalStore(subscribe, getSnapshot);
 
   const noopFunction = useMemo(() => () => {}, []);
 
   return {
-    goToIndex: manager?.goToIndex || noopFunction,
-    goToPrevious: manager?.goToPrevious || noopFunction,
-    goToNext: manager?.goToNext || noopFunction,
-    zoomIn: manager?.zoomIn || noopFunction,
-    zoomOut: manager?.zoomOut || noopFunction,
-    resetZoom: manager?.resetZoom || noopFunction,
-    rotate: manager?.rotate || noopFunction,
+    goToIndex: managerRef.current?.goToIndex || noopFunction,
+    goToPrevious: managerRef.current?.goToPrevious || noopFunction,
+    goToNext: managerRef.current?.goToNext || noopFunction,
+    zoomIn: managerRef.current?.zoomIn || noopFunction,
+    zoomOut: managerRef.current?.zoomOut || noopFunction,
+    resetZoom: managerRef.current?.resetZoom || noopFunction,
+    rotate: managerRef.current?.rotate || noopFunction,
     ...state,
   };
 };


### PR DESCRIPTION
- Refactors `useGestureViewerController` to use [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore).
- This change resolves a potential tearing bug that can occur in concurrent mode by ensuring the hook's state is always synchronized with the external store.
- Optimized the update logic to prevent unnecessary re-renders when currentIndex or totalCount remain unchanged, improving performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual tearing in concurrent mode so viewer navigation and zoom remain visually consistent.

* **Refactor**
  * Reworked viewer state handling for more consistent updates and smoother interactions.
  * Reduced unnecessary re-renders when index or total count don't change, improving performance.
  * No changes to the public API or visible behavior.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->