### PR TITLE
ci: add v1.* branch to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - main
       - next
+      - v1.*
   pull_request:
     branches:
       - main
       - next
+      - v1.*
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - next
+      - v1.*
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration triggers to include v1.* branches, ensuring tests and checks run on pushes, pull requests, and merge groups for those branches.
  * Updated release workflow to support publishing from any v1.* branch, enabling consistent release automation across the v1 line without altering existing steps or job behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->