### PR TITLE
feat!: add useGestureViewerState hook and refactor controller

### DIFF
--- a/.changeset/afraid-worlds-create.md
+++ b/.changeset/afraid-worlds-create.md
@@ -1,0 +1,32 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+feat!: add `useGestureViewerState` hook and refactor controller
+
+- Add `useGestureViewerState` hook to access `currentIndex` and `totalCount`
+- Refactor `useGestureViewerController` to return control methods only
+- Rename `GestureViewerControllerState` to `GestureViewerState`
+- Update exports and type definitions
+
+BREAKING CHANGE: `useGestureViewerController` no longer returns `currentIndex` and `totalCount`. Use `useGestureViewerState` instead.
+
+Example:
+
+```diff
+import {
+  GestureViewer,
+-  GestureViewerControllerState,
++  GestureViewerState
+  useGestureViewerController,
+  useGestureViewerEvent,
++  useGestureViewerState,
+} from 'react-native-gesture-image-viewer';
+
+const { 
+  goToIndex, goToPrevious, goToNext, zoomIn, zoomOut, resetZoom, rotate,
+-  currentIndex, totalCount
+} = useGestureViewerController();
+
++ const { currentIndex, totalCount } = useGestureViewerState();
+```

--- a/example/src/V1Example.tsx
+++ b/example/src/V1Example.tsx
@@ -3,12 +3,7 @@ import { FlashList } from '@shopify/flash-list';
 import { Image } from 'expo-image';
 import { useCallback, useState } from 'react';
 import { Button, Modal, StyleSheet, Text, View } from 'react-native';
