### PR TITLE
chore(docs): replace `@remark` with `@remarks` per TSDoc spec

### DIFF
--- a/.changeset/twenty-ways-strive.md
+++ b/.changeset/twenty-ways-strive.md
@@ -1,0 +1,10 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+chore(docs): replace `@remark` with `@remarks` per TSDoc spec
+
+- TSDoc specifies the tag name as `@remarks` (not `@remark`).
+- This aligns our comments with the spec and improves tooling support.
+- No runtime behavior changes.
+- Ref: https://tsdoc.org/pages/tags/remarks/

--- a/docs/docs/1.x/en/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/1.x/en/guide/usage/gesture-viewer-props.mdx
@@ -90,7 +90,7 @@ Controls the maximum zoom scale multiplier.
 export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
-   * @remark `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
+   * @remarks `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
    * @defaultValue 'default'
    */
   id?: string;
@@ -125,14 +125,14 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   ListComponent: LC;
   /**
    * The width of the `GestureViewer`.
-   * @remark If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
+   * @remarks If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
    * @defaultValue screen width
    */
   width?: number;
   /**
    * Enables snap scrolling mode.
    *
-   * @remark
+   * @remarks
    * **`false` (default)**: Paging mode (`pagingEnabled: true`)
    * - Scrolls by full screen size increments
    *
@@ -152,13 +152,13 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   // velocityThreshold?: number;
   /**
    * Calls `onDismiss` function when swiping down.
-   * @remark Useful for closing modals with downward swipe gestures.
+   * @remarks Useful for closing modals with downward swipe gestures.
    * @defaultValue true
    */
   enableDismissGesture?: boolean;
   /**
    * Controls left/right swipe gestures.
-   * @remark When `false`, horizontal gestures are disabled.
+   * @remarks When `false`, horizontal gestures are disabled.
    * @defaultValue true
    */
   enableSwipeGesture?: boolean;
@@ -169,7 +169,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   resistance?: number;
   /**
    * The props to pass to the list component.
-   * @remark The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
+   * @remarks The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
    */
   listProps?: Partial<ConditionalListProps<LC>>;
   /**
@@ -182,25 +182,25 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   containerStyle?: StyleProp<ViewStyle>;
   /**
    * By default, the background `opacity` gradually decreases from 1 to 0 during downward swipe gestures.
-   * @remark When `false`, this animation is disabled.
+   * @remarks When `false`, this animation is disabled.
    * @defaultValue true
    */
   animateBackdrop?: boolean;
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
-   * @remark When `false`, gesture movement is disabled during zoom.
+   * @remarks When `false`, gesture movement is disabled during zoom.
    * @defaultValue true
    */
   enableZoomPanGesture?: boolean;
   /**
    * Controls two-finger pinch gestures.
-   * @remark When `false`, two-finger zoom gestures are disabled.
+   * @remarks When `false`, two-finger zoom gestures are disabled.
    * @defaultValue true
    */
   enableZoomGesture?: boolean;
   /**
    * Controls double-tap zoom gestures.
-   * @remark When `false`, double-tap zoom gestures are disabled.
+   * @remarks When `false`, double-tap zoom gestures are disabled.
    * @defaultValue true
    */
   enableDoubleTapGesture?: boolean;
@@ -216,7 +216,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   maxZoomScale?: number;
   /**
    * The spacing between items in pixels.
-   * @remark Only applied when `useSnap` is `true`.
+   * @remarks Only applied when `useSnap` is `true`.
    * @defaultValue 0
    */
   itemSpacing?: number;

