### PR TITLE
fix: sync dataRef on data change; use manager.currentIndex for comparison

### DIFF
--- a/.changeset/gentle-women-visit.md
+++ b/.changeset/gentle-women-visit.md
@@ -1,0 +1,8 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+fix: sync `dataRef` on data change; use `manager.currentIndex` for comparison
+
+- move `dataRef.current` update into `useEffect([data])` to sync only when data changes
+- compare against `manager.getState().currentIndex` for accurate index checks

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -27,7 +27,6 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
   const Component = ListComponent as React.ComponentType<any>;
 
   const dataRef = useRef(data);
-  dataRef.current = data;
 
   const { width: screenWidth } = useWindowDimensions();
 
@@ -104,6 +103,10 @@ export function GestureViewer<T = any, LC = typeof FlatList>({
   const gesture = useMemo(() => {
     return Gesture.Race(dismissGesture, zoomGesture);
   }, [zoomGesture, dismissGesture]);
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   useEffect(() => {
     registry.createManager(id);

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -368,7 +368,7 @@ export const useGestureViewer = <T = any>({
         scrollTo(jumpToIndex, false);
       }
 
-      const currentIndex = manager?.getState() ?? 0;
+      const currentIndex = manager?.getState().currentIndex;
 
       if (realIndex !== currentIndex && realIndex >= 0 && realIndex < dataLength) {
         if (manager) {


### PR DESCRIPTION
- move dataRef.current update into useEffect([data]) to sync only when data changes
- compare against manager.getState().currentIndex for accurate index checks