### PR TITLE
fix: support bidirectional (up & down) swipe-to-dismiss

### DIFF
--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -475,7 +475,7 @@ export const useGestureViewer = <ItemT, LC>({
         translateY.value = event.translationY / dismissOptions.resistance;
       })
       .onEnd((event) => {
-        if (canDismiss && event.translationY > dismissOptions.threshold) {
+        if (canDismiss && Math.abs(event.translationY) > dismissOptions.threshold) {
           scheduleOnRN(handleDismiss);
           return;
         }
@@ -693,7 +693,7 @@ export const useGestureViewer = <ItemT, LC>({
       return { opacity: baseOpacity };
     }
 
-    const dismissOpacity = interpolate(translateY.value, [0, 200], [1, 0], 'clamp');
+    const dismissOpacity = interpolate(Math.abs(translateY.value), [0, 200], [1, 0], 'clamp');
 
     return { opacity: baseOpacity * dismissOpacity };
   }, [dismissOptions.fadeBackdrop]);


### PR DESCRIPTION
## Problem

Currently the dismiss gesture only triggers when swiping **down** (`translationY > threshold`). Swiping up does nothing, which feels unnatural — most image viewers (Instagram, Telegram, etc.) dismiss on both directions.

## Fix

Two minimal changes in `useGestureViewer.ts`:

1. Use `Math.abs(event.translationY)` in the dismiss condition so both up and down swipes trigger dismiss.
2. Use `Math.abs(translateY.value)` in the backdrop opacity interpolation so the background fades correctly when swiping upward.

## Changes

- `onEnd`: `event.translationY > threshold` → `Math.abs(event.translationY) > threshold`  
- `backdropStyle`: `interpolate(translateY.value, ...)` → `interpolate(Math.abs(translateY.value), ...)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gesture viewer dismissal now recognizes vertical drags in both upward and downward directions, improving reliability of swipe-to-dismiss interactions.
  * Backdrop fade animation updated to respond symmetrically to upward and downward drags, ensuring consistent visual feedback while dragging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->