### PR TITLE
feat: add auto-play functionality to gesture viewer with configurable interval

### DIFF
--- a/.changeset/fine-buses-argue.md
+++ b/.changeset/fine-buses-argue.md
@@ -1,0 +1,23 @@
+---
+"react-native-gesture-image-viewer": minor
+---
+
+feat: add auto-play functionality to gesture viewer with configurable interval
+
+- add `autoPlay` and `autoPlayInterval` props
+- when `autoPlay` is enabled, the viewer will automatically play the next item after the specified interval
+- when `enableLoop` is enabled, the viewer will loop back to the first item after the last item
+- when `enableLoop` is disabled, the viewer will stop at the last item
+- when there is only one item, auto-play is disabled
+- interval must be a positive integer in milliseconds (values < 250ms are clamped to 250ms)
+- `autoPlayInterval` is optional and defaults to 3000ms
+- `autoPlay` is optional and defaults to `false`
+- when zoom or rotate gestures are detected, the auto-play will be paused
+
+```tsx
+import { GestureViewer } from "react-native-gesture-image-viewer";
+
+function App() {
+  return <GestureViewer autoPlay autoPlayInterval={3000} />;
+}
+```

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,25 @@ export interface GestureViewerProps<ItemT, LC> {
    */
   containerStyle?: StyleProp<ViewStyle>;
   /**
+   * Auto play mode.
+   * @remarks
+   * - When `true`, the viewer will automatically play the next item after the specified interval.
+   * - When `enableLoop` is enabled, the viewer will loop back to the first item after the last item.
+   * - When `enableLoop` is disabled, the viewer will stop at the last item.
+   * - When there is only one item, auto-play is disabled.
+   * - When zoom or rotate gestures are detected, the auto-play will be paused.
+   * @defaultValue false
+   */
+  autoPlay?: boolean;
+  /**
+   * Auto play interval.
+   * @remarks
+   * - When `autoPlay` is enabled, the viewer advances to the next item after the specified interval (ms).
+   * - Must be a positive integer. Values below 250ms are clamped to 250ms at runtime.
+   * @defaultValue 3000
+   */
+  autoPlayInterval?: number;
+  /**
    * Dismiss gesture options. Calls `onDismiss` function when swiping down.
    * @remarks Useful for closing modals with downward swipe gestures.
    */

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -49,6 +49,8 @@ export const useGestureViewer = <ItemT, LC>({
   id = 'default',
   onDismissStart,
   triggerAnimation,
+  autoPlay = false,
+  autoPlayInterval = 3000,
 }: UseGestureViewerProps<ItemT, LC>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const width = customWidth || screenWidth;
@@ -58,6 +60,7 @@ export const useGestureViewer = <ItemT, LC>({
   const [isRotated, setIsRotated] = useState(false);
   const [shouldStartTriggerAnimation, setShouldStartTriggerAnimation] = useState(false);
   const [manager, setManager] = useState<GestureViewerManager | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
 
   const listRef = useRef<any>(null);
   const triggerRectRef = useRef<TriggerRect | null>(null);
@@ -99,12 +102,12 @@ export const useGestureViewer = <ItemT, LC>({
   }, [dismiss?.enabled, dismiss?.threshold, dismiss?.resistance, dismiss?.fadeBackdrop]);
 
   const adjustedInitialIndex = useMemo(() => {
-    if (enableLoop && data.length > 1) {
+    if (enableLoop && dataLength > 1) {
       return initialIndex + 1;
     }
 
     return initialIndex;
-  }, [enableLoop, data.length, initialIndex]);
+  }, [enableLoop, dataLength, initialIndex]);
 
   const constrainTranslation = useMemo(() => createBoundsConstraint({ width, height }), [width, height]);
 
@@ -162,9 +165,17 @@ export const useGestureViewer = <ItemT, LC>({
   );
 
   useEffect(() => {
-    const unsubscribe = registry.subscribeToManager(id, setManager);
+    let unsubscribe: (() => void) | undefined;
 
-    return unsubscribe;
+    const unsubscribeFromRegistry = registry.subscribeToManager(id, (managerInstance) => {
+      setManager(managerInstance);
+      unsubscribe = managerInstance?.subscribe((state) => setCurrentIndex(state.currentIndex));
+    });
+
+    return () => {
+      unsubscribeFromRegistry();
+      unsubscribe?.();
+    };
   }, [id]);
 
   useEffect(() => {
@@ -225,6 +236,35 @@ export const useGestureViewer = <ItemT, LC>({
       runAfterInteractions?.cancel();
     };
   }, [adjustedInitialIndex, translateY, backdropOpacity, translateX, scale, startScale, rotation, scrollTo]);
+
+  useEffect(() => {
+    if (
+      !autoPlay ||
+      !manager ||
+      dataLength <= 1 ||
+      isZoomed ||
+      isRotated ||
+      (!enableLoop && currentIndex === dataLength - 1)
+    ) {
+      return;
+    }
+
+    const intervalMs = Math.max(250, Math.floor(autoPlayInterval || 0));
+
+    if (!Number.isFinite(intervalMs)) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (isZoomed || isRotated) {
+        return;
+      }
+
+      manager.goToNext();
+    }, intervalMs);
+
+    return () => clearInterval(interval);
+  }, [autoPlay, autoPlayInterval, manager, dataLength, currentIndex, enableLoop, isZoomed, isRotated]);
 
   useEffect(() => {
     onAnimationCompleteRef.current = triggerAnimation?.onAnimationComplete;


### PR DESCRIPTION
- add `autoPlay` and `autoPlayInterval` props
- when `autoPlay` is enabled, the viewer will automatically play the next item after the specified interval
- when `enableLoop` is enabled, the viewer will loop back to the first item after the last item
- when `enableLoop` is disabled, the viewer will stop at the last item
- when there is only one item, auto-play is disabled
- interval must be a positive integer in milliseconds (values < 250ms are clamped to 250ms)
- `autoPlayInterval` is optional and defaults to 3000ms
- `autoPlay` is optional and defaults to `false`
- when zoom or rotate gestures are detected, the auto-play will be paused