### PR TITLE
feat: implement trigger-based modal animation system

### DIFF
--- a/.changeset/quick-files-train.md
+++ b/.changeset/quick-files-train.md
@@ -1,0 +1,49 @@
+---
+"react-native-gesture-image-viewer": minor
+---
+
+feat: implement trigger-based modal animation system
+
+- Add `GestureTrigger` component for registering trigger elements
+- Implement trigger position-based modal open/close animations
+- Enable smooth transition from trigger element to full modal view
+- add `triggerAnimation` prop for customizable open animation (duration/easing/reduce-motion, with onAnimationComplete)
+- add `onDismissStart` callback to signal dismiss gesture start (useful for hiding external UI)
+- add `dismiss()` helper to `renderContainer` for programmatic close
+
+Example:
+
+```tsx
+import { GestureTrigger, GestureViewer } from 'react-native-gesture-image-viewer';
+
+// Wrap your thumbnail with GestureTrigger
+<GestureTrigger id="gallery" onPress={() => openModal(index)}>
+  <Pressable>
+    <Image source={{ uri }} />
+  </Pressable>
+</GestureTrigger>
+
+// Configure GestureViewer with matching id
+<GestureViewer
+  id="gallery"
+  data={images}
+  renderItem={renderImage}
+  onDismiss={() => setVisible(false)}
+  onDismissStart={() => setShowUI(false)}
+  triggerAnimation={{
+    duration: 300,
+    easing: Easing.bezier(0.25, 0.1, 0.25, 1.0),
+    onAnimationComplete: () => console.log('Animation finished!')
+  }}
+  renderContainer={(children, helpers) => (
+    <View style={{ flex: 1 }}>
+      {children}
+      {showUI && (
+        <View style={styles.header}>
+          <Button onPress={helpers.dismiss} title="Close" />
+        </View>
+      )}
+    </View>
+  )}
+/>
+```

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -2,8 +2,13 @@ import { Feather } from '@expo/vector-icons';
 import { FlashList } from '@shopify/flash-list';
 import { Image } from 'expo-image';
 import { useCallback, useState } from 'react';
