### PR TITLE
chore(docs): replace `@remark` with `@remarks` per TSDoc spec

### DIFF
--- a/.changeset/pink-loops-cry.md
+++ b/.changeset/pink-loops-cry.md
@@ -1,0 +1,10 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+chore(docs): replace `@remark` with `@remarks` per TSDoc spec
+
+- TSDoc specifies the tag name as `@remarks` (not `@remark`).
+- This aligns our comments with the spec and improves tooling support.
+- No runtime behavior changes.
+- Ref: https://tsdoc.org/pages/tags/remarks/

--- a/src/GestureTrigger.tsx
+++ b/src/GestureTrigger.tsx
@@ -27,7 +27,7 @@ export type GestureTriggerProps<T extends WithOnPress> = {
 /**
  * Wraps a pressable child element and registers its native view as a trigger for `GestureViewer`.
  *
- * @remark
+ * @remarks
  * Behavior on press:
  * - Registers the child's native node to the internal registry under the given `id`.
  * - Invokes the child's own `onPress` first (if provided).

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface TriggerAnimationConfig extends WithTimingConfig {
 export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
-   * @remark `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
+   * @remarks `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
    * @defaultValue 'default'
    */
   id?: string;
@@ -87,14 +87,14 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   ListComponent: LC;
   /**
    * The width of the `GestureViewer`.
-   * @remark If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
+   * @remarks If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
    * @defaultValue screen width
    */
   width?: number;
   /**
    * Enables snap scrolling mode.
    *
-   * @remark
+   * @remarks
    * **`false` (default)**: Paging mode (`pagingEnabled: true`)
    * - Scrolls by full screen size increments
    *
@@ -112,13 +112,13 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   dismissThreshold?: number;
   /**
    * Calls `onDismiss` function when swiping down.
-   * @remark Useful for closing modals with downward swipe gestures.
+   * @remarks Useful for closing modals with downward swipe gestures.
    * @defaultValue true
    */
   enableDismissGesture?: boolean;
   /**
    * Controls left/right swipe gestures.
-   * @remark When `false`, horizontal gestures are disabled.
+   * @remarks When `false`, horizontal gestures are disabled.
    * @defaultValue true
    */
   enableSwipeGesture?: boolean;
@@ -129,7 +129,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   resistance?: number;
   /**
    * The props to pass to the list component.
-   * @remark The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
+   * @remarks The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
    */
   listProps?: Partial<ConditionalListProps<LC>>;
   /**
@@ -142,25 +142,25 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   containerStyle?: StyleProp<ViewStyle>;
   /**
    * By default, the background `opacity` gradually decreases from 1 to 0 during downward swipe gestures.
-   * @remark When `false`, this animation is disabled.
+   * @remarks When `false`, this animation is disabled.
    * @defaultValue true
    */
   animateBackdrop?: boolean;
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
-   * @remark When `false`, gesture movement is disabled during zoom.
+   * @remarks When `false`, gesture movement is disabled during zoom.
    * @defaultValue true
    */
   enableZoomPanGesture?: boolean;
   /**
    * Controls two-finger pinch gestures.
-   * @remark When `false`, two-finger zoom gestures are disabled.
+   * @remarks When `false`, two-finger zoom gestures are disabled.
    * @defaultValue true
    */
   enableZoomGesture?: boolean;
   /**
    * Controls double-tap zoom gestures.
-   * @remark When `false`, double-tap zoom gestures are disabled.
+   * @remarks When `false`, double-tap zoom gestures are disabled.
    * @defaultValue true
    */
   enableDoubleTapGesture?: boolean;
@@ -176,7 +176,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   maxZoomScale?: number;
   /**
    * The spacing between items in pixels.
-   * @remark Only applied when `useSnap` is `true`.
+   * @remarks Only applied when `useSnap` is `true`.
    * @defaultValue 0
    */
   itemSpacing?: number;


### PR DESCRIPTION
- TSDoc specifies the tag name as `@remarks` (not `@remark`).
- This aligns our comments with the spec and improves tooling support.
- No runtime behavior changes.
- Ref: https://tsdoc.org/pages/tags/remarks/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Standardized TSDoc comments by replacing `@remark` with `@remarks` across public-facing props and components, aligning with the TSDoc spec for clearer, more consistent IDE/intellisense rendering. No behavioral or type changes.
* Chores
  * Added a changeset entry documenting a patch release for these documentation updates. Confirms no public API or runtime changes and clarifies that this is a docs-only adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->