### PR TITLE
fix: improve type inference for listProps with generic list components

### DIFF
--- a/.changeset/open-baths-serve.md
+++ b/.changeset/open-baths-serve.md
@@ -1,0 +1,39 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+fix: improve type inference for listProps with generic list components
+
+- Add InstantiateGeneric helper type for better generic component props inference
+- Change generic type parameter from T to ItemT for clarity
+- Fix type inference issues with FlashList, FlatList keyExtractor and renderItem props
+- Ensure all list component props receive correct ItemT type instead of unknown
+
+**Before:**
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  ListComponent={FlashList}
+  // keyExtractor's item parameter was unknown type
+  listProps={{
+    keyExtractor: (item, index) => item.id, // ❌ item is unknown
+  }}
+/>
+```
+
+**After:**
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  ListComponent={FlashList}
+  // keyExtractor's item parameter is now properly typed
+  listProps={{
+    keyExtractor: (item, index) => item.id, // ✅ item has correct type
+    // and other props...
+  }}
+/>
+```

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Platform, type ScrollView, type ScrollViewProps, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { Platform, type ScrollViewProps, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import { registry } from './GestureViewerRegistry';
@@ -8,7 +8,7 @@ import { useGestureViewer } from './useGestureViewer';
 import { createLoopData, isFlashListLike, isFlatListLike, isScrollViewLike } from './utils';
 import WebPagingFixStyle from './WebPagingFixStyle';
 
-export function GestureViewer<T = any, LC = typeof ScrollView>({
+export function GestureViewer<ItemT, LC>({
   id = 'default',
   data,
   renderItem: renderItemProp,
@@ -24,7 +24,7 @@ export function GestureViewer<T = any, LC = typeof ScrollView>({
   enableSnapMode = false,
   enableLoop = false,
   ...props
-}: GestureViewerProps<T, LC>) {
+}: GestureViewerProps<ItemT, LC>) {
   const Component = ListComponent as React.ComponentType<any>;
 
   const dataRef = useRef(data);
@@ -61,7 +61,7 @@ export function GestureViewer<T = any, LC = typeof ScrollView>({
   });
 
   const keyExtractor = useCallback(
-    (item: T, index: number) => {
+    (item: ItemT, index: number) => {
       if (enableLoop) {
         return typeof item === 'string' ? `${item}-${index}` : `item-${index}`;
       }
@@ -72,7 +72,7 @@ export function GestureViewer<T = any, LC = typeof ScrollView>({
   );
 
   const renderItem = useCallback(
-    ({ item, index }: { item: T; index: number }) => {
+    ({ item, index }: { item: ItemT; index: number }) => {
       return (
         <View
           key={isScrollView ? keyExtractor(item, index) : undefined}
@@ -93,7 +93,7 @@ export function GestureViewer<T = any, LC = typeof ScrollView>({
   );
 
   const getItemLayout = useCallback(
-    (_: ArrayLike<T> | null | undefined, index: number) => ({
+    (_: ArrayLike<ItemT> | null | undefined, index: number) => ({
       length: width + itemSpacing,
       offset: (width + itemSpacing) * index,
       index,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,65 @@
 import type React from 'react';
-import type { FlatList as RNFlatList, ScrollView as RNScrollView, StyleProp, ViewStyle } from 'react-native';
+import type {
+  FlatListProps,
+  ListRenderItem,
+  FlatList as RNFlatList,
+  ScrollView as RNScrollView,
+  StyleProp,
+  ViewabilityConfig,
+  ViewStyle,
+  ViewToken,
+} from 'react-native';
 import type { FlatList as GHFlatList, ScrollView as GHScrollView } from 'react-native-gesture-handler';
 import type { WithTimingConfig } from 'react-native-reanimated';
 
-export type FlatListComponent = typeof RNFlatList | typeof GHFlatList;
+export type FlatListComponent<ItemT> = typeof RNFlatList<ItemT> | typeof GHFlatList<ItemT>;
 export type ScrollViewComponent = typeof RNScrollView | typeof GHScrollView;
 
-type GetComponentProps<T> = T extends React.ComponentType<infer P> ? P : never;
+interface ViewabilityConfigCallbackPair<TItem> {
+  viewabilityConfig: ViewabilityConfig;
+  onViewableItemsChanged: ((info: { viewableItems: ViewToken<TItem>[]; changed: ViewToken<TItem>[] }) => void) | null;
+}
 
-type ConditionalListProps<LC> = LC extends FlatListComponent
-  ? React.ComponentProps<LC>
-  : LC extends ScrollViewComponent
-    ? React.ComponentProps<LC>
-    : GetComponentProps<LC>;
+// Helper type to instantiate generic components with specific type parameter
+export type InstantiateGeneric<ItemT, LC> = LC extends React.ComponentType<infer P>
+  ? P extends Record<string, any>
+    ? {
+        [K in keyof P]: K extends 'data'
+          ? ArrayLike<ItemT> | null | undefined
+          : K extends 'renderItem'
+            ? ListRenderItem<ItemT>
+            : K extends 'keyExtractor'
+              ? (item: ItemT, index: number) => string
+              : K extends 'getItemType'
+                ? (item: ItemT, index: number, extraData?: any) => string | number | undefined
+                : K extends 'overrideItemLayout'
+                  ? (
+                      layout: { span?: number; size?: number },
+                      item: ItemT,
+                      index: number,
+                      maxColumns?: number,
+                      extraData?: any,
+                    ) => void
+                  : K extends 'onViewableItemsChanged'
+                    ? FlatListProps<ItemT>['onViewableItemsChanged']
+                    : K extends 'viewabilityConfigCallbackPairs'
+                      ? ViewabilityConfigCallbackPair<ItemT>[]
+                      : P[K];
+      }
+    : P
+  : never;
+
+export type GetComponentProps<ItemT, LC> = LC extends React.ComponentType<any> ? InstantiateGeneric<ItemT, LC> : never;
+
+type ConditionalListProps<ItemT, LC> = LC extends typeof RNFlatList<ItemT>
+  ? React.ComponentProps<typeof RNFlatList<ItemT>>
+  : LC extends typeof GHFlatList<ItemT>
+    ? React.ComponentProps<typeof GHFlatList<ItemT>>
+    : LC extends typeof RNScrollView
+      ? React.ComponentProps<typeof RNScrollView>
+      : LC extends typeof GHScrollView
+        ? React.ComponentProps<typeof GHScrollView>
+        : GetComponentProps<ItemT, LC>;
 
 export type TriggerRect = {
   x: number;
@@ -38,7 +85,7 @@ export interface TriggerAnimationConfig extends WithTimingConfig {
   onAnimationComplete?: () => void;
 }
 
-export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
+export interface GestureViewerProps<ItemT, LC> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
    * @remarks `GestureViewer` automatically removes instances from memory when components are unmounted, so no manual memory management is required.
@@ -48,7 +95,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * The data to display in the `GestureViewer`.
    */
-  data: T[];
+  data: ItemT[];
   /**
    * The index of the item to display in the `GestureViewer` when the component is mounted.
    * @defaultValue 0
@@ -66,7 +113,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
   /**
    * A callback function that is called to render the item.
    */
-  renderItem: (item: T, index: number) => React.ReactElement;
+  renderItem: (item: ItemT, index: number) => React.ReactElement;
   /**
    * A callback function that is called to render the container.
    * @remarks Useful for composing additional UI (e.g., close button, toolbars) around the viewer.
@@ -97,7 +144,7 @@ export interface GestureViewerProps<T = any, LC = typeof RNScrollView> {
    * The props to pass to the list component.
    * @remarks The `listProps` provides **type inference based on the selected list component**, ensuring accurate autocompletion and type safety in your IDE.
    */
-  listProps?: Partial<ConditionalListProps<LC>>;
+  listProps?: Partial<ConditionalListProps<ItemT, LC>>;
   /**
    * The style of the backdrop.
    */

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -21,8 +21,8 @@ import { registry } from './GestureViewerRegistry';
 import type { GestureViewerProps, TriggerRect } from './types';
 import { createBoundsConstraint, createScrollAction, getLoopAdjustedIndex } from './utils';
 
-type UseGestureViewerProps<T = any> = Omit<
-  GestureViewerProps<T>,
+type UseGestureViewerProps<ItemT, LC> = Omit<
+  GestureViewerProps<ItemT, LC>,
   | 'renderItem'
   | 'renderContainer'
   | 'ListComponent'
@@ -32,7 +32,7 @@ type UseGestureViewerProps<T = any> = Omit<
   | 'enableSnapMode'
 >;
 
-export const useGestureViewer = <T = any>({
+export const useGestureViewer = <ItemT, LC>({
   data,
   initialIndex = 0,
   onDismiss,
@@ -49,7 +49,7 @@ export const useGestureViewer = <T = any>({
   id = 'default',
   onDismissStart,
   triggerAnimation,
-}: UseGestureViewerProps<T>) => {
+}: UseGestureViewerProps<ItemT, LC>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const width = customWidth || screenWidth;
   const height = customHeight || screenHeight;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,11 +2,11 @@ import { FlatList as RNFlatList, ScrollView as RNScrollView } from 'react-native
 import { FlatList as GestureFlatList, ScrollView as GestureScrollView } from 'react-native-gesture-handler';
 import type { FlatListComponent, ScrollViewComponent } from './types';
 
-export const isScrollViewLike = (component: any): component is ScrollViewComponent => {
+export const isScrollViewLike = (component: React.ComponentType<any>): component is ScrollViewComponent => {
   return component === RNScrollView || component === GestureScrollView;
 };
 
-export const isFlatListLike = (component: any): component is FlatListComponent => {
+export const isFlatListLike = (component: React.ComponentType<any>): component is FlatListComponent<any> => {
   if (component === RNFlatList || component === GestureFlatList || isFlashListLike(component)) {
     return true;
   }
@@ -14,7 +14,7 @@ export const isFlatListLike = (component: any): component is FlatListComponent =
   return false;
 };
 
-export const isFlashListLike = (component: any): component is any => {
+export const isFlashListLike = (component: React.ComponentType<any>): boolean => {
   try {
     const FlashList = require('@shopify/flash-list')?.FlashList;
 
@@ -25,7 +25,7 @@ export const isFlashListLike = (component: any): component is any => {
     // do nothing
   }
 
-  return component?.name === 'FlashList';
+  return component?.displayName === 'FlashList' || component?.name === 'FlashList';
 };
 
 export const createBoundsConstraint =


### PR DESCRIPTION
- Add InstantiateGeneric helper type for better generic component props inference
- Change generic type parameter from T to ItemT for clarity
- Fix type inference issues with FlashList, FlatList keyExtractor and renderItem props
- Ensure all list component props receive correct ItemT type instead of unknown