-import { Button, Modal, StyleSheet, Text, View } from 'react-native';
-import { GestureViewer, useGestureViewerController, useGestureViewerEvent } from 'react-native-gesture-image-viewer';
+import { Button, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  GestureTrigger,
+  GestureViewer,
+  useGestureViewerController,
+  useGestureViewerEvent,
+} from 'react-native-gesture-image-viewer';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const images = [
@@ -17,11 +22,19 @@ const images = [
 function Example() {
   const [visible, setVisible] = useState(false);
   const [enableLoop, setEnableLoop] = useState(false);
+  const [showExternalUI, setShowExternalUI] = useState(true);
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
   const { goToIndex, goToPrevious, goToNext, currentIndex, totalCount, zoomIn, zoomOut, resetZoom, rotate } =
     useGestureViewerController();
 
   const insets = useSafeAreaInsets();
+
+  const modalOpen = useCallback((index: number) => {
+    setSelectedIndex(index);
+    setShowExternalUI(true);
+    setVisible(true);
+  }, []);
 
   useGestureViewerEvent('zoomChange', (data) => {
     console.log(`Zoom changed from ${data.previousScale} to ${data.scale}`);
@@ -46,126 +59,146 @@ function Example() {
     <View style={styles.container}>
       <View style={styles.buttonWrapper}>
         <Button title={`Loop: ${enableLoop ? 'ON' : 'OFF'}`} onPress={() => setEnableLoop(!enableLoop)} />
-        <Button title="Open Gallery" onPress={() => setVisible(true)} />
+        <Text style={styles.text}>Click on thumbnail to open!</Text>
+        <View style={styles.galleryContainer}>
+          {images.map((uri, index) => (
+            <GestureTrigger key={uri} onPress={() => modalOpen(index)}>
+              <Pressable style={styles.thumb}>
+                <Image source={{ uri }} style={styles.thumbImage} contentFit="cover" />
+              </Pressable>
+            </GestureTrigger>
+          ))}
+        </View>
       </View>
-      <Modal visible={visible} onRequestClose={() => setVisible(false)}>
+      <Modal visible={visible} transparent animationType="none">
         <View style={{ flex: 1 }}>
           <GestureViewer
             data={images}
-            initialIndex={0}
+            initialIndex={selectedIndex}
             onDismiss={() => setVisible(false)}
+            onDismissStart={() => setShowExternalUI(false)}
             enableLoop={enableLoop}
             ListComponent={FlashList}
             renderItem={renderImage}
-            backdropStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.90)' }}
-            renderContainer={(children) => <View style={{ flex: 1 }}>{children}</View>}
+            backdropStyle={{ backgroundColor: '#181818' }}
+            renderContainer={(children, helpers) => (
+              <View style={{ flex: 1 }}>
+                {children}
+                {showExternalUI && (
+                  <View
+                    style={{
+                      position: 'absolute',
+                      top: insets.top + 10,
+                      right: 10,
+                      zIndex: 1000,
+                    }}
+                  >
+                    <Feather.Button
+                      name="x"
+                      size={30}
+                      iconStyle={{ marginRight: 0 }}
+                      backgroundColor="transparent"
+                      color="white"
+                      onPress={helpers.dismiss}
+                    />
+                  </View>
+                )}
+              </View>
+            )}
           />
-          <View
-            style={{
-              position: 'absolute',
-              top: insets.top + 10,
-              left: 10,
-              zIndex: 1000,
-              flexDirection: 'row',
-              gap: 10,
-            }}
-          >
-            <View style={{ flexDirection: 'column' }}>
-              <Feather.Button
-                name="zoom-in"
-                size={30}
-                iconStyle={{ marginRight: 0 }}
-                backgroundColor="transparent"
-                color="white"
-                onPress={() => zoomIn(0.25)}
-              />
-              <Feather.Button
-                name="zoom-out"
-                size={30}
-                iconStyle={{ marginRight: 0 }}
-                backgroundColor="transparent"
-                color="white"
-                onPress={() => zoomOut(0.25)}
-              />
-              <Feather.Button
-                name="refresh-cw"
-                size={30}
-                iconStyle={{ marginRight: 0 }}
-                backgroundColor="transparent"
-                color="white"
-                onPress={() => {
-                  rotate(0);
-                  resetZoom();
+          {showExternalUI && (
+            <>
+              <View
+                style={{
+                  position: 'absolute',
+                  top: insets.top + 10,
+                  left: 10,
+                  zIndex: 1000,
+                  flexDirection: 'row',
+                  gap: 10,
                 }}
-              />
-            </View>
-            <View style={{ flexDirection: 'column' }}>
-              <Feather.Button
-                name="rotate-cw"
-                size={30}
-                iconStyle={{ marginRight: 0 }}
-                backgroundColor="transparent"
-                color="white"
-                onPress={() => rotate()}
-              />
-              <Feather.Button
-                name="rotate-ccw"
-                size={30}
-                iconStyle={{ marginRight: 0 }}
-                backgroundColor="transparent"
-                color="white"
-                onPress={() => rotate(90, false)}
-              />
-            </View>
-          </View>
-          <View
-            style={{
-              position: 'absolute',
-              top: insets.top + 10,
-              right: 10,
-              zIndex: 1000,
-            }}
-          >
-            <Feather.Button
-              name="x"
-              size={30}
-              iconStyle={{ marginRight: 0 }}
-              backgroundColor="transparent"
-              color="white"
-              onPress={() => setVisible(false)}
-            />
-          </View>
-          <View
-            style={{
-              position: 'absolute',
-              bottom: insets.bottom + 10,
-              left: 0,
-              right: 0,
-              gap: 10,
-              flexDirection: 'column',
-            }}
-          >
-            <View style={{ flexDirection: 'row', gap: 10, justifyContent: 'space-around', alignItems: 'center' }}>
-              <Feather.Button
-                backgroundColor="transparent"
-                name="chevron-left"
-                size={30}
-                iconStyle={{ marginRight: 0 }}
-                color="white"
-                onPress={goToPrevious}
-              />
-              <Button title="Jump to 3" onPress={() => goToIndex(2)} />
-              <Feather.Button
-                backgroundColor="transparent"
-                name="chevron-right"
-                size={30}
-                iconStyle={{ marginRight: 0 }}
-                color="white"
-                onPress={goToNext}
-              />
-            </View>
-            <Text style={{ textAlign: 'center', color: 'white' }}>{`${currentIndex + 1} / ${totalCount}`}</Text>
-          </View>
+              >
+                <View style={{ flexDirection: 'column' }}>
+                  <Feather.Button
+                    name="zoom-in"
+                    size={30}
+                    iconStyle={{ marginRight: 0 }}
+                    backgroundColor="transparent"
+                    color="white"
+                    onPress={() => zoomIn(0.25)}
+                  />
+                  <Feather.Button
+                    name="zoom-out"
+                    size={30}
+                    iconStyle={{ marginRight: 0 }}
+                    backgroundColor="transparent"
+                    color="white"
+                    onPress={() => zoomOut(0.25)}
+                  />
+                  <Feather.Button
+                    name="refresh-cw"
+                    size={30}
+                    iconStyle={{ marginRight: 0 }}
+                    backgroundColor="transparent"
+                    color="white"
+                    onPress={() => {
+                      rotate(0);
+                      resetZoom();
+                    }}
+                  />
+                </View>
+                <View style={{ flexDirection: 'column' }}>
+                  <Feather.Button
+                    name="rotate-cw"
+                    size={30}
+                    iconStyle={{ marginRight: 0 }}
+                    backgroundColor="transparent"
+                    color="white"
+                    onPress={() => rotate()}
+                  />
+                  <Feather.Button
+                    name="rotate-ccw"
+                    size={30}
+                    iconStyle={{ marginRight: 0 }}
+                    backgroundColor="transparent"
+                    color="white"
+                    onPress={() => rotate(90, false)}
+                  />
+                </View>
+              </View>
+              <View
+                style={{
+                  position: 'absolute',
+                  bottom: insets.bottom + 10,
+                  left: 0,
+                  right: 0,
+                  gap: 10,
+                  flexDirection: 'column',
+                }}
+              >
+                <View style={{ flexDirection: 'row', gap: 10, justifyContent: 'space-around', alignItems: 'center' }}>
+                  <Feather.Button
+                    backgroundColor="transparent"
+                    name="chevron-left"
+                    size={30}
+                    iconStyle={{ marginRight: 0 }}
+                    color="white"
+                    onPress={goToPrevious}
+                  />
+                  <Button title="Jump to 3" onPress={() => goToIndex(2)} />
+                  <Feather.Button
+                    backgroundColor="transparent"
+                    name="chevron-right"
+                    size={30}
+                    iconStyle={{ marginRight: 0 }}
+                    color="white"
+                    onPress={goToNext}
+                  />
+                </View>
+                <Text style={{ textAlign: 'center', color: 'white' }}>{`${currentIndex + 1} / ${totalCount}`}</Text>
+              </View>
+            </>
+          )}
         </View>
       </Modal>
     </View>
@@ -179,7 +212,32 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   buttonWrapper: {
+    gap: 16,
+  },
+  galleryContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+    maxWidth: 360,
+  },
+  thumb: {
+    width: 110,
+    height: 110,
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: '#222',
+  },
+  thumbImage: {
+    width: '100%',
+    height: '100%',
+  },
+  text: {
+    textAlign: 'center',
+    color: '#222',
+    fontSize: 22,
+    fontWeight: 'bold',
   },
 });
 

--- a/src/GestureTrigger.tsx
+++ b/src/GestureTrigger.tsx
@@ -82,5 +82,9 @@ export function GestureTrigger<T extends WithOnPress>({ id = 'default', children
     });
   }, [id, onPress, children]);
 
-  return <View ref={ref}>{wrapped}</View>;
+  return (
+    <View ref={ref} collapsable={false}>
+      {wrapped}
+    </View>
+  );
 }

--- a/src/GestureTrigger.tsx
+++ b/src/GestureTrigger.tsx
@@ -1,0 +1,86 @@
+import type { ReactElement } from 'react';
+import { Children, cloneElement, isValidElement, useMemo, useRef } from 'react';
+import { View } from 'react-native';
+import { registry } from './GestureViewerRegistry';
+
+/**
+ * Minimal contract for a pressable child's props.
+ * The child must optionally accept an `onPress` handler.
+ */
+type WithOnPress = { onPress?: (...args: unknown[]) => void };
+
+/**
+ * Props for `GestureTrigger`.
+ *
+ * @typeParam T - The child's props type. Must include an optional `onPress` handler.
+ *
+ * @property id - Optional identifier to associate this trigger with a `GestureViewer`.
+ * @property children - A single React element whose props include `onPress` (e.g., `Pressable`, `Touchable*`).
+ * @property onPress - Optional handler invoked after the child's own `onPress`.
+ */
+export type GestureTriggerProps<T extends WithOnPress> = {
+  id?: string;
+  children: ReactElement<T>;
+  onPress?: (...args: unknown[]) => void;
+};
+
+/**
+ * Wraps a pressable child element and registers its native view as a trigger for `GestureViewer`.
+ *
+ * @remark
+ * Behavior on press:
+ * - Registers the child's native node to the internal registry under the given `id`.
+ * - Invokes the child's own `onPress` first (if provided).
+ * - Invokes the `onPress` passed to `GestureTrigger` next (if provided).
+ *
+ * Type parameters:
+ * - `T` — The child's props type. Must include an optional `onPress` handler, ensuring the child is pressable.
+ *
+ * Props:
+ * - `id` — Optional identifier to associate this trigger with a `GestureViewer`. Defaults to `"default"`.
+ * - `children` — A single React element whose props include `onPress` (e.g., `Pressable`, `Touchable*`, custom button).
+ * - `onPress` — Optional handler invoked after the child's `onPress`. Receives the same arguments as the child's handler.
+ *
+ * Notes:
+ * - If neither the child nor this component provides `onPress`, a dev warning is logged and nothing happens on press.
+ * - Only a single child is allowed; wrap lists using `React.Children.map` when needed.
+ *
+ * Example:
+ * ```tsx
+ * <GestureTrigger id="gallery" onPress={() => openModal(index)}>
+ *   <Pressable style={styles.thumb}>
+ *     <Image source={{ uri }} style={styles.thumbImage} />
+ *   </Pressable>
+ * </GestureTrigger>
+ * ```
+ */
+export function GestureTrigger<T extends WithOnPress>({ id = 'default', children, onPress }: GestureTriggerProps<T>) {
+  const ref = useRef<View>(null);
+
+  const wrapped = useMemo(() => {
+    const child = Children.only(children);
+
+    if (!isValidElement(child)) {
+      return children;
+    }
+
+    const originalOnPress = child.props?.onPress;
+
+    const handlePress = (...args: unknown[]) => {
+      registry.setTriggerNode(id, ref.current);
+      originalOnPress?.(...args);
+      onPress?.(...args);
+
+      if (__DEV__ && !originalOnPress && !onPress) {
+        console.warn('[GestureTrigger] No onPress found on child or props. Nothing will happen on press.');
+      }
+    };
+
+    return cloneElement(child, {
+      ...child.props,
+      onPress: handlePress,
+    });
+  }, [id, onPress, children]);
+
+  return <View ref={ref}>{wrapped}</View>;
+}

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -45,6 +45,7 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
     zoomGesture,
     onMomentumScrollEnd,
     onScrollBeginDrag,
+    handleDismiss,
     animatedStyle,
     backdropStyle,
   } = useGestureViewer({
@@ -133,6 +134,8 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
     [width, itemSpacing, isZoomed, isRotated, onMomentumScrollEnd, onScrollBeginDrag, useSnap],
   );
 
+  const control = useMemo(() => ({ dismiss: handleDismiss }), [handleDismiss]);
+
   const listComponent = (
     <GestureHandlerRootView>
       <GestureDetector gesture={gesture}>
@@ -174,7 +177,7 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
     </GestureHandlerRootView>
   );
 
-  return renderContainer ? renderContainer(listComponent) : listComponent;
+  return renderContainer ? renderContainer(listComponent, control) : listComponent;
 }
 
 const styles = StyleSheet.create({

--- a/src/GestureViewerRegistry.ts
+++ b/src/GestureViewerRegistry.ts
@@ -1,8 +1,10 @@
+import type { View } from 'react-native';
 import GestureViewerManager from './GestureViewerManager';
 
 class GestureViewerRegistry {
   private managers = new Map<string, GestureViewerManager>();
   private subscribers = new Map<string, Set<(manager: GestureViewerManager | null) => void>>();
+  private triggers = new Map<string, View | null>();
 
   subscribeToManager(id: string, callback: (manager: GestureViewerManager | null) => void) {
     if (!this.subscribers.has(id)) {
@@ -51,6 +53,8 @@ class GestureViewerRegistry {
       this.managers.delete(id);
 
       this.notifySubscribers(id, null);
+
+      this.clearTriggerNode(id);
     }
   }
 
@@ -60,6 +64,18 @@ class GestureViewerRegistry {
     if (listeners) {
       [...listeners].forEach((callback) => callback(manager));
     }
+  }
+
+  setTriggerNode(id: string, node: View | null) {
+    this.triggers.set(id, node);
+  }
+
+  getTriggerNode(id: string): View | null {
+    return this.triggers.get(id) ?? null;
+  }
+
+  clearTriggerNode(id: string) {
+    this.triggers.delete(id);
   }
 }
 

--- a/src/GestureViewerRegistry.ts
+++ b/src/GestureViewerRegistry.ts
@@ -52,9 +52,8 @@ class GestureViewerRegistry {
       manager.cleanUp();
       this.managers.delete(id);
 
-      this.notifySubscribers(id, null);
-
       this.clearTriggerNode(id);
+      this.notifySubscribers(id, null);
     }
   }
 
@@ -67,6 +66,11 @@ class GestureViewerRegistry {
   }
 
   setTriggerNode(id: string, node: View | null) {
+    if (!node) {
+      this.clearTriggerNode(id);
+      return;
+    }
+
     this.triggers.set(id, node);
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+export { GestureTrigger, type GestureTriggerProps } from './GestureTrigger';
 export { GestureViewer } from './GestureViewer';
 export type {
   GestureViewerController,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
 import type { FlatList as RNFlatList, ScrollView as RNScrollView, StyleProp, ViewStyle } from 'react-native';
 import type { FlatList as GHFlatList, ScrollView as GHScrollView } from 'react-native-gesture-handler';
+import type { WithTimingConfig } from 'react-native-reanimated';
 
 export type FlatListComponent = typeof RNFlatList | typeof GHFlatList;
 export type ScrollViewComponent = typeof RNScrollView | typeof GHScrollView;
@@ -12,6 +13,30 @@ type ConditionalListProps<LC> = LC extends FlatListComponent
   : LC extends ScrollViewComponent
     ? React.ComponentProps<LC>
     : GetComponentProps<LC>;
+
+export type TriggerRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export interface TriggerAnimationConfig extends WithTimingConfig {
+  /**
+   * Animation duration in milliseconds
+   * @defaultValue 300
+   */
+  duration?: WithTimingConfig['duration'];
+  /**
+   * Animation easing function
+   * @defaultValue Easing.bezier(0.25, 0.1, 0.25, 1.0)
+   */
+  easing?: WithTimingConfig['easing'];
+  /**
+   * Callback function called after animation completion
+   */
+  onAnimationComplete?: () => void;
+}
 
 export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   /**
@@ -38,13 +63,24 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
    */
   onDismiss?: () => void;
   /**
+   * A callback function that is called when the dismiss interaction starts.
+   * @remarks Useful to hide external UI (e.g., headers, buttons) while the dismiss gesture/animation is in progress.
+   */
+  onDismissStart?: () => void;
+  /**
    * A callback function that is called to render the item.
    */
   renderItem: (item: T, index: number) => React.ReactElement;
   /**
    * A callback function that is called to render the container.
+   * @remarks Useful for composing additional UI (e.g., close button, toolbars) around the viewer.
+   * The second argument provides control helpers such as `dismiss()` to close the viewer.
+   *
+   * @param children - The viewer content to be rendered inside your container.
+   * @param helpers - Control helpers for the viewer. Currently includes `dismiss()`.
+   * @returns A React element that wraps and renders the provided `children`.
    */
-  renderContainer?: (children: React.ReactElement) => React.ReactElement;
+  renderContainer?: (children: React.ReactElement, helpers: { dismiss: () => void }) => React.ReactElement;
   /**
    * Support for any list component like `ScrollView`, `FlatList`, `FlashList` through the `ListComponent` prop.
    */
@@ -74,8 +110,6 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
    * @defaultValue 80
    */
   dismissThreshold?: number;
-  // swipeThreshold?: number;
-  // velocityThreshold?: number;
   /**
    * Calls `onDismiss` function when swiping down.
    * @remark Useful for closing modals with downward swipe gestures.
@@ -146,6 +180,25 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
    * @defaultValue 0
    */
   itemSpacing?: number;
+  /**
+   * Trigger-based animation settings
+   * @remarks You can customize animation duration, easing, and system reduce-motion behavior.
+   *
+   * @example
+   * ```tsx
+   * <GestureViewer
+   *   triggerAnimation={{
+   *     duration: 250,
+   *     easing: Easing.out(Easing.cubic),
+   *     reduceMotion: 'system',
+   *     onAnimationComplete: () => {
+   *       console.log('Animation complete');
+   *     },
+   *   }}
+   * />
+   * ```
+   */
+  triggerAnimation?: TriggerAnimationConfig;
 }
 
 /**

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -18,7 +18,7 @@ import {
 } from 'react-native-reanimated';
 import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
-import type { GestureViewerProps } from './types';
+import type { GestureViewerProps, TriggerRect } from './types';
 import { createBoundsConstraint, createScrollAction, getLoopAdjustedIndex } from './utils';
 
 type UseGestureViewerProps<T = any> = Omit<
@@ -34,8 +34,6 @@ export const useGestureViewer = <T = any>({
   width: customWidth,
   dismissThreshold = 80,
   resistance = 2,
-  // swipeThreshold = 0.5,
-  // velocityThreshold = 200,
   animateBackdrop = true,
   enableDismissGesture = true,
   enableSwipeGesture = true,
@@ -47,6 +45,8 @@ export const useGestureViewer = <T = any>({
   itemSpacing = 0,
   useSnap = false,
   id = 'default',
+  onDismissStart,
+  triggerAnimation,
 }: UseGestureViewerProps<T>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const width = useSnap ? customWidth || screenWidth : screenWidth;
@@ -54,11 +54,14 @@ export const useGestureViewer = <T = any>({
   const [isZoomed, setIsZoomed] = useState(false);
   const [isRotated, setIsRotated] = useState(false);
   const [manager, setManager] = useState<GestureViewerManager | null>(null);
+  const [shouldStartTriggerAnimation, setShouldStartTriggerAnimation] = useState(false);
 
   const listRef = useRef<any>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
   const onIndexChangeRef = useRef<((index: number) => void) | null>(null);
   const lastEmittedIndexRef = useRef<number>(null);
+  const triggerRectRef = useRef<TriggerRect | null>(null);
+  const onAnimationCompleteRef = useRef(triggerAnimation?.onAnimationComplete);
 
   const initialTranslateY = useSharedValue(0);
   const initialTranslateX = useSharedValue(0);
@@ -70,7 +73,21 @@ export const useGestureViewer = <T = any>({
   const backdropOpacity = useSharedValue(1);
   const rotation = useSharedValue(0);
 
+  const triggerScale = useSharedValue(1);
+  const triggerTranslateX = useSharedValue(0);
+  const triggerTranslateY = useSharedValue(0);
+  const triggerOpacity = useSharedValue(1);
+
   const dataLength = data?.length || 0;
+
+  const animationConfig = useMemo(
+    () => ({
+      duration: triggerAnimation?.duration ?? 300,
+      easing: triggerAnimation?.easing ?? Easing.bezier(0.25, 0.1, 0.25, 1.0),
+      reduceMotion: triggerAnimation?.reduceMotion,
+    }),
+    [triggerAnimation?.duration, triggerAnimation?.easing, triggerAnimation?.reduceMotion],
+  );
 
   const adjustedInitialIndex = useMemo(() => {
     if (enableLoop && data.length > 1) {
@@ -84,6 +101,10 @@ export const useGestureViewer = <T = any>({
     () => createBoundsConstraint({ width, height: screenHeight }),
     [width, screenHeight],
   );
+
+  const onAnimationComplete = useCallback(() => {
+    onAnimationCompleteRef.current?.();
+  }, []);
 
   const scrollTo = useCallback(
     (index: number, animated: boolean) => {
@@ -139,6 +160,68 @@ export const useGestureViewer = <T = any>({
       onIndexChangeRef.current = null;
     };
   }, []);
+
+  useEffect(() => {
+    onAnimationCompleteRef.current = triggerAnimation?.onAnimationComplete;
+  }, [triggerAnimation?.onAnimationComplete]);
+
+  useEffect(() => {
+    if (shouldStartTriggerAnimation && triggerRectRef.current) {
+      const startX = triggerRectRef.current.x + triggerRectRef.current.width / 2 - screenWidth / 2;
+      const startY = triggerRectRef.current.y + triggerRectRef.current.height / 2 - screenHeight / 2;
+      const initialScaleFromTrigger = Math.min(
+        triggerRectRef.current.width / screenWidth,
+        triggerRectRef.current.height / screenHeight,
+      );
+
+      triggerScale.value = initialScaleFromTrigger;
+      triggerTranslateX.value = startX;
+      triggerTranslateY.value = startY;
+      triggerOpacity.value = 0;
+
+      triggerScale.value = withTiming(1, animationConfig, (finished) => {
+        if (finished) {
+          runOnJS(onAnimationComplete)();
+        }
+      });
+      triggerTranslateX.value = withTiming(0, animationConfig);
+      triggerTranslateY.value = withTiming(0, animationConfig);
+      triggerOpacity.value = withTiming(1, {
+        duration: animationConfig.duration / 2,
+        easing: animationConfig.easing,
+        reduceMotion: animationConfig.reduceMotion,
+      });
+
+      setShouldStartTriggerAnimation(false);
+    }
+  }, [
+    shouldStartTriggerAnimation,
+    animationConfig,
+    screenWidth,
+    screenHeight,
+    triggerOpacity,
+    triggerScale,
+    triggerTranslateX,
+    triggerTranslateY,
+    onAnimationComplete,
+  ]);
+
+  useEffect(() => {
+    const node = registry.getTriggerNode(id);
+
+    if (node && typeof node.measure === 'function') {
+      node.measure((_x, _y, width, height, pageX, pageY) => {
+        triggerRectRef.current = { x: pageX, y: pageY, width, height };
+        triggerOpacity.value = 0;
+        setShouldStartTriggerAnimation(true);
+        registry.clearTriggerNode(id);
+      });
+    }
+
+    return () => {
+      triggerRectRef.current = null;
+    };
+  }, [id, triggerOpacity]);
 
   useEffect(() => {
     const handleManagerChange = (manager: GestureViewerManager | null) => {
@@ -227,6 +310,43 @@ export const useGestureViewer = <T = any>({
     };
   }, [adjustedInitialIndex, translateY, backdropOpacity, translateX, scale, startScale, rotation, scrollTo]);
 
+  const handleDismiss = useCallback(() => {
+    onDismissStart?.();
+
+    if (triggerRectRef.current) {
+      const endX = triggerRectRef.current.x + triggerRectRef.current.width / 2 - screenWidth / 2;
+      const endY = triggerRectRef.current.y + triggerRectRef.current.height / 2 - screenHeight / 2;
+      const endScale = Math.min(
+        triggerRectRef.current.width / screenWidth,
+        triggerRectRef.current.height / screenHeight,
+      );
+
+      triggerScale.value = withTiming(endScale, animationConfig);
+      triggerTranslateX.value = withTiming(endX, animationConfig);
+      triggerTranslateY.value = withTiming(endY, animationConfig);
+      triggerOpacity.value = withTiming(0, animationConfig, (finished) => {
+        if (finished && onDismiss) {
+          runOnJS(onDismiss)();
+        }
+      });
+      return;
+    }
+
+    if (onDismiss) {
+      runOnJS(onDismiss)();
+    }
+  }, [
+    animationConfig,
+    onDismiss,
+    onDismissStart,
+    screenWidth,
+    screenHeight,
+    triggerTranslateX,
+    triggerScale,
+    triggerTranslateY,
+    triggerOpacity,
+  ]);
+
   const onMomentumScrollEnd = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
       if (!enableSwipeGesture) {
@@ -297,8 +417,8 @@ export const useGestureViewer = <T = any>({
         translateY.value = event.translationY / resistance;
       })
       .onEnd((event) => {
-        if (canDismiss && event.translationY > dismissThreshold && onDismiss) {
-          runOnJS(onDismiss)();
+        if (canDismiss && event.translationY > dismissThreshold && handleDismiss) {
+          runOnJS(handleDismiss)();
           return;
         }
 
@@ -307,7 +427,7 @@ export const useGestureViewer = <T = any>({
           stiffness: 150,
         });
       });
-  }, [translateY, dismissThreshold, enableDismissGesture, onDismiss, resistance, isZoomed]);
+  }, [translateY, dismissThreshold, enableDismissGesture, handleDismiss, resistance, isZoomed]);
 
   const zoomPinchGesture = useMemo(() => {
     return Gesture.Pinch()
@@ -478,7 +598,12 @@ export const useGestureViewer = <T = any>({
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
+      opacity: triggerOpacity.value,
       transform: [
+        { translateX: triggerTranslateX.value },
+        { translateY: triggerTranslateY.value },
+        { scale: triggerScale.value },
+
         { translateY: translateY.value },
         { translateX: translateX.value },
         { scale: scale.value },
@@ -488,13 +613,15 @@ export const useGestureViewer = <T = any>({
   });
 
   const backdropStyle = useAnimatedStyle(() => {
+    const baseOpacity = triggerOpacity.value;
+
     if (!animateBackdrop || scale.value !== 1) {
-      return { opacity: 1 };
+      return { opacity: baseOpacity };
     }
 
-    const opacity = interpolate(translateY.value, [0, 200], [1, 0], 'clamp');
+    const dismissOpacity = interpolate(translateY.value, [0, 200], [1, 0], 'clamp');
 
-    return { opacity };
+    return { opacity: dismissOpacity * baseOpacity };
   }, [animateBackdrop]);
 
   const onScrollBeginDrag = useCallback(() => {
@@ -503,7 +630,6 @@ export const useGestureViewer = <T = any>({
 
   return {
     dataLength,
-    translateY,
     listRef,
     isZoomed,
     isRotated,
@@ -512,6 +638,7 @@ export const useGestureViewer = <T = any>({
 
     onMomentumScrollEnd,
     onScrollBeginDrag,
+    handleDismiss,
 
     animatedStyle,
     backdropStyle,


### PR DESCRIPTION
- Add `GestureTrigger` component for registering trigger elements
- Implement trigger position-based modal open/close animations
- Enable smooth transition from trigger element to full modal view
- add `triggerAnimation` prop for customizable open animation
- add `onDismissStart` callback to signal dismiss gesture start
- add `dismiss()` helper to `renderContainer` for programmatic close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Trigger-based modal open/close animations tied to a trigger element.
  - New GestureTrigger component to open a viewer by id.
  - New triggerAnimation prop for customizable open animation (duration, easing, reduce motion, completion callback).
  - New onDismissStart callback to signal dismissal start.
  - Programmatic close via helpers.dismiss exposed to renderContainer.

- Documentation
  - Example updated: thumbnail gallery using GestureTrigger, external UI overlay, custom triggerAnimation, and dismiss button via helpers.

- Chores
  - Minor version bump in changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->