### PR TITLE
fix(android): restore horizontal swipe by scoping native scroll workaround to iOS

### DIFF
--- a/.changeset/violet-plums-crash.md
+++ b/.changeset/violet-plums-crash.md
@@ -1,0 +1,8 @@
+---
+'react-native-gesture-image-viewer': patch
+---
+
+fix(android): restore horizontal swipe by scoping native scroll workaround to iOS
+
+Fix an Android regression where horizontal swiping could stop working after the iOS native scroll gesture
+workaround was introduced. The workaround is now scoped to iOS scrollables only, while still preserving the iOS dismiss behavior.

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -12,7 +12,13 @@ import Animated from 'react-native-reanimated';
 import { registry } from './GestureViewerRegistry';
 import type { GestureViewerProps } from './types';
 import { useGestureViewer } from './useGestureViewer';
-import { createLoopData, isFlashListLike, isFlatListLike, isScrollViewLike } from './utils';
+import {
+  createLoopData,
+  isFlashListLike,
+  isFlatListLike,
+  isScrollViewLike,
+  shouldUseNativeScrollGesture,
+} from './utils';
 import WebPagingFixStyle from './WebPagingFixStyle';
 
 export function GestureViewer<ItemT, LC>({
@@ -158,6 +164,22 @@ export function GestureViewer<ItemT, LC>({
 
   const control = useMemo(() => ({ dismiss: handleDismiss }), [handleDismiss]);
 
+  const shouldWrapScrollableWithNativeGesture = shouldUseNativeScrollGesture(
+    Platform.OS,
+    Component,
+  );
+
+  const maybeWrapWithNativeScrollGesture = useCallback(
+    (children: React.ReactNode) => {
+      if (!shouldWrapScrollableWithNativeGesture) {
+        return children;
+      }
+
+      return <GestureDetector gesture={nativeScrollGesture}>{children}</GestureDetector>;
+    },
+    [nativeScrollGesture, shouldWrapScrollableWithNativeGesture],
+  );
+
   const listComponent = (
     <GestureHandlerRootView>
       <GestureDetector gesture={gesture}>
@@ -168,15 +190,14 @@ export function GestureViewer<ItemT, LC>({
             {...(Platform.OS === 'web' &&
               isFlashListLike(Component) && { dataSet: { 'flash-list-paging-enabled-fix': true } })}
           >
-            {isScrollView ? (
-              <GestureDetector gesture={nativeScrollGesture}>
-                <Component ref={listRef} {...commonProps} {...listProps}>
-                  {loopData.map((item, index) => renderItem({ item, index }))}
-                </Component>
-              </GestureDetector>
-            ) : (
-              isFlatListLike(Component) && (
-                <GestureDetector gesture={nativeScrollGesture}>
+            {isScrollView
+              ? maybeWrapWithNativeScrollGesture(
+                  <Component ref={listRef} {...commonProps} {...listProps}>
+                    {loopData.map((item, index) => renderItem({ item, index }))}
+                  </Component>,
+                )
+              : isFlatListLike(Component) &&
+                maybeWrapWithNativeScrollGesture(
                   <Component
                     ref={listRef}
                     {...commonProps}
@@ -196,10 +217,8 @@ export function GestureViewer<ItemT, LC>({
                         dataSet: { 'flat-list-paging-enabled-fix': true },
                       })}
                     {...listProps}
-                  />
-                </GestureDetector>
-              )
-            )}
+                  />,
+                )}
           </Animated.View>
           <WebPagingFixStyle Component={Component} />
         </View>

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('react-native-gesture-handler', () => ({
+  FlatList: function GestureFlatList() {
+    return null;
+  },
+  ScrollView: function GestureScrollView() {
+    return null;
+  },
+}));
+
+import {
+  FlatList as GestureFlatList,
+  ScrollView as GestureScrollView,
+} from 'react-native-gesture-handler';
+
+import { shouldUseNativeScrollGesture } from '../utils';
+
+function PlainScrollView() {
+  return null;
+}
+
+function PlainFlatList() {
+  return null;
+}
+
+describe('shouldUseNativeScrollGesture', () => {
+  it('enables the native scroll workaround for non-RNGH scrollables on iOS', () => {
+    expect(shouldUseNativeScrollGesture('ios', PlainScrollView)).toBe(true);
+    expect(shouldUseNativeScrollGesture('ios', PlainFlatList)).toBe(true);
+  });
+
+  it('disables the workaround on Android', () => {
+    expect(shouldUseNativeScrollGesture('android', PlainScrollView)).toBe(false);
+    expect(shouldUseNativeScrollGesture('android', PlainFlatList)).toBe(false);
+  });
+
+  it('does not double-apply the workaround to RNGH scrollables', () => {
+    expect(shouldUseNativeScrollGesture('ios', GestureScrollView)).toBe(false);
+    expect(shouldUseNativeScrollGesture('ios', GestureFlatList)).toBe(false);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,8 @@
-import { FlatList as RNFlatList, ScrollView as RNScrollView } from 'react-native';
+import {
+  FlatList as RNFlatList,
+  ScrollView as RNScrollView,
+  type PlatformOSType,
+} from 'react-native';
 import {
   FlatList as GestureFlatList,
   ScrollView as GestureScrollView,
@@ -29,6 +33,18 @@ export const isFlashListLike = (component: React.ComponentType<any>): boolean =>
   }
 
   return component?.displayName === 'FlashList' || component?.name === 'FlashList';
+};
+
+/**
+ * iOS needs the extra Native gesture wrapper so the dismiss pan can resolve before the scrollable claims touches.
+ * We intentionally skip Android because the same require-to-fail relation regressed horizontal paging there,
+ * and we also avoid wrapping RNGH-provided scrollables to prevent double-applying Gesture.Native() to components that already participate in RNGH.
+ */
+export const shouldUseNativeScrollGesture = (
+  platformOS: PlatformOSType,
+  component: React.ComponentType<any>,
+): boolean => {
+  return platformOS === 'ios' && component !== GestureScrollView && component !== GestureFlatList;
 };
 
 export const createBoundsConstraint =


### PR DESCRIPTION
Fix an Android regression where horizontal swiping could stop working after the iOS native scroll gesture
workaround was introduced. The workaround is now scoped to iOS scrollables only, while still preserving the iOS dismiss behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restored horizontal swipe functionality on Android devices by refining gesture handling to be platform-aware
  * Maintained iOS dismiss behavior during the fix

* **Tests**
  * Added test coverage for platform-specific gesture detection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->