--- a/docs/docs/1.x/ko/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/1.x/ko/guide/usage/gesture-viewer-props.mdx
@@ -91,7 +91,7 @@ function App() {
 export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
-   * @remark `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
+   * @remarks `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
    * @defaultValue 'default'
    */
   id?: string;
@@ -126,14 +126,14 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   ListComponent: LC;
   /**
    * The width of the `GestureViewer`.
-   * @remark If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
+   * @remarks If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
    * @defaultValue screen width
    */
   width?: number;
   /**
    * Enables snap scrolling mode.
    *
-   * @remark
+   * @remarks
    * **`false` (default)**: Paging mode (`pagingEnabled: true`)
    * - Scrolls by full screen size increments
    *
@@ -153,13 +153,13 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   // velocityThreshold?: number;
   /**
    * Calls `onDismiss` function when swiping down.
-   * @remark Useful for closing modals with downward swipe gestures.
+   * @remarks Useful for closing modals with downward swipe gestures.
    * @defaultValue true
    */
   enableDismissGesture?: boolean;
   /**
    * Controls left/right swipe gestures.
-   * @remark When `false`, horizontal gestures are disabled.
+   * @remarks When `false`, horizontal gestures are disabled.
    * @defaultValue true
    */
   enableSwipeGesture?: boolean;
@@ -170,7 +170,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   resistance?: number;
   /**
    * The props to pass to the list component.
-   * @remark The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
+   * @remarks The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
    */
   listProps?: Partial<ConditionalListProps<LC>>;
   /**
@@ -183,25 +183,25 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   containerStyle?: StyleProp<ViewStyle>;
   /**
    * By default, the background `opacity` gradually decreases from 1 to 0 during downward swipe gestures.
-   * @remark When `false`, this animation is disabled.
+   * @remarks When `false`, this animation is disabled.
    * @defaultValue true
    */
   animateBackdrop?: boolean;
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
-   * @remark When `false`, gesture movement is disabled during zoom.
+   * @remarks When `false`, gesture movement is disabled during zoom.
    * @defaultValue true
    */
   enableZoomPanGesture?: boolean;
   /**
    * Controls two-finger pinch gestures.
-   * @remark When `false`, two-finger zoom gestures are disabled.
+   * @remarks When `false`, two-finger zoom gestures are disabled.
    * @defaultValue true
    */
   enableZoomGesture?: boolean;
   /**
    * Controls double-tap zoom gestures.
-   * @remark When `false`, double-tap zoom gestures are disabled.
+   * @remarks When `false`, double-tap zoom gestures are disabled.
    * @defaultValue true
    */
   enableDoubleTapGesture?: boolean;
@@ -217,7 +217,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNFlatList> {
   maxZoomScale?: number;
   /**
    * The spacing between items in pixels.
-   * @remark Only applied when `useSnap` is `true`.
+   * @remarks Only applied when `useSnap` is `true`.
    * @defaultValue 0
    */
   itemSpacing?: number;

--- a/docs/docs/2.x/en/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/2.x/en/guide/usage/gesture-viewer-props.mdx
@@ -73,7 +73,7 @@ Controls the maximum zoom scale multiplier.
 export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
-   * @remark `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
+   * @remarks `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
    * @defaultValue 'default'
    */
   id?: string;
@@ -115,13 +115,13 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   ListComponent: LC;
   /**
    * The width of the `GestureViewer`.
-   * @remark If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
+   * @remarks If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
    * @defaultValue screen width
    */
   width?: number;
   /**
    * The props to pass to the list component.
-   * @remark The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
+   * @remarks The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
    */
   listProps?: Partial<ConditionalListProps<LC>>;
   /**
@@ -134,7 +134,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   containerStyle?: StyleProp<ViewStyle>;
   /**
    * Dismiss gesture options. Calls `onDismiss` function when swiping down.
-   * @remark Useful for closing modals with downward swipe gestures.
+   * @remarks Useful for closing modals with downward swipe gestures.
    */
   dismiss?: {
     /**
@@ -154,32 +154,32 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
     resistance?: number;
     /**
      * By default, the background `opacity` gradually decreases from 1 to 0 during downward swipe gestures.
-     * @remark When `false`, this animation is disabled.
+     * @remarks When `false`, this animation is disabled.
      * @defaultValue true
      */
     fadeBackdrop?: boolean;
   };
   /**
    * Controls left/right swipe gestures.
-   * @remark When `false`, horizontal gestures are disabled.
+   * @remarks When `false`, horizontal gestures are disabled.
    * @defaultValue true
    */
   enableHorizontalSwipe?: boolean;
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
-   * @remark When `false`, gesture movement is disabled during zoom.
+   * @remarks When `false`, gesture movement is disabled during zoom.
    * @defaultValue true
    */
   enablePanWhenZoomed?: boolean;
   /**
    * Controls two-finger pinch gestures.
-   * @remark When `false`, two-finger zoom gestures are disabled.
+   * @remarks When `false`, two-finger zoom gestures are disabled.
    * @defaultValue true
    */
   enablePinchZoom?: boolean;
   /**
    * Controls double-tap zoom gestures.
-   * @remark When `false`, double-tap zoom gestures are disabled.
+   * @remarks When `false`, double-tap zoom gestures are disabled.
    * @defaultValue true
    */
   enableDoubleTapZoom?: boolean;
@@ -191,7 +191,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * Enables snap scrolling mode.
    *
-   * @remark
+   * @remarks
    * **`false` (default)**: Paging mode (`pagingEnabled: true`)
    * - Scrolls by full screen size increments
    *
@@ -204,7 +204,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   enableSnapMode?: boolean;
   /**
    * The spacing between items in pixels.
-   * @remark Only applied when `enableSnapMode` is `true`.
+   * @remarks Only applied when `enableSnapMode` is `true`.
    * @defaultValue 0
    */
   itemSpacing?: number;

--- a/docs/docs/2.x/ko/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/2.x/ko/guide/usage/gesture-viewer-props.mdx
@@ -73,7 +73,7 @@ function App() {
 export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
-   * @remark `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
+   * @remarks `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
    * @defaultValue 'default'
    */
   id?: string;
@@ -115,13 +115,13 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   ListComponent: LC;
   /**
    * The width of the `GestureViewer`.
-   * @remark If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
+   * @remarks If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
    * @defaultValue screen width
    */
   width?: number;
   /**
    * The props to pass to the list component.
-   * @remark The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
+   * @remarks The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
    */
   listProps?: Partial<ConditionalListProps<LC>>;
   /**
@@ -134,7 +134,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   containerStyle?: StyleProp<ViewStyle>;
   /**
    * Dismiss gesture options. Calls `onDismiss` function when swiping down.
-   * @remark Useful for closing modals with downward swipe gestures.
+   * @remarks Useful for closing modals with downward swipe gestures.
    */
   dismiss?: {
     /**
@@ -154,32 +154,32 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
     resistance?: number;
     /**
      * By default, the background `opacity` gradually decreases from 1 to 0 during downward swipe gestures.
-     * @remark When `false`, this animation is disabled.
+     * @remarks When `false`, this animation is disabled.
      * @defaultValue true
      */
     fadeBackdrop?: boolean;
   };
   /**
    * Controls left/right swipe gestures.
-   * @remark When `false`, horizontal gestures are disabled.
+   * @remarks When `false`, horizontal gestures are disabled.
    * @defaultValue true
    */
   enableHorizontalSwipe?: boolean;
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
-   * @remark When `false`, gesture movement is disabled during zoom.
+   * @remarks When `false`, gesture movement is disabled during zoom.
    * @defaultValue true
    */
   enablePanWhenZoomed?: boolean;
   /**
    * Controls two-finger pinch gestures.
-   * @remark When `false`, two-finger zoom gestures are disabled.
+   * @remarks When `false`, two-finger zoom gestures are disabled.
    * @defaultValue true
    */
   enablePinchZoom?: boolean;
   /**
    * Controls double-tap zoom gestures.
-   * @remark When `false`, double-tap zoom gestures are disabled.
+   * @remarks When `false`, double-tap zoom gestures are disabled.
    * @defaultValue true
    */
   enableDoubleTapZoom?: boolean;
@@ -191,7 +191,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * Enables snap scrolling mode.
    *
-   * @remark
+   * @remarks
    * **`false` (default)**: Paging mode (`pagingEnabled: true`)
    * - Scrolls by full screen size increments
    *
@@ -204,7 +204,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   enableSnapMode?: boolean;
   /**
    * The spacing between items in pixels.
-   * @remark Only applied when `enableSnapMode` is `true`.
+   * @remarks Only applied when `enableSnapMode` is `true`.
    * @defaultValue 0
    */
   itemSpacing?: number;

--- a/src/GestureTrigger.tsx
+++ b/src/GestureTrigger.tsx
@@ -27,7 +27,7 @@ export type GestureTriggerProps<T extends WithOnPress> = {
 /**
  * Wraps a pressable child element and registers its native view as a trigger for `GestureViewer`.
  *
- * @remark
+ * @remarks
  * Behavior on press:
  * - Registers the child's native node to the internal registry under the given `id`.
  * - Invokes the child's own `onPress` first (if provided).

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface TriggerAnimationConfig extends WithTimingConfig {
 export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
-   * @remark `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
+   * @remarks `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
    * @defaultValue 'default'
    */
   id?: string;
@@ -83,13 +83,13 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   ListComponent: LC;
   /**
    * The width of the `GestureViewer`.
-   * @remark If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
+   * @remarks If you don't set this prop, the width of the `GestureViewer` will be the same as the width of the screen.
    * @defaultValue screen width
    */
   width?: number;
   /**
    * The props to pass to the list component.
-   * @remark The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
+   * @remarks The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
    */
   listProps?: Partial<ConditionalListProps<LC>>;
   /**
@@ -102,7 +102,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   containerStyle?: StyleProp<ViewStyle>;
   /**
    * Dismiss gesture options. Calls `onDismiss` function when swiping down.
-   * @remark Useful for closing modals with downward swipe gestures.
+   * @remarks Useful for closing modals with downward swipe gestures.
    */
   dismiss?: {
     /**
@@ -122,32 +122,32 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
     resistance?: number;
     /**
      * By default, the background `opacity` gradually decreases from 1 to 0 during downward swipe gestures.
-     * @remark When `false`, this animation is disabled.
+     * @remarks When `false`, this animation is disabled.
      * @defaultValue true
      */
     fadeBackdrop?: boolean;
   };
   /**
    * Controls left/right swipe gestures.
-   * @remark When `false`, horizontal gestures are disabled.
+   * @remarks When `false`, horizontal gestures are disabled.
    * @defaultValue true
    */
   enableHorizontalSwipe?: boolean;
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
-   * @remark When `false`, gesture movement is disabled during zoom.
+   * @remarks When `false`, gesture movement is disabled during zoom.
    * @defaultValue true
    */
   enablePanWhenZoomed?: boolean;
   /**
    * Controls two-finger pinch gestures.
-   * @remark When `false`, two-finger zoom gestures are disabled.
+   * @remarks When `false`, two-finger zoom gestures are disabled.
    * @defaultValue true
    */
   enablePinchZoom?: boolean;
   /**
    * Controls double-tap zoom gestures.
-   * @remark When `false`, double-tap zoom gestures are disabled.
+   * @remarks When `false`, double-tap zoom gestures are disabled.
    * @defaultValue true
    */
   enableDoubleTapZoom?: boolean;
@@ -159,7 +159,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * Enables snap scrolling mode.
    *
-   * @remark
+   * @remarks
    * **`false` (default)**: Paging mode (`pagingEnabled: true`)
    * - Scrolls by full screen size increments
    *
@@ -172,7 +172,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   enableSnapMode?: boolean;
   /**
    * The spacing between items in pixels.
-   * @remark Only applied when `enableSnapMode` is `true`.
+   * @remarks Only applied when `enableSnapMode` is `true`.
    * @defaultValue 0
    */
   itemSpacing?: number;


### PR DESCRIPTION
- TSDoc specifies the tag name as `@remarks` (not `@remark`).
- This aligns our comments with the spec and improves tooling support.
- No runtime behavior changes.
- Ref: https://tsdoc.org/pages/tags/remarks/