### PR TITLE
feat: add auto-play functionality to gesture viewer with configurable interval

### DIFF
--- a/.changeset/good-numbers-boil.md
+++ b/.changeset/good-numbers-boil.md
@@ -8,8 +8,11 @@ feat: add auto-play functionality to gesture viewer with configurable interval
 - when `autoPlay` is enabled, the viewer will automatically play the next item after the specified interval
 - when `enableLoop` is enabled, the viewer will loop back to the first item after the last item
 - when `enableLoop` is disabled, the viewer will stop at the last item
+- when there is only one item, auto-play is disabled
+- interval must be a positive integer in milliseconds (values < 250ms are clamped to 250ms)
 - `autoPlayInterval` is optional and defaults to 3000ms
 - `autoPlay` is optional and defaults to `false`
+- when zoom or rotate gestures are detected, the auto-play will be paused
 
 ```tsx
 import { GestureViewer } from 'react-native-gesture-image-viewer';

--- a/.changeset/good-numbers-boil.md
+++ b/.changeset/good-numbers-boil.md
@@ -1,0 +1,25 @@
+---
+"react-native-gesture-image-viewer": minor
+---
+
+feat: add auto-play functionality to gesture viewer with configurable interval
+
+- add `autoPlay` and `autoPlayInterval` props
+- when `autoPlay` is enabled, the viewer will automatically play the next item after the specified interval
+- when `enableLoop` is enabled, the viewer will loop back to the first item after the last item
+- when `enableLoop` is disabled, the viewer will stop at the last item
+- `autoPlayInterval` is optional and defaults to 3000ms
+- `autoPlay` is optional and defaults to `false`
+
+```tsx
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      autoPlay
+      autoPlayInterval={3000}
+    />
+  );
+}
+```

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,12 +138,16 @@ export interface GestureViewerProps<ItemT, LC> {
    * - When `true`, the viewer will automatically play the next item after the specified interval.
    * - When `enableLoop` is enabled, the viewer will loop back to the first item after the last item.
    * - When `enableLoop` is disabled, the viewer will stop at the last item.
+   * - When there is only one item, auto-play is disabled.
+   * - When zoom or rotate gestures are detected, the auto-play will be paused.
    * @defaultValue false
    */
   autoPlay?: boolean;
   /**
    * Auto play interval.
-   * @remarks When `autoPlay` is enabled, the viewer will automatically play the next item after the specified interval.
+   * @remarks
+   * - When `autoPlay` is enabled, the viewer advances to the next item after the specified interval (ms).
+   * - Must be a positive integer. Values below 250ms are clamped to 250ms at runtime.
    * @defaultValue 3000
    */
   autoPlayInterval?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,21 @@ export interface GestureViewerProps<ItemT, LC> {
    */
   height?: number;
   /**
+   * Auto play mode.
+   * @remarks
+   * - When `true`, the viewer will automatically play the next item after the specified interval.
+   * - When `enableLoop` is enabled, the viewer will loop back to the first item after the last item.
+   * - When `enableLoop` is disabled, the viewer will stop at the last item.
+   * @defaultValue false
+   */
+  autoPlay?: boolean;
+  /**
+   * Auto play interval.
+   * @remarks When `autoPlay` is enabled, the viewer will automatically play the next item after the specified interval.
+   * @defaultValue 3000
+   */
+  autoPlayInterval?: number;
+  /**
    * Enables snap scrolling mode.
    *
    * @remarks

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -153,7 +153,20 @@ export const useGestureViewer = <ItemT, LC>({
   );
 
   useEffect(() => {
-    if (!autoPlay || !manager || dataLength <= 1 || (!enableLoop && currentIndex === dataLength - 1)) {
+    if (
+      !autoPlay ||
+      !manager ||
+      dataLength <= 1 ||
+      isZoomed ||
+      isRotated ||
+      (!enableLoop && currentIndex === dataLength - 1)
+    ) {
+      return;
+    }
+
+    const intervalMs = Math.max(250, Math.floor(autoPlayInterval || 0));
+
+    if (!Number.isFinite(intervalMs)) {
       return;
     }
 
@@ -162,7 +175,7 @@ export const useGestureViewer = <ItemT, LC>({
     }, autoPlayInterval);
 
     return () => clearInterval(interval);
-  }, [autoPlay, autoPlayInterval, manager, dataLength, currentIndex, enableLoop]);
+  }, [autoPlay, autoPlayInterval, manager, dataLength, currentIndex, enableLoop, isZoomed, isRotated]);
 
   useEffect(() => {
     onIndexChangeRef.current = onIndexChange ?? null;

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -171,8 +171,12 @@ export const useGestureViewer = <ItemT, LC>({
     }
 
     const interval = setInterval(() => {
+      if (isZoomed || isRotated) {
+        return;
+      }
+
       manager.goToNext();
-    }, autoPlayInterval);
+    }, intervalMs);
 
     return () => clearInterval(interval);
   }, [autoPlay, autoPlayInterval, manager, dataLength, currentIndex, enableLoop, isZoomed, isRotated]);

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -47,6 +47,8 @@ export const useGestureViewer = <ItemT, LC>({
   id = 'default',
   onDismissStart,
   triggerAnimation,
+  autoPlay = false,
+  autoPlayInterval = 3000,
 }: UseGestureViewerProps<ItemT, LC>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const width = customWidth || screenWidth;
@@ -56,6 +58,7 @@ export const useGestureViewer = <ItemT, LC>({
   const [isRotated, setIsRotated] = useState(false);
   const [manager, setManager] = useState<GestureViewerManager | null>(null);
   const [shouldStartTriggerAnimation, setShouldStartTriggerAnimation] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
 
   const listRef = useRef<any>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
@@ -91,12 +94,12 @@ export const useGestureViewer = <ItemT, LC>({
   );
 
   const adjustedInitialIndex = useMemo(() => {
-    if (enableLoop && data.length > 1) {
+    if (enableLoop && dataLength > 1) {
       return initialIndex + 1;
     }
 
     return initialIndex;
-  }, [enableLoop, data.length, initialIndex]);
+  }, [enableLoop, dataLength, initialIndex]);
 
   const constrainTranslation = useMemo(() => createBoundsConstraint({ width, height }), [width, height]);
 
@@ -148,6 +151,18 @@ export const useGestureViewer = <ItemT, LC>({
       runOnJS(setIsRotated)(currentRotation % 360 !== 0);
     },
   );
+
+  useEffect(() => {
+    if (!autoPlay || !manager || dataLength <= 1 || (!enableLoop && currentIndex === dataLength - 1)) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      manager.goToNext();
+    }, autoPlayInterval);
+
+    return () => clearInterval(interval);
+  }, [autoPlay, autoPlayInterval, manager, dataLength, currentIndex, enableLoop]);
 
   useEffect(() => {
     onIndexChangeRef.current = onIndexChange ?? null;
@@ -235,6 +250,7 @@ export const useGestureViewer = <ItemT, LC>({
           if (lastEmittedIndexRef.current !== state.currentIndex) {
             lastEmittedIndexRef.current = state.currentIndex;
             onIndexChangeRef.current?.(state.currentIndex);
+            setCurrentIndex(state.currentIndex);
           }
         });
         return;


### PR DESCRIPTION
- add `autoPlay` and `autoPlayInterval` props
- `autoPlayInterval` is optional and defaults to 3000ms
- `autoPlay` is optional and defaults to `false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added autoplay to GestureViewer: items advance automatically when enabled.
  * New props: autoPlay (default: false) and autoPlayInterval (default: 3000ms).
  * Auto-play pauses on zoom/rotate gestures and is disabled for a single item.
  * Interval validation: values below 250ms are clamped; behavior respects enableLoop (loops or stops at last item).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->