### PR TITLE
fix(web): stabilize paging sync for autoplay, controller, and double-click zoom

### DIFF
--- a/.changeset/shaggy-showers-judge.md
+++ b/.changeset/shaggy-showers-judge.md
@@ -1,0 +1,9 @@
+---
+'react-native-gesture-image-viewer': patch
+---
+
+fix(web): stabilize paging sync for autoplay, controller, and double-click zoom
+
+Fix several web-specific paging and interaction issues in `GestureViewer`.
+
+This improves loop and autoplay index synchronization on web, keeps controller-driven navigation in sync, restores double-click zoom, and refines web paging behavior so settled pages match the browser's final scroll position more naturally.

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -59,7 +59,9 @@ export function GestureViewer<ItemT, LC>({
     dismissGesture,
     zoomGesture,
     nativeScrollGesture,
+    onWebDoubleClick,
     onMomentumScrollEnd,
+    onScroll,
     onScrollBeginDrag,
     animatedStyle,
     backdropStyle,
@@ -136,7 +138,8 @@ export function GestureViewer<ItemT, LC>({
         horizontal: true,
         scrollEnabled: !isZoomed && !isRotated && !isPinching,
         showsHorizontalScrollIndicator: false,
-        onMomentumScrollEnd: onMomentumScrollEnd,
+        onMomentumScrollEnd,
+        onScroll,
         onScrollBeginDrag,
         ...(enableSnapMode
           ? {
@@ -157,6 +160,7 @@ export function GestureViewer<ItemT, LC>({
       isRotated,
       isPinching,
       onMomentumScrollEnd,
+      onScroll,
       onScrollBeginDrag,
       enableSnapMode,
     ],
@@ -187,6 +191,7 @@ export function GestureViewer<ItemT, LC>({
           <Animated.View style={[styles.background, backdropStyleProps, backdropStyle]} />
           <Animated.View
             style={[styles.content, animatedStyle]}
+            {...(Platform.OS === 'web' && { onClick: onWebDoubleClick })}
             {...(Platform.OS === 'web' &&
               isFlashListLike(Component) && { dataSet: { 'flash-list-paging-enabled-fix': true } })}
           >

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -269,7 +269,7 @@ class GestureViewerManager {
         this.loopCallback = () => {
           scrollTo(this.dataLength, false);
           this.updateCurrentIndex(this.dataLength - 1);
-          this.loopCallback = null;
+          this.cancelPendingLoopTransition();
         };
 
         this.programmaticScrollVersion += 1;
@@ -281,7 +281,7 @@ class GestureViewerManager {
         this.loopCallback = () => {
           scrollTo(1, false);
           this.updateCurrentIndex(0);
-          this.loopCallback = null;
+          this.cancelPendingLoopTransition();
         };
 
         this.programmaticScrollVersion += 1;

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -22,6 +22,7 @@ class GestureViewerManager {
   private rotation: SharedValue<number> | null = null;
   private translateX: SharedValue<number> | null = null;
   private translateY: SharedValue<number> | null = null;
+  private resetTransformCallback: (() => void) | null = null;
 
   private loopCallback: (() => void) | null = null;
   private programmaticScrollVersion = 0;
@@ -136,6 +137,10 @@ class GestureViewerManager {
     this.translateX = translateX;
     this.translateY = translateY;
     this.maxZoomScale = maxZoomScale;
+  }
+
+  setResetTransformCallback(callback: (() => void) | null) {
+    this.resetTransformCallback = callback;
   }
 
   notifyStateChange() {
@@ -272,6 +277,7 @@ class GestureViewerManager {
           this.cancelPendingLoopTransition();
         };
 
+        this.resetTransformCallback?.();
         this.programmaticScrollVersion += 1;
         scrollTo(0, true);
         return;
@@ -284,11 +290,13 @@ class GestureViewerManager {
           this.cancelPendingLoopTransition();
         };
 
+        this.resetTransformCallback?.();
         this.programmaticScrollVersion += 1;
         scrollTo(this.dataLength + 1, true);
         return;
       }
 
+      this.resetTransformCallback?.();
       this.programmaticScrollVersion += 1;
       scrollTo(index + 1, true);
       this.updateCurrentIndex(index);
@@ -300,6 +308,7 @@ class GestureViewerManager {
       return;
     }
 
+    this.resetTransformCallback?.();
     this.programmaticScrollVersion += 1;
     scrollTo(index, true);
     this.updateCurrentIndex(index);
@@ -343,11 +352,11 @@ class GestureViewerManager {
     this.currentIndex = 0;
     this.dataLength = 0;
     this.maxZoomScale = 2;
-    this.programmaticScrollVersion = 0;
     this.scale = null;
     this.translateX = null;
     this.translateY = null;
     this.rotation = null;
+    this.resetTransformCallback = null;
     this.eventListeners.clear();
   }
 

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -24,6 +24,7 @@ class GestureViewerManager {
   private translateY: SharedValue<number> | null = null;
 
   private loopCallback: (() => void) | null = null;
+  private programmaticScrollVersion = 0;
 
   private listeners = new Set<(state: GestureViewerState) => void>();
   private eventListeners = new Map<GestureViewerEventType, Set<(data: any) => void>>();
@@ -89,6 +90,10 @@ class GestureViewerManager {
       currentIndex: this.currentIndex,
       totalCount: this.dataLength,
     };
+  }
+
+  getProgrammaticScrollVersion() {
+    return this.programmaticScrollVersion;
   }
 
   setEnableLoop(enabled: boolean) {
@@ -255,7 +260,8 @@ class GestureViewerManager {
       return;
     }
 
-    this.loopCallback = null;
+    this.programmaticScrollVersion += 1;
+    this.cancelPendingLoopTransition();
 
     const { scrollTo } = createScrollAction(this.listRef, this.width);
 
@@ -306,12 +312,16 @@ class GestureViewerManager {
       return true;
     }
 
-    this.loopCallback = null;
+    this.cancelPendingLoopTransition();
     return true;
   };
 
-  handleScrollBeginDrag = () => {
+  cancelPendingLoopTransition = () => {
     this.loopCallback = null;
+  };
+
+  handleScrollBeginDrag = () => {
+    this.cancelPendingLoopTransition();
   };
 
   goToPrevious = () => {
@@ -323,13 +333,14 @@ class GestureViewerManager {
   };
 
   cleanUp() {
-    this.loopCallback = null;
+    this.cancelPendingLoopTransition();
     this.listeners.clear();
     this.listRef = null;
     this.enableHorizontalSwipe = true;
     this.currentIndex = 0;
     this.dataLength = 0;
     this.maxZoomScale = 2;
+    this.programmaticScrollVersion = 0;
     this.scale = null;
     this.translateX = null;
     this.translateY = null;

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -260,7 +260,6 @@ class GestureViewerManager {
       return;
     }
 
-    this.programmaticScrollVersion += 1;
     this.cancelPendingLoopTransition();
 
     const { scrollTo } = createScrollAction(this.listRef, this.width);
@@ -273,6 +272,7 @@ class GestureViewerManager {
           this.loopCallback = null;
         };
 
+        this.programmaticScrollVersion += 1;
         scrollTo(0, true);
         return;
       }
@@ -284,10 +284,12 @@ class GestureViewerManager {
           this.loopCallback = null;
         };
 
+        this.programmaticScrollVersion += 1;
         scrollTo(this.dataLength + 1, true);
         return;
       }
 
+      this.programmaticScrollVersion += 1;
       scrollTo(index + 1, true);
       this.updateCurrentIndex(index);
 
@@ -298,6 +300,7 @@ class GestureViewerManager {
       return;
     }
 
+    this.programmaticScrollVersion += 1;
     scrollTo(index, true);
     this.updateCurrentIndex(index);
   };

--- a/src/__tests__/webScroll.test.ts
+++ b/src/__tests__/webScroll.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { getWebAutoPlayTargetPhysicalIndex, resolveWebScrollFinalState } from '../utils/webScroll';
+
+describe('web scroll settling', () => {
+  it('wraps from the first page to the last page when loop is enabled', () => {
+    expect(
+      resolveWebScrollFinalState({
+        dataLength: 5,
+        enableLoop: true,
+        lastSettledPhysicalIndex: 1,
+        offsetX: 0,
+        pageWidth: 100,
+      }),
+    ).toEqual({
+      logicalIndex: 4,
+      rawPhysicalIndex: 0,
+      settledPhysicalIndex: 5,
+    });
+  });
+
+  it('wraps from the last page to the first page when loop is enabled', () => {
+    expect(
+      resolveWebScrollFinalState({
+        dataLength: 5,
+        enableLoop: true,
+        lastSettledPhysicalIndex: 5,
+        offsetX: 600,
+        pageWidth: 100,
+      }),
+    ).toEqual({
+      logicalIndex: 0,
+      rawPhysicalIndex: 6,
+      settledPhysicalIndex: 1,
+    });
+  });
+
+  it('treats a FlashList-style jump from the first page to the loop tail as a wrap to the last page', () => {
+    expect(
+      resolveWebScrollFinalState({
+        dataLength: 5,
+        enableLoop: true,
+        lastSettledPhysicalIndex: 1,
+        offsetX: 500,
+        pageWidth: 100,
+      }),
+    ).toEqual({
+      logicalIndex: 4,
+      rawPhysicalIndex: 5,
+      settledPhysicalIndex: 5,
+    });
+  });
+
+  it('treats a FlashList-style jump from the last page to the loop head as a wrap to the first page', () => {
+    expect(
+      resolveWebScrollFinalState({
+        dataLength: 5,
+        enableLoop: true,
+        lastSettledPhysicalIndex: 5,
+        offsetX: 100,
+        pageWidth: 100,
+      }),
+    ).toEqual({
+      logicalIndex: 0,
+      rawPhysicalIndex: 1,
+      settledPhysicalIndex: 1,
+    });
+  });
+  it('does not settle on an intermediate raw page when the last observed raw page has already changed', () => {
+    const firstPass = resolveWebScrollFinalState({
+      dataLength: 5,
+      enableLoop: false,
+      lastSettledPhysicalIndex: 1,
+      offsetX: 200,
+      pageWidth: 100,
+    });
+
+    expect(firstPass).toEqual({
+      logicalIndex: 2,
+      rawPhysicalIndex: 2,
+      settledPhysicalIndex: 2,
+    });
+  });
+  it('keeps non-loop web paging aligned to the browser-settled logical page', () => {
+    expect(
+      resolveWebScrollFinalState({
+        dataLength: 5,
+        enableLoop: false,
+        lastSettledPhysicalIndex: 1,
+        offsetX: 400,
+        pageWidth: 100,
+      }),
+    ).toEqual({
+      logicalIndex: 4,
+      rawPhysicalIndex: 4,
+      settledPhysicalIndex: 4,
+    });
+  });
+
+  it('calculates the next autoplay target for looped web paging', () => {
+    expect(
+      getWebAutoPlayTargetPhysicalIndex({
+        currentIndex: 3,
+        dataLength: 5,
+        enableLoop: true,
+      }),
+    ).toBe(5);
+
+    expect(
+      getWebAutoPlayTargetPhysicalIndex({
+        currentIndex: 4,
+        dataLength: 5,
+        enableLoop: true,
+      }),
+    ).toBe(6);
+  });
+});

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  InteractionManager,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-  useWindowDimensions,
-} from 'react-native';
+import { InteractionManager, useWindowDimensions } from 'react-native';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import {
   Easing,
@@ -20,7 +15,9 @@ import { scheduleOnRN } from 'react-native-worklets';
 import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
 import type { GestureViewerProps, TriggerRect } from './types';
-import { createBoundsConstraint, createScrollAction, getLoopAdjustedIndex } from './utils';
+import { useGestureViewerPaging } from './useGestureViewerPaging';
+import { createBoundsConstraint, createScrollAction } from './utils';
+import { applyTapZoomAtPoint } from './utils/tapZoom';
 
 type UseGestureViewerProps<ItemT, LC> = Omit<
   GestureViewerProps<ItemT, LC>,
@@ -129,6 +126,35 @@ export const useGestureViewer = <ItemT, LC>({
       return scrollAction.scrollTo(index, animated);
     },
     [width, itemSpacing],
+  );
+
+  const resetTransformState = useCallback(() => {
+    translateX.value = withTiming(0);
+    translateY.value = withTiming(0);
+    initialTranslateX.value = withTiming(0);
+    initialTranslateY.value = withTiming(0);
+    startScale.value = withTiming(1);
+    scale.value = withTiming(1);
+    rotation.value = 0;
+  }, [initialTranslateX, initialTranslateY, rotation, scale, startScale, translateX, translateY]);
+
+  const syncCurrentIndex = useCallback(
+    (nextIndex: number) => {
+      if (!manager || nextIndex < 0 || nextIndex >= dataLength) {
+        return;
+      }
+
+      const currentIndex = manager.getState().currentIndex;
+
+      if (nextIndex === currentIndex) {
+        return;
+      }
+
+      manager.setCurrentIndex(nextIndex);
+      manager.notifyStateChange();
+      resetTransformState();
+    },
+    [dataLength, manager, resetTransformState],
   );
 
   const emitZoomChange = useCallback(
@@ -258,44 +284,6 @@ export const useGestureViewer = <ItemT, LC>({
   ]);
 
   useEffect(() => {
-    if (
-      !autoPlay ||
-      !manager ||
-      dataLength <= 1 ||
-      isZoomed ||
-      isRotated ||
-      (!enableLoop && currentIndex === dataLength - 1)
-    ) {
-      return;
-    }
-
-    const intervalMs = Math.max(250, Math.floor(autoPlayInterval || 0));
-
-    if (!Number.isFinite(intervalMs)) {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      if (isZoomed || isRotated) {
-        return;
-      }
-
-      manager.goToNext();
-    }, intervalMs);
-
-    return () => clearInterval(interval);
-  }, [
-    autoPlay,
-    autoPlayInterval,
-    manager,
-    dataLength,
-    currentIndex,
-    enableLoop,
-    isZoomed,
-    isRotated,
-  ]);
-
-  useEffect(() => {
     onAnimationCompleteRef.current = triggerAnimation?.onAnimationComplete;
   }, [triggerAnimation?.onAnimationComplete]);
 
@@ -393,66 +381,6 @@ export const useGestureViewer = <ItemT, LC>({
     triggerTranslateY,
     triggerOpacity,
   ]);
-
-  const onMomentumScrollEnd = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      if (!enableHorizontalSwipe) {
-        return;
-      }
-
-      const { contentOffset } = event.nativeEvent;
-      const scrollIndex = Math.round(contentOffset.x / (width + itemSpacing));
-
-      const isLoopHandled = manager?.handleMomentumScrollEnd(scrollIndex);
-
-      if (isLoopHandled) {
-        return;
-      }
-
-      const { realIndex, needsJump, jumpToIndex } = getLoopAdjustedIndex(
-        scrollIndex,
-        dataLength,
-        enableLoop,
-      );
-
-      if (needsJump && jumpToIndex !== undefined) {
-        scrollTo(jumpToIndex, false);
-      }
-
-      const currentIndex = manager?.getState()?.currentIndex;
-
-      if (realIndex !== currentIndex && realIndex >= 0 && realIndex < dataLength) {
-        if (manager) {
-          manager.setCurrentIndex(realIndex);
-          manager.notifyStateChange();
-        }
-
-        translateX.value = withTiming(0);
-        translateY.value = withTiming(0);
-        initialTranslateX.value = withTiming(0);
-        initialTranslateY.value = withTiming(0);
-        startScale.value = withTiming(1);
-        scale.value = withTiming(1);
-        rotation.value = 0;
-      }
-    },
-    [
-      scrollTo,
-      manager,
-      dataLength,
-      width,
-      itemSpacing,
-      enableHorizontalSwipe,
-      enableLoop,
-      translateX,
-      translateY,
-      scale,
-      initialTranslateX,
-      initialTranslateY,
-      startScale,
-      rotation,
-    ],
-  );
 
   const dismissGesture = useMemo(() => {
     const canDismiss = !isZoomed && dismissOptions.enabled;
@@ -647,38 +575,18 @@ export const useGestureViewer = <ItemT, LC>({
         .enabled(enableDoubleTapZoom)
         .numberOfTaps(2)
         .onEnd((event) => {
-          const nextScale = scale.value > 1 ? 1 : maxZoomScale;
-
-          if (nextScale > 1) {
-            const centerX = event.x - width / 2;
-            const centerY = event.y - height / 2;
-
-            // NOTE 확대로 밀려난 거리만큼 반대로 이동해서 탭 지점을 제자리에 유지
-            translateX.value = withTiming(-centerX * (nextScale - 1), {
-              duration: 300,
-              easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-            });
-            translateY.value = withTiming(-centerY * (nextScale - 1), {
-              duration: 300,
-              easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-            });
-          } else {
-            translateX.value = withTiming(0, {
-              duration: 300,
-              easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-            });
-            translateY.value = withTiming(0, {
-              duration: 300,
-              easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-            });
-          }
-
-          scale.value = withTiming(nextScale, {
-            duration: 300,
-            easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+          applyTapZoomAtPoint({
+            x: event.x,
+            y: event.y,
+            width,
+            height,
+            maxZoomScale,
+            scale,
+            translateX,
+            translateY,
           });
         }),
-    [scale, enableDoubleTapZoom, maxZoomScale, translateX, translateY, width, height],
+    [enableDoubleTapZoom, height, maxZoomScale, scale, translateX, translateY, width],
   );
 
   const zoomGesture = useMemo(
@@ -716,9 +624,29 @@ export const useGestureViewer = <ItemT, LC>({
     return Gesture.Native().requireExternalGestureToFail(dismissGestureRef);
   }, []);
 
-  const onScrollBeginDrag = useCallback(() => {
-    manager?.handleScrollBeginDrag();
-  }, [manager]);
+  const { onMomentumScrollEnd, onScroll, onScrollBeginDrag, onWebDoubleClick } =
+    useGestureViewerPaging({
+      adjustedInitialIndex,
+      autoPlay,
+      autoPlayInterval,
+      currentIndex,
+      dataLength,
+      enableDoubleTapZoom,
+      enableHorizontalSwipe,
+      enableLoop,
+      height,
+      isRotated,
+      isZoomed,
+      itemSpacing,
+      manager,
+      maxZoomScale,
+      scale,
+      scrollTo,
+      syncCurrentIndex,
+      translateX,
+      translateY,
+      width,
+    });
 
   return {
     animatedStyle,
@@ -732,7 +660,9 @@ export const useGestureViewer = <ItemT, LC>({
     isZoomed,
     listRef,
     nativeScrollGesture,
+    onWebDoubleClick,
     onMomentumScrollEnd,
+    onScroll,
 
     onScrollBeginDrag,
     zoomGesture,

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -144,9 +144,9 @@ export const useGestureViewer = <ItemT, LC>({
         return;
       }
 
-      const currentIndex = manager.getState().currentIndex;
+      const managerCurrentIndex = manager.getState().currentIndex;
 
-      if (nextIndex === currentIndex) {
+      if (nextIndex === managerCurrentIndex) {
         return;
       }
 

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -226,6 +226,7 @@ export const useGestureViewer = <ItemT, LC>({
     manager.setWidth(width + itemSpacing);
     manager.setHeight(height);
     manager.setZoomSharedValues(scale, translateX, translateY, maxZoomScale);
+    manager.setResetTransformCallback(resetTransformState);
     manager.setRotation(rotation);
     manager.setEnableLoop(enableLoop);
     manager.notifyStateChange();
@@ -240,6 +241,7 @@ export const useGestureViewer = <ItemT, LC>({
     enableLoop,
     scale,
     height,
+    resetTransformState,
     translateX,
     translateY,
     rotation,

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, useWindowDimensions } from 'react-native';
+import { InteractionManager, Platform, useWindowDimensions } from 'react-native';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import {
   Easing,
@@ -572,7 +572,7 @@ export const useGestureViewer = <ItemT, LC>({
   const doubleTapGesture = useMemo(
     () =>
       Gesture.Tap()
-        .enabled(enableDoubleTapZoom)
+        .enabled(enableDoubleTapZoom && Platform.OS !== 'web')
         .numberOfTaps(2)
         .onEnd((event) => {
           applyTapZoomAtPoint({

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect } from 'react';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+
+import type {
+  UseGestureViewerPagingArgs,
+  UseGestureViewerPagingResult,
+} from './useGestureViewerPaging.types';
+import { getLoopAdjustedIndex } from './utils';
+
+export function useGestureViewerPaging({
+  autoPlay,
+  autoPlayInterval,
+  currentIndex,
+  dataLength,
+  enableHorizontalSwipe,
+  enableLoop,
+  isRotated,
+  isZoomed,
+  itemSpacing,
+  manager,
+  scrollTo,
+  syncCurrentIndex,
+  width,
+}: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
+  useEffect(() => {
+    if (
+      !autoPlay ||
+      !manager ||
+      dataLength <= 1 ||
+      isZoomed ||
+      isRotated ||
+      (!enableLoop && currentIndex === dataLength - 1)
+    ) {
+      return;
+    }
+
+    const intervalMs = Math.max(250, Math.floor(autoPlayInterval || 0));
+
+    if (!Number.isFinite(intervalMs)) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (isZoomed || isRotated) {
+        return;
+      }
+
+      manager.goToNext();
+    }, intervalMs);
+
+    return () => clearInterval(interval);
+  }, [
+    autoPlay,
+    autoPlayInterval,
+    currentIndex,
+    dataLength,
+    enableLoop,
+    isRotated,
+    isZoomed,
+    manager,
+  ]);
+
+  const onMomentumScrollEnd = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (!enableHorizontalSwipe) {
+        return;
+      }
+
+      const { contentOffset } = event.nativeEvent;
+      const scrollIndex = Math.round(contentOffset.x / (width + itemSpacing));
+
+      const isLoopHandled = manager?.handleMomentumScrollEnd(scrollIndex);
+
+      if (isLoopHandled) {
+        return;
+      }
+
+      const { realIndex, needsJump, jumpToIndex } = getLoopAdjustedIndex(
+        scrollIndex,
+        dataLength,
+        enableLoop,
+      );
+
+      if (needsJump && jumpToIndex !== undefined) {
+        scrollTo(jumpToIndex, false);
+      }
+
+      syncCurrentIndex(realIndex);
+    },
+    [
+      dataLength,
+      enableHorizontalSwipe,
+      enableLoop,
+      itemSpacing,
+      manager,
+      scrollTo,
+      syncCurrentIndex,
+      width,
+    ],
+  );
+
+  const onScrollBeginDrag = useCallback(() => {
+    manager?.handleScrollBeginDrag();
+  }, [manager]);
+
+  return {
+    onMomentumScrollEnd,
+    onScroll: undefined,
+    onScrollBeginDrag,
+    onWebDoubleClick: undefined,
+  };
+}

--- a/src/useGestureViewerPaging.types.ts
+++ b/src/useGestureViewerPaging.types.ts
@@ -1,0 +1,34 @@
+import type { ScrollViewProps } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
+
+import type GestureViewerManager from './GestureViewerManager';
+
+export type UseGestureViewerPagingArgs = {
+  adjustedInitialIndex: number;
+  autoPlay: boolean;
+  autoPlayInterval: number;
+  currentIndex: number;
+  dataLength: number;
+  enableDoubleTapZoom: boolean;
+  enableHorizontalSwipe: boolean;
+  enableLoop: boolean;
+  height: number;
+  isRotated: boolean;
+  isZoomed: boolean;
+  itemSpacing: number;
+  manager: GestureViewerManager | null;
+  maxZoomScale: number;
+  scale: SharedValue<number>;
+  scrollTo: (index: number, animated: boolean) => void;
+  syncCurrentIndex: (nextIndex: number) => void;
+  translateX: SharedValue<number>;
+  translateY: SharedValue<number>;
+  width: number;
+};
+
+export type UseGestureViewerPagingResult = {
+  onMomentumScrollEnd?: ScrollViewProps['onMomentumScrollEnd'];
+  onScroll?: ScrollViewProps['onScroll'];
+  onScrollBeginDrag?: ScrollViewProps['onScrollBeginDrag'];
+  onWebDoubleClick?: (event: any) => void;
+};

--- a/src/useGestureViewerPaging.web.ts
+++ b/src/useGestureViewerPaging.web.ts
@@ -6,7 +6,11 @@ import type {
   UseGestureViewerPagingResult,
 } from './useGestureViewerPaging.types';
 import { applyTapZoomAtPoint } from './utils/tapZoom';
-import { getWebAutoPlayTargetPhysicalIndex, resolveWebScrollFinalState } from './utils/webScroll';
+import {
+  getWebAutoPlayTargetPhysicalIndex,
+  getWebScrollPhysicalIndex,
+  resolveWebScrollFinalState,
+} from './utils/webScroll';
 
 type WebScrollActor = 'idle' | 'user' | 'autoplay';
 
@@ -79,7 +83,15 @@ export function useGestureViewerPaging({
     runtime.resumeAutoplayTimer = setTimeout(() => {
       runtime.isAutoplayPausedByUser = false;
       runtime.resumeAutoplayTimer = null;
-    }, 1200);
+    }, 800);
+  }, [clearWebAutoplayResumeTimer]);
+
+  const pauseWebAutoplayWithoutPagingInteraction = useCallback(() => {
+    const runtime = webScrollRuntimeRef.current;
+
+    runtime.isAutoplayPausedByUser = true;
+    runtime.actor = 'idle';
+    clearWebAutoplayResumeTimer();
   }, [clearWebAutoplayResumeTimer]);
 
   const beginWebUserInteraction = useCallback(
@@ -121,7 +133,7 @@ export function useGestureViewerPaging({
   }, [clearWebAutoplayResumeTimer, manager]);
 
   const finalizeWebScroll = useCallback(
-    (offsetX: number) => {
+    (offsetX: number, source: 'scroll' | 'momentum' = 'scroll') => {
       if (!enableHorizontalSwipe || dataLength <= 0) {
         return;
       }
@@ -146,7 +158,7 @@ export function useGestureViewerPaging({
 
       const { logicalIndex, rawPhysicalIndex, settledPhysicalIndex } = settledState;
 
-      if (runtime.latestRawPhysicalIndex !== rawPhysicalIndex) {
+      if (source === 'scroll' && runtime.latestRawPhysicalIndex !== rawPhysicalIndex) {
         return;
       }
 
@@ -188,10 +200,10 @@ export function useGestureViewerPaging({
       const runtime = webScrollRuntimeRef.current;
 
       runtime.latestOffsetX = offsetX;
-      runtime.latestRawPhysicalIndex = Math.round(offsetX / (width + itemSpacing));
+      runtime.latestRawPhysicalIndex = getWebScrollPhysicalIndex(offsetX, width + itemSpacing);
       clearWebSettleTimer();
       runtime.settleTimer = setTimeout(() => {
-        finalizeWebScroll(runtime.latestOffsetX);
+        finalizeWebScroll(runtime.latestOffsetX, 'scroll');
       }, 180);
     },
     [clearWebSettleTimer, finalizeWebScroll, itemSpacing, width],
@@ -308,7 +320,7 @@ export function useGestureViewerPaging({
         return;
       }
 
-      finalizeWebScroll(event.nativeEvent.contentOffset.x);
+      finalizeWebScroll(event.nativeEvent.contentOffset.x, 'momentum');
     },
     [enableHorizontalSwipe, finalizeWebScroll],
   );
@@ -325,15 +337,29 @@ export function useGestureViewerPaging({
         return;
       }
 
-      beginWebUserInteraction(true);
+      pauseWebAutoplayWithoutPagingInteraction();
       scheduleWebAutoplayResume();
 
-      const locationX = event?.nativeEvent?.locationX ?? width / 2;
-      const locationY = event?.nativeEvent?.locationY ?? height / 2;
+      const nativeEvent = event?.nativeEvent;
+      const eventTarget = event?.currentTarget ?? nativeEvent?.currentTarget ?? nativeEvent?.target;
+      let locationX = nativeEvent?.locationX;
+      let locationY = nativeEvent?.locationY;
+
+      if (
+        (!Number.isFinite(locationX) || !Number.isFinite(locationY)) &&
+        typeof eventTarget?.getBoundingClientRect === 'function' &&
+        Number.isFinite(nativeEvent?.clientX) &&
+        Number.isFinite(nativeEvent?.clientY)
+      ) {
+        const rect = eventTarget.getBoundingClientRect();
+
+        locationX = nativeEvent.clientX - rect.left;
+        locationY = nativeEvent.clientY - rect.top;
+      }
 
       applyTapZoomAtPoint({
-        x: locationX,
-        y: locationY,
+        x: Number.isFinite(locationX) ? locationX : width / 2,
+        y: Number.isFinite(locationY) ? locationY : height / 2,
         width,
         height,
         maxZoomScale,
@@ -343,10 +369,10 @@ export function useGestureViewerPaging({
       });
     },
     [
-      beginWebUserInteraction,
       enableDoubleTapZoom,
       height,
       maxZoomScale,
+      pauseWebAutoplayWithoutPagingInteraction,
       scheduleWebAutoplayResume,
       scale,
       translateX,

--- a/src/useGestureViewerPaging.web.ts
+++ b/src/useGestureViewerPaging.web.ts
@@ -1,0 +1,364 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+
+import type {
+  UseGestureViewerPagingArgs,
+  UseGestureViewerPagingResult,
+} from './useGestureViewerPaging.types';
+import { applyTapZoomAtPoint } from './utils/tapZoom';
+import { getWebAutoPlayTargetPhysicalIndex, resolveWebScrollFinalState } from './utils/webScroll';
+
+type WebScrollActor = 'idle' | 'user' | 'autoplay';
+
+type WebScrollRuntime = {
+  actor: WebScrollActor;
+  isAutoplayPausedByUser: boolean;
+  lastSettledPhysicalIndex: number;
+  latestOffsetX: number;
+  latestRawPhysicalIndex: number;
+  lastProgrammaticScrollVersion: number;
+  settleTimer: ReturnType<typeof setTimeout> | null;
+  resumeAutoplayTimer: ReturnType<typeof setTimeout> | null;
+};
+
+export function useGestureViewerPaging({
+  adjustedInitialIndex,
+  autoPlay,
+  autoPlayInterval,
+  currentIndex,
+  dataLength,
+  enableDoubleTapZoom,
+  enableHorizontalSwipe,
+  enableLoop,
+  height,
+  isRotated,
+  isZoomed,
+  itemSpacing,
+  manager,
+  maxZoomScale,
+  scale,
+  scrollTo,
+  syncCurrentIndex,
+  translateX,
+  translateY,
+  width,
+}: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
+  const webScrollRuntimeRef = useRef<WebScrollRuntime>({
+    actor: 'idle',
+    isAutoplayPausedByUser: false,
+    lastSettledPhysicalIndex: adjustedInitialIndex,
+    latestOffsetX: adjustedInitialIndex * (width + itemSpacing),
+    latestRawPhysicalIndex: adjustedInitialIndex,
+    lastProgrammaticScrollVersion: 0,
+    settleTimer: null,
+    resumeAutoplayTimer: null,
+  });
+
+  const clearWebSettleTimer = useCallback(() => {
+    const runtime = webScrollRuntimeRef.current;
+
+    if (runtime.settleTimer) {
+      clearTimeout(runtime.settleTimer);
+      runtime.settleTimer = null;
+    }
+  }, []);
+
+  const clearWebAutoplayResumeTimer = useCallback(() => {
+    const runtime = webScrollRuntimeRef.current;
+
+    if (runtime.resumeAutoplayTimer) {
+      clearTimeout(runtime.resumeAutoplayTimer);
+      runtime.resumeAutoplayTimer = null;
+    }
+  }, []);
+
+  const scheduleWebAutoplayResume = useCallback(() => {
+    const runtime = webScrollRuntimeRef.current;
+
+    clearWebAutoplayResumeTimer();
+    runtime.resumeAutoplayTimer = setTimeout(() => {
+      runtime.isAutoplayPausedByUser = false;
+      runtime.resumeAutoplayTimer = null;
+    }, 1200);
+  }, [clearWebAutoplayResumeTimer]);
+
+  const beginWebUserInteraction = useCallback(
+    (force = false) => {
+      const runtime = webScrollRuntimeRef.current;
+
+      if (!force && runtime.actor === 'autoplay') {
+        return;
+      }
+
+      runtime.actor = 'user';
+      runtime.isAutoplayPausedByUser = true;
+      clearWebAutoplayResumeTimer();
+    },
+    [clearWebAutoplayResumeTimer],
+  );
+
+  const beginWebAutoplayScroll = useCallback(() => {
+    const runtime = webScrollRuntimeRef.current;
+
+    runtime.actor = 'autoplay';
+    runtime.isAutoplayPausedByUser = false;
+    runtime.lastProgrammaticScrollVersion = manager?.getProgrammaticScrollVersion() ?? 0;
+    clearWebAutoplayResumeTimer();
+  }, [clearWebAutoplayResumeTimer, manager]);
+
+  const syncProgrammaticActorFromManager = useCallback(() => {
+    const runtime = webScrollRuntimeRef.current;
+    const nextVersion = manager?.getProgrammaticScrollVersion() ?? 0;
+
+    if (nextVersion === runtime.lastProgrammaticScrollVersion) {
+      return;
+    }
+
+    runtime.actor = 'autoplay';
+    runtime.isAutoplayPausedByUser = false;
+    runtime.lastProgrammaticScrollVersion = nextVersion;
+    clearWebAutoplayResumeTimer();
+  }, [clearWebAutoplayResumeTimer, manager]);
+
+  const finalizeWebScroll = useCallback(
+    (offsetX: number) => {
+      if (!enableHorizontalSwipe || dataLength <= 0) {
+        return;
+      }
+
+      const runtime = webScrollRuntimeRef.current;
+      const settledByActor = runtime.actor;
+
+      clearWebSettleTimer();
+      runtime.latestOffsetX = offsetX;
+
+      const settledState = resolveWebScrollFinalState({
+        dataLength,
+        enableLoop,
+        lastSettledPhysicalIndex: runtime.lastSettledPhysicalIndex,
+        offsetX,
+        pageWidth: width + itemSpacing,
+      });
+
+      if (!settledState) {
+        return;
+      }
+
+      const { logicalIndex, rawPhysicalIndex, settledPhysicalIndex } = settledState;
+
+      if (runtime.latestRawPhysicalIndex !== rawPhysicalIndex) {
+        return;
+      }
+
+      if (rawPhysicalIndex !== settledPhysicalIndex) {
+        const crossedLoopBoundary =
+          enableLoop &&
+          dataLength > 1 &&
+          (rawPhysicalIndex === 0 || rawPhysicalIndex === dataLength + 1);
+
+        scrollTo(settledPhysicalIndex, !crossedLoopBoundary);
+      }
+
+      runtime.lastSettledPhysicalIndex = settledPhysicalIndex;
+      runtime.latestOffsetX = settledPhysicalIndex * (width + itemSpacing);
+      runtime.actor = 'idle';
+      manager?.cancelPendingLoopTransition();
+      syncCurrentIndex(logicalIndex);
+
+      if (settledByActor === 'user') {
+        scheduleWebAutoplayResume();
+      }
+    },
+    [
+      clearWebSettleTimer,
+      dataLength,
+      enableHorizontalSwipe,
+      enableLoop,
+      itemSpacing,
+      manager,
+      scheduleWebAutoplayResume,
+      scrollTo,
+      syncCurrentIndex,
+      width,
+    ],
+  );
+
+  const scheduleWebScrollSettle = useCallback(
+    (offsetX: number) => {
+      const runtime = webScrollRuntimeRef.current;
+
+      runtime.latestOffsetX = offsetX;
+      runtime.latestRawPhysicalIndex = Math.round(offsetX / (width + itemSpacing));
+      clearWebSettleTimer();
+      runtime.settleTimer = setTimeout(() => {
+        finalizeWebScroll(runtime.latestOffsetX);
+      }, 180);
+    },
+    [clearWebSettleTimer, finalizeWebScroll, itemSpacing, width],
+  );
+
+  useEffect(() => {
+    const runtime = webScrollRuntimeRef.current;
+
+    runtime.actor = 'idle';
+    runtime.isAutoplayPausedByUser = false;
+    runtime.lastSettledPhysicalIndex = adjustedInitialIndex;
+    runtime.latestOffsetX = adjustedInitialIndex * (width + itemSpacing);
+    runtime.latestRawPhysicalIndex = adjustedInitialIndex;
+    runtime.lastProgrammaticScrollVersion = manager?.getProgrammaticScrollVersion() ?? 0;
+    clearWebSettleTimer();
+    clearWebAutoplayResumeTimer();
+  }, [
+    adjustedInitialIndex,
+    clearWebAutoplayResumeTimer,
+    clearWebSettleTimer,
+    itemSpacing,
+    manager,
+    width,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      clearWebSettleTimer();
+      clearWebAutoplayResumeTimer();
+    };
+  }, [clearWebAutoplayResumeTimer, clearWebSettleTimer]);
+
+  useEffect(() => {
+    if (
+      !autoPlay ||
+      dataLength <= 1 ||
+      isZoomed ||
+      isRotated ||
+      (!enableLoop && currentIndex === dataLength - 1)
+    ) {
+      return;
+    }
+
+    const intervalMs = Math.max(250, Math.floor(autoPlayInterval || 0));
+
+    if (!Number.isFinite(intervalMs)) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (isZoomed || isRotated) {
+        return;
+      }
+
+      const runtime = webScrollRuntimeRef.current;
+
+      if (runtime.actor !== 'idle' || runtime.isAutoplayPausedByUser || runtime.settleTimer) {
+        return;
+      }
+
+      const targetPhysicalIndex = getWebAutoPlayTargetPhysicalIndex({
+        currentIndex,
+        dataLength,
+        enableLoop,
+      });
+
+      if (targetPhysicalIndex === null) {
+        return;
+      }
+
+      beginWebAutoplayScroll();
+      runtime.latestOffsetX = targetPhysicalIndex * (width + itemSpacing);
+      scrollTo(targetPhysicalIndex, true);
+      scheduleWebScrollSettle(runtime.latestOffsetX);
+    }, intervalMs);
+
+    return () => clearInterval(interval);
+  }, [
+    autoPlay,
+    autoPlayInterval,
+    beginWebAutoplayScroll,
+    currentIndex,
+    dataLength,
+    enableLoop,
+    isRotated,
+    isZoomed,
+    itemSpacing,
+    scheduleWebScrollSettle,
+    scrollTo,
+    width,
+  ]);
+
+  const onScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (!enableHorizontalSwipe) {
+        return;
+      }
+
+      syncProgrammaticActorFromManager();
+      beginWebUserInteraction();
+      scheduleWebScrollSettle(event.nativeEvent.contentOffset.x);
+    },
+    [
+      beginWebUserInteraction,
+      enableHorizontalSwipe,
+      scheduleWebScrollSettle,
+      syncProgrammaticActorFromManager,
+    ],
+  );
+
+  const onMomentumScrollEnd = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (!enableHorizontalSwipe) {
+        return;
+      }
+
+      finalizeWebScroll(event.nativeEvent.contentOffset.x);
+    },
+    [enableHorizontalSwipe, finalizeWebScroll],
+  );
+
+  const onScrollBeginDrag = useCallback(() => {
+    beginWebUserInteraction(true);
+    clearWebSettleTimer();
+    manager?.handleScrollBeginDrag();
+  }, [beginWebUserInteraction, clearWebSettleTimer, manager]);
+
+  const onWebDoubleClick = useCallback(
+    (event: any) => {
+      if (!enableDoubleTapZoom || event?.nativeEvent?.detail !== 2) {
+        return;
+      }
+
+      beginWebUserInteraction(true);
+      scheduleWebAutoplayResume();
+
+      const locationX = event?.nativeEvent?.locationX ?? width / 2;
+      const locationY = event?.nativeEvent?.locationY ?? height / 2;
+
+      applyTapZoomAtPoint({
+        x: locationX,
+        y: locationY,
+        width,
+        height,
+        maxZoomScale,
+        scale,
+        translateX,
+        translateY,
+      });
+    },
+    [
+      beginWebUserInteraction,
+      enableDoubleTapZoom,
+      height,
+      maxZoomScale,
+      scheduleWebAutoplayResume,
+      scale,
+      translateX,
+      translateY,
+      width,
+    ],
+  );
+
+  return {
+    onMomentumScrollEnd,
+    onScroll,
+    onScrollBeginDrag,
+    onWebDoubleClick,
+  };
+}

--- a/src/utils/tapZoom.ts
+++ b/src/utils/tapZoom.ts
@@ -1,0 +1,44 @@
+import type { SharedValue } from 'react-native-reanimated';
+import { Easing, withTiming } from 'react-native-reanimated';
+
+export const applyTapZoomAtPoint = ({
+  x,
+  y,
+  width,
+  height,
+  maxZoomScale,
+  scale,
+  translateX,
+  translateY,
+}: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  maxZoomScale: number;
+  scale: SharedValue<number>;
+  translateX: SharedValue<number>;
+  translateY: SharedValue<number>;
+}) => {
+  'worklet';
+
+  const nextScale = scale.value > 1 ? 1 : maxZoomScale;
+  const timingConfig = {
+    duration: 300,
+    easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+  };
+
+  if (nextScale > 1) {
+    const centerX = x - width / 2;
+    const centerY = y - height / 2;
+
+    // NOTE 확대로 밀려난 거리만큼 반대로 이동해서 탭 지점을 제자리에 유지
+    translateX.value = withTiming(-centerX * (nextScale - 1), timingConfig);
+    translateY.value = withTiming(-centerY * (nextScale - 1), timingConfig);
+  } else {
+    translateX.value = withTiming(0, timingConfig);
+    translateY.value = withTiming(0, timingConfig);
+  }
+
+  scale.value = withTiming(nextScale, timingConfig);
+};

--- a/src/utils/webScroll.ts
+++ b/src/utils/webScroll.ts
@@ -19,7 +19,7 @@ export const resolveWebScrollFinalState = ({
   dataLength: number;
   enableLoop: boolean;
 }): { logicalIndex: number; rawPhysicalIndex: number; settledPhysicalIndex: number } | null => {
-  if (dataLength <= 0) {
+  if (dataLength <= 0 || !Number.isFinite(pageWidth) || pageWidth <= 0) {
     return null;
   }
 

--- a/src/utils/webScroll.ts
+++ b/src/utils/webScroll.ts
@@ -19,7 +19,12 @@ export const resolveWebScrollFinalState = ({
   dataLength: number;
   enableLoop: boolean;
 }): { logicalIndex: number; rawPhysicalIndex: number; settledPhysicalIndex: number } | null => {
-  if (dataLength <= 0 || !Number.isFinite(pageWidth) || pageWidth <= 0) {
+  if (
+    dataLength <= 0 ||
+    !Number.isFinite(offsetX) ||
+    !Number.isFinite(pageWidth) ||
+    pageWidth <= 0
+  ) {
     return null;
   }
 
@@ -38,7 +43,7 @@ export const resolveWebScrollFinalState = ({
       };
     }
 
-    if (isWrappingForward || rawPhysicalIndex === dataLength + 1) {
+    if (isWrappingForward || rawPhysicalIndex >= dataLength + 1) {
       return {
         logicalIndex: 0,
         rawPhysicalIndex,

--- a/src/utils/webScroll.ts
+++ b/src/utils/webScroll.ts
@@ -1,0 +1,91 @@
+export const getWebScrollPhysicalIndex = (offsetX: number, pageWidth: number): number => {
+  if (!Number.isFinite(offsetX) || !Number.isFinite(pageWidth) || pageWidth <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, Math.round(offsetX / pageWidth));
+};
+
+export const resolveWebScrollFinalState = ({
+  dataLength,
+  enableLoop,
+  lastSettledPhysicalIndex,
+  offsetX,
+  pageWidth,
+}: {
+  offsetX: number;
+  pageWidth: number;
+  lastSettledPhysicalIndex: number;
+  dataLength: number;
+  enableLoop: boolean;
+}): { logicalIndex: number; rawPhysicalIndex: number; settledPhysicalIndex: number } | null => {
+  if (dataLength <= 0) {
+    return null;
+  }
+
+  const maxPhysicalIndex = enableLoop && dataLength > 1 ? dataLength + 1 : dataLength - 1;
+  const rawPhysicalIndex = getWebScrollPhysicalIndex(offsetX, pageWidth);
+
+  if (enableLoop && dataLength > 1) {
+    const isWrappingBackward = lastSettledPhysicalIndex === 1 && rawPhysicalIndex >= dataLength;
+    const isWrappingForward = lastSettledPhysicalIndex === dataLength && rawPhysicalIndex <= 1;
+
+    if (isWrappingBackward || rawPhysicalIndex === 0) {
+      return {
+        logicalIndex: dataLength - 1,
+        rawPhysicalIndex,
+        settledPhysicalIndex: dataLength,
+      };
+    }
+
+    if (isWrappingForward || rawPhysicalIndex === dataLength + 1) {
+      return {
+        logicalIndex: 0,
+        rawPhysicalIndex,
+        settledPhysicalIndex: 1,
+      };
+    }
+  }
+
+  const targetPhysicalIndex = Math.max(0, Math.min(maxPhysicalIndex, rawPhysicalIndex));
+
+  if (enableLoop && dataLength > 1) {
+    return {
+      logicalIndex: targetPhysicalIndex - 1,
+      rawPhysicalIndex,
+      settledPhysicalIndex: targetPhysicalIndex,
+    };
+  }
+
+  return {
+    logicalIndex: targetPhysicalIndex,
+    rawPhysicalIndex,
+    settledPhysicalIndex: targetPhysicalIndex,
+  };
+};
+
+export const getWebAutoPlayTargetPhysicalIndex = ({
+  currentIndex,
+  dataLength,
+  enableLoop,
+}: {
+  currentIndex: number;
+  dataLength: number;
+  enableLoop: boolean;
+}): number | null => {
+  if (dataLength <= 1) {
+    return null;
+  }
+
+  if (enableLoop && currentIndex === dataLength - 1) {
+    return dataLength + 1;
+  }
+
+  const nextIndex = currentIndex + 1;
+
+  if (nextIndex >= dataLength) {
+    return null;
+  }
+
+  return enableLoop ? nextIndex + 1 : nextIndex;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized autoplay paging and kept programmatic navigation aligned with the visible page.
  * Improved web paging so the displayed page reliably matches the browser’s final scroll position.
  * Restored double-click zoom on web; autoplay now pauses/resumes correctly on user interaction.

* **New Features**
  * Tap-to-zoom anchors to the tapped point for smoother, predictable zooming.

* **Tests**
  * Added tests covering web scroll settling and autoplay target behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->