-import {
-  GestureViewer,
-  useGestureViewerController,
-  useGestureViewerEvent,
-  useGestureViewerState,
-} from 'react-native-gesture-image-viewer';
+import { GestureViewer, useGestureViewerController, useGestureViewerEvent } from 'react-native-gesture-image-viewer';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const images = [
@@ -19,13 +14,13 @@ const images = [
   'https://picsum.photos/200/400',
 ];
 
-function Example() {
+function V1Example() {
   const [visible, setVisible] = useState(false);
   const [enableLoop, setEnableLoop] = useState(false);
 
-  const { goToIndex, goToPrevious, goToNext, zoomIn, zoomOut, resetZoom, rotate } = useGestureViewerController();
-
-  const { currentIndex, totalCount } = useGestureViewerState();
+  // @ts-ignore
+  const { goToIndex, goToPrevious, goToNext, zoomIn, zoomOut, resetZoom, rotate, currentIndex, totalCount } =
+    useGestureViewerController();
 
   const insets = useSafeAreaInsets();
 
@@ -189,4 +184,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default Example;
+export default V1Example;

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -1,9 +1,9 @@
 import { type SharedValue, withTiming } from 'react-native-reanimated';
 import type {
-  GestureViewerControllerState,
   GestureViewerEventCallback,
   GestureViewerEventData,
   GestureViewerEventType,
+  GestureViewerState,
 } from './types';
 import { createBoundsConstraint, createScrollAction } from './utils';
 
@@ -24,7 +24,7 @@ class GestureViewerManager {
 
   private loopCallback: (() => void) | null = null;
 
-  private listeners = new Set<(state: GestureViewerControllerState) => void>();
+  private listeners = new Set<(state: GestureViewerState) => void>();
   private eventListeners = new Map<GestureViewerEventType, Set<(data: any) => void>>();
 
   private notifyListeners() {
@@ -33,7 +33,7 @@ class GestureViewerManager {
     this.listeners.forEach((listener) => listener(state));
   }
 
-  subscribe(listener: (state: GestureViewerControllerState) => void) {
+  subscribe(listener: (state: GestureViewerState) => void) {
     this.listeners.add(listener);
 
     return () => {

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -77,7 +77,7 @@ class GestureViewerManager {
     this.emitEvent('rotationChange', { rotation, previousRotation });
   };
 
-  getState() {
+  getState(): GestureViewerState {
     return {
       currentIndex: this.currentIndex,
       totalCount: this.dataLength,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,12 @@
 export { GestureViewer } from './GestureViewer';
 export type {
   GestureViewerController,
-  GestureViewerControllerState,
   GestureViewerEventCallback,
   GestureViewerEventData,
   GestureViewerEventType,
   GestureViewerProps,
+  GestureViewerState,
 } from './types';
 export { useGestureViewerController } from './useGestureViewerController';
 export { useGestureViewerEvent } from './useGestureViewerEvent';
+export { useGestureViewerState } from './useGestureViewerState';

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,13 +252,13 @@ export type GestureViewerController = {
    * ```
    */
   rotate: (angle?: RotationAngle, clockwise?: boolean) => void;
-} & GestureViewerControllerState;
+};
 
 /**
  * State information for the gesture viewer controller.
  * Contains read-only properties that reflect the current state.
  */
-export type GestureViewerControllerState = {
+export type GestureViewerState = {
   /**
    * The current index of the active item in the viewer.
    *
@@ -267,7 +267,7 @@ export type GestureViewerControllerState = {
    *
    * @example
    * ```typescript
-   * console.log(`Currently viewing item ${controller.currentIndex + 1} of ${controller.totalCount}`);
+   * console.log(`Currently viewing item ${currentIndex + 1} of ${totalCount}`);
    * ```
    */
   readonly currentIndex: number;
@@ -280,8 +280,8 @@ export type GestureViewerControllerState = {
    *
    * @example
    * ```typescript
-   * const hasNext = controller.currentIndex < controller.totalCount - 1;
-   * const hasPrevious = controller.currentIndex > 0;
+   * const hasNext = currentIndex < totalCount - 1;
+   * const hasPrevious = currentIndex > 0;
    * ```
    */
   readonly totalCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,8 +167,10 @@ export type GestureViewerController = {
    *
    * @example
    * ```typescript
+   * const { totalCount } = useGestureViewerState();
+   *
    * controller.goToIndex(0); // Go to first item
-   * controller.goToIndex(controller.totalCount - 1); // Go to last item
+   * controller.goToIndex(totalCount - 1); // Go to last item
    * ```
    */
   goToIndex: (index: number) => void;

--- a/src/useGestureViewerController.ts
+++ b/src/useGestureViewerController.ts
@@ -55,7 +55,7 @@ export const useGestureViewerController = (id = 'default'): GestureViewerControl
     return unsubscribe;
   }, [id]);
 
-  return useMemo<Omit<GestureViewerController, 'currentIndex' | 'totalCount'>>(
+  return useMemo<GestureViewerController>(
     () => ({
       goToIndex: (index) => {
         managerRef.current?.goToIndex(index);

--- a/src/useGestureViewerController.ts
+++ b/src/useGestureViewerController.ts
@@ -1,13 +1,13 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
-import type { GestureViewerController, GestureViewerControllerState } from './types';
+import type { GestureViewerController } from './types';
 
 /**
  * Hook to control the gesture viewer programmatically.
  *
  * @param id - Viewer instance identifier (default: 'default')
- * @returns Methods and state for controlling the viewer
+ * @returns Methods for controlling the viewer
  *
  * **Available methods:**
  * - `goToIndex(index: number)` - Navigate to specific index (0 to totalCount-1)
@@ -16,98 +16,46 @@ import type { GestureViewerController, GestureViewerControllerState } from './ty
  * - `zoomIn(multiplier?: number)` - Zoom in (default: 0.25)
  * - `zoomOut(multiplier?: number)` - Zoom out (default: 0.25)
  * - `resetZoom(scale?: number)` - Reset zoom level (default: 1.0)
- * - `rotate(angle?: 0|90|180|270|360, clockwise?: boolean)` - Rotate content (default: 90° clockwise)
- *
- * **Available state:**
- * - `currentIndex: number` - Current active index (read-only)
- * - `totalCount: number` - Total number of items (read-only)
+ * - `rotate(angle?: RotationAngle, clockwise?: boolean)` - Rotate content (default: 90° clockwise)
  *
  * @example
  * ```tsx
- * const { goToIndex, goToNext, goToPrevious, zoomIn, zoomOut, resetZoom, rotate, currentIndex, totalCount } = useGestureViewerController();
+ * const controller = useGestureViewerController();
  *
  * // Navigate to specific index
- * goToIndex(2);
+ * controller.goToIndex(2);
  *
  * // Go to next image
- * goToNext();
+ * controller.goToNext();
  *
  * // Zoom in by 25%
- * zoomIn();
+ * controller.zoomIn();
  *
  * // Zoom out by 50%
- * zoomOut(0.5);
+ * controller.zoomOut(0.5);
  *
  * // Reset to original size
- * resetZoom();
+ * controller.resetZoom();
  *
  * // Rotate 90 degrees clockwise
- * rotate();
+ * controller.rotate();
  *
  * // Rotate 180 degrees
- * rotate(180);
- *
- * // Check current state
- * console.log(`Image ${currentIndex + 1} of ${totalCount}`);
- *
- * // Check navigation availability
- * const canGoNext = currentIndex < totalCount - 1;
- * const canGoPrevious = currentIndex > 0;
+ * controller.rotate(180);
  * ```
  */
 export const useGestureViewerController = (id = 'default'): GestureViewerController => {
   const managerRef = useRef<GestureViewerManager | null>(null);
-  const stateRef = useRef<GestureViewerControllerState>({ currentIndex: 0, totalCount: 0 });
 
-  const updateState = useCallback((newState: GestureViewerControllerState, onStoreChange: () => void) => {
-    if (
-      stateRef.current.currentIndex !== newState.currentIndex ||
-      stateRef.current.totalCount !== newState.totalCount
-    ) {
-      stateRef.current = {
-        currentIndex: newState.currentIndex,
-        totalCount: newState.totalCount,
-      };
-      onStoreChange();
-    }
-  }, []);
+  useEffect(() => {
+    const unsubscribe = registry.subscribeToManager(id, (manager) => {
+      managerRef.current = manager;
+    });
 
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      let unsubscribeFromManager: (() => void) | null = null;
+    return unsubscribe;
+  }, [id]);
 
-      const unsubscribeFromRegistry = registry.subscribeToManager(id, (newManager) => {
-        unsubscribeFromManager?.();
-        unsubscribeFromManager = null;
-        managerRef.current = newManager;
-
-        if (newManager) {
-          unsubscribeFromManager = newManager.subscribe((newState) => {
-            updateState(newState, onStoreChange);
-          });
-
-          updateState(newManager.getState(), onStoreChange);
-          return;
-        }
-
-        updateState({ currentIndex: 0, totalCount: 0 }, onStoreChange);
-      });
-
-      return () => {
-        unsubscribeFromRegistry();
-        unsubscribeFromManager?.();
-      };
-    },
-    [id, updateState],
-  );
-
-  const getSnapshot = useCallback(() => {
-    return stateRef.current;
-  }, []);
-
-  const state = useSyncExternalStore(subscribe, getSnapshot);
-
-  const controller = useMemo<Omit<GestureViewerController, 'currentIndex' | 'totalCount'>>(
+  return useMemo<Omit<GestureViewerController, 'currentIndex' | 'totalCount'>>(
     () => ({
       goToIndex: (index) => {
         managerRef.current?.goToIndex(index);
@@ -133,9 +81,4 @@ export const useGestureViewerController = (id = 'default'): GestureViewerControl
     }),
     [],
   );
-
-  return {
-    ...controller,
-    ...state,
-  };
 };

--- a/src/useGestureViewerState.ts
+++ b/src/useGestureViewerState.ts
@@ -1,5 +1,4 @@
 import { useCallback, useRef, useSyncExternalStore } from 'react';
-import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
 import type { GestureViewerState } from './types';
 
@@ -36,7 +35,6 @@ import type { GestureViewerState } from './types';
  * ```
  */
 export const useGestureViewerState = (id = 'default'): GestureViewerState => {
-  const managerRef = useRef<GestureViewerManager | null>(null);
   const stateRef = useRef<GestureViewerState>({ currentIndex: 0, totalCount: 0 });
 
   const updateState = useCallback((newState: GestureViewerState, onStoreChange: () => void) => {
@@ -56,7 +54,6 @@ export const useGestureViewerState = (id = 'default'): GestureViewerState => {
       const unsubscribeFromRegistry = registry.subscribeToManager(id, (newManager) => {
         unsubscribeFromManager?.();
         unsubscribeFromManager = null;
-        managerRef.current = newManager;
 
         if (newManager) {
           unsubscribeFromManager = newManager.subscribe((newState) => {

--- a/src/useGestureViewerState.ts
+++ b/src/useGestureViewerState.ts
@@ -1,0 +1,88 @@
+import { useCallback, useRef, useSyncExternalStore } from 'react';
+import type GestureViewerManager from './GestureViewerManager';
+import { registry } from './GestureViewerRegistry';
+import type { GestureViewerState } from './types';
+
+/**
+ * Hook to access the current state of the gesture viewer.
+ *
+ * @param id - Viewer instance identifier (default: 'default')
+ * @returns Current state of the viewer
+ *
+ * **Available state:**
+ * - `currentIndex: number` - Current active index (read-only)
+ * - `totalCount: number` - Total number of items (read-only)
+ *
+ * @example
+ * ```tsx
+ * const { currentIndex, totalCount } = useGestureViewerState();
+ *
+ * // Display current position
+ * return (
+ *   <Text>
+ *     {currentIndex + 1} / {totalCount}
+ *   </Text>
+ * );
+ *
+ * // React to index changes
+ * useEffect(() => {
+ *   console.log(`Moved to image ${currentIndex + 1}`);
+ *   trackPageView(currentIndex);
+ * }, [currentIndex]);
+ *
+ * // Check navigation availability
+ * const canGoNext = currentIndex < totalCount - 1;
+ * const canGoPrevious = currentIndex > 0;
+ * ```
+ */
+export const useGestureViewerState = (id = 'default'): GestureViewerState => {
+  const managerRef = useRef<GestureViewerManager | null>(null);
+  const stateRef = useRef<GestureViewerState>({ currentIndex: 0, totalCount: 0 });
+
+  const updateState = useCallback((newState: GestureViewerState, onStoreChange: () => void) => {
+    if (
+      stateRef.current.currentIndex !== newState.currentIndex ||
+      stateRef.current.totalCount !== newState.totalCount
+    ) {
+      stateRef.current = { ...newState };
+      onStoreChange();
+    }
+  }, []);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      let unsubscribeFromManager: (() => void) | null = null;
+
+      const unsubscribeFromRegistry = registry.subscribeToManager(id, (newManager) => {
+        unsubscribeFromManager?.();
+        unsubscribeFromManager = null;
+        managerRef.current = newManager;
+
+        if (newManager) {
+          unsubscribeFromManager = newManager.subscribe((newState) => {
+            updateState(newState, onStoreChange);
+          });
+
+          updateState(newManager.getState(), onStoreChange);
+          return;
+        }
+
+        updateState({ currentIndex: 0, totalCount: 0 }, onStoreChange);
+      });
+
+      return () => {
+        unsubscribeFromRegistry();
+        unsubscribeFromManager?.();
+      };
+    },
+    [id, updateState],
+  );
+
+  const getSnapshot = useCallback(() => {
+    return stateRef.current;
+  }, []);
+
+  const state = useSyncExternalStore(subscribe, getSnapshot);
+
+  return state;
+};


### PR DESCRIPTION
- Add useGestureViewerState hook to access currentIndex and totalCount
- Refactor useGestureViewerController to return control methods only
- Rename GestureViewerControllerState to GestureViewerState
- Update exports and type definitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added useGestureViewerState hook to access currentIndex and totalCount.
  * Added a new example screen demonstrating gallery controls and state display.

* Refactor
  * Updated controller hook to return only control methods; state is now obtained via useGestureViewerState.
  * Renamed public type to GestureViewerState.

* Documentation
  * Updated examples and usage to reflect the new state hook and controller API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->