### PR TITLE
fix: preserve pinch zoom focal midpoint

### DIFF
--- a/.changeset/swift-suits-flash.md
+++ b/.changeset/swift-suits-flash.md
@@ -1,0 +1,10 @@
+---
+"react-native-gesture-image-viewer": patch
+---
+
+Fix pinch zoom drift near image edges for fullscreen contained images.
+
+Pinch zoom now tracks the two-finger midpoint during scaling instead of feeling anchored to one finger or biased toward
+the viewer center.
+
+Fixes https://github.com/saseungmin/react-native-gesture-image-viewer/issues/164

--- a/.changeset/swift-suits-flash.md
+++ b/.changeset/swift-suits-flash.md
@@ -1,5 +1,5 @@
 ---
-"react-native-gesture-image-viewer": patch
+'react-native-gesture-image-viewer': patch
 ---
 
 Fix pinch zoom drift near image edges for fullscreen contained images.

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -266,7 +266,6 @@ const styles = StyleSheet.create({
     gap: 8,
     justifyContent: 'center',
     alignItems: 'center',
-    maxWidth: 360,
   },
   thumb: {
     width: 110,

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -15,6 +15,7 @@ import {
 } from 'react-native-gesture-handler';
 
 import { shouldUseNativeScrollGesture } from '../utils';
+import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from '../utils/zoom';
 
 function PlainScrollView() {
   return null;
@@ -38,5 +39,150 @@ describe('shouldUseNativeScrollGesture', () => {
   it('does not double-apply the workaround to RNGH scrollables', () => {
     expect(shouldUseNativeScrollGesture('ios', GestureScrollView)).toBe(false);
     expect(shouldUseNativeScrollGesture('ios', GestureFlatList)).toBe(false);
+  });
+});
+
+describe('calculateFocalPointTranslation', () => {
+  it('keeps translation unchanged when zooming around the viewer center', () => {
+    expect(
+      calculateFocalPointTranslation({
+        currentFocalX: 200,
+        currentFocalY: 400,
+        height: 800,
+        initialScale: 1,
+        initialTranslateX: 0,
+        initialTranslateY: 0,
+        nextScale: 2,
+        startFocalX: 200,
+        startFocalY: 400,
+        width: 400,
+      }),
+    ).toEqual({ translateX: 0, translateY: 0 });
+  });
+
+  it('anchors horizontal edge focal points during zoom', () => {
+    expect(
+      calculateFocalPointTranslation({
+        currentFocalX: 50,
+        currentFocalY: 400,
+        height: 800,
+        initialScale: 1,
+        initialTranslateX: 0,
+        initialTranslateY: 0,
+        nextScale: 2,
+        startFocalX: 50,
+        startFocalY: 400,
+        width: 400,
+      }).translateX,
+    ).toBe(150);
+
+    expect(
+      calculateFocalPointTranslation({
+        currentFocalX: 350,
+        currentFocalY: 400,
+        height: 800,
+        initialScale: 1,
+        initialTranslateX: 0,
+        initialTranslateY: 0,
+        nextScale: 2,
+        startFocalX: 350,
+        startFocalY: 400,
+        width: 400,
+      }).translateX,
+    ).toBe(-150);
+  });
+
+  it('anchors vertical edge focal points during zoom', () => {
+    expect(
+      calculateFocalPointTranslation({
+        currentFocalX: 200,
+        currentFocalY: 100,
+        height: 800,
+        initialScale: 1,
+        initialTranslateX: 0,
+        initialTranslateY: 0,
+        nextScale: 2,
+        startFocalX: 200,
+        startFocalY: 100,
+        width: 400,
+      }).translateY,
+    ).toBe(300);
+
+    expect(
+      calculateFocalPointTranslation({
+        currentFocalX: 200,
+        currentFocalY: 700,
+        height: 800,
+        initialScale: 1,
+        initialTranslateX: 0,
+        initialTranslateY: 0,
+        nextScale: 2,
+        startFocalX: 200,
+        startFocalY: 700,
+        width: 400,
+      }).translateY,
+    ).toBe(-300);
+  });
+
+  it('scales previous translation from an existing zoom state', () => {
+    expect(
+      calculateFocalPointTranslation({
+        currentFocalX: 350,
+        currentFocalY: 700,
+        height: 800,
+        initialScale: 2,
+        initialTranslateX: 20,
+        initialTranslateY: -40,
+        nextScale: 3,
+        startFocalX: 350,
+        startFocalY: 700,
+        width: 400,
+      }),
+    ).toEqual({ translateX: -45, translateY: -210 });
+  });
+
+  it('follows movement of the two-finger midpoint while scaling', () => {
+    expect(
+      calculateFocalPointTranslation({
+        currentFocalX: 230,
+        currentFocalY: 430,
+        height: 800,
+        initialScale: 1,
+        initialTranslateX: 0,
+        initialTranslateY: 0,
+        nextScale: 2,
+        startFocalX: 200,
+        startFocalY: 400,
+        width: 400,
+      }),
+    ).toEqual({ translateX: 30, translateY: 30 });
+  });
+});
+
+describe('shouldAcceptFocalPoint', () => {
+  it('always accepts the first active focal point sample', () => {
+    expect(
+      shouldAcceptFocalPoint({
+        focalX: 350,
+        focalY: 700,
+        hasActiveFocal: false,
+        lastFocalX: 0,
+        lastFocalY: 0,
+        threshold: 50,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps rejecting large focal jumps after active focal initialization', () => {
+    expect(
+      shouldAcceptFocalPoint({
+        focalX: 350,
+        focalY: 700,
+        hasActiveFocal: true,
+        lastFocalX: 0,
+        lastFocalY: 0,
+        threshold: 50,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -540,7 +540,7 @@ export const useGestureViewer = <ItemT, LC>({
           startFocalY.set(event.focalY);
           lastFocalX.set(event.focalX);
           lastFocalY.set(event.focalY);
-          hasActiveFocal.set(true);
+          hasActiveFocal.set(false);
         })
         .onUpdate((event) => {
           const initialScale = startScale.get();

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -19,6 +19,7 @@ import { useGestureViewerPaging } from './useGestureViewerPaging';
 import { createBoundsConstraint, createScrollAction } from './utils';
 import { getDismissDistance, shouldDismissByDirection } from './utils/dismiss';
 import { applyTapZoomAtPoint } from './utils/tapZoom';
+import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from './utils/zoom';
 
 type UseGestureViewerProps<ItemT, LC> = Omit<
   GestureViewerProps<ItemT, LC>,
@@ -95,6 +96,9 @@ export const useGestureViewer = <ItemT, LC>({
 
   const lastFocalX = useSharedValue(0);
   const lastFocalY = useSharedValue(0);
+  const startFocalX = useSharedValue(0);
+  const startFocalY = useSharedValue(0);
+  const hasActiveFocal = useSharedValue(false);
 
   const dataLength = data?.length || 0;
 
@@ -528,12 +532,15 @@ export const useGestureViewer = <ItemT, LC>({
             scheduleOnRN(setIsPinching, true);
           }
         })
-        .onBegin((event) => {
+        .onStart((event) => {
           startScale.set(scale.get());
           initialTranslateX.set(translateX.get());
           initialTranslateY.set(translateY.get());
+          startFocalX.set(event.focalX);
+          startFocalY.set(event.focalY);
           lastFocalX.set(event.focalX);
           lastFocalY.set(event.focalY);
+          hasActiveFocal.set(true);
         })
         .onUpdate((event) => {
           const initialScale = startScale.get();
@@ -547,26 +554,44 @@ export const useGestureViewer = <ItemT, LC>({
             return;
           }
 
-          const currentLastFocalX = lastFocalX.get();
-          const currentLastFocalY = lastFocalY.get();
-          const focalDeltaX = Math.abs(event.focalX - currentLastFocalX);
-          const focalDeltaY = Math.abs(event.focalY - currentLastFocalY);
           const threshold = 50;
 
-          if (focalDeltaX < threshold && focalDeltaY < threshold) {
+          if (
+            shouldAcceptFocalPoint({
+              focalX: event.focalX,
+              focalY: event.focalY,
+              hasActiveFocal: hasActiveFocal.get(),
+              lastFocalX: lastFocalX.get(),
+              lastFocalY: lastFocalY.get(),
+              threshold,
+            })
+          ) {
+            if (!hasActiveFocal.get()) {
+              startFocalX.set(event.focalX);
+              startFocalY.set(event.focalY);
+            }
+
             lastFocalX.set(event.focalX);
             lastFocalY.set(event.focalY);
+            hasActiveFocal.set(true);
           }
 
           const nextLastFocalX = lastFocalX.get();
           const nextLastFocalY = lastFocalY.get();
-          const deltaScale = newScale - initialScale;
-          const centerX = nextLastFocalX - width / 2;
-          const centerY = nextLastFocalY - height / 2;
 
-          // NOTE 새로운 이동값 = 기존 이동값 - (중심점 거리 × 스케일 변화량) / 원래 스케일 (중심점이 화면 중심에서 멀수록, 확대 배율이 클수록 더 많이 이동)
-          const newTranslateX = initialTranslateX.get() - (centerX * deltaScale) / initialScale;
-          const newTranslateY = initialTranslateY.get() - (centerY * deltaScale) / initialScale;
+          const { translateX: newTranslateX, translateY: newTranslateY } =
+            calculateFocalPointTranslation({
+              currentFocalX: nextLastFocalX,
+              currentFocalY: nextLastFocalY,
+              height,
+              initialScale,
+              initialTranslateX: initialTranslateX.get(),
+              initialTranslateY: initialTranslateY.get(),
+              nextScale: newScale,
+              startFocalX: startFocalX.get(),
+              startFocalY: startFocalY.get(),
+              width,
+            });
 
           const { translateX: constrainedTranslateX, translateY: constrainedTranslateY } =
             constrainTranslation({
@@ -613,6 +638,7 @@ export const useGestureViewer = <ItemT, LC>({
             translateY.set(withTiming(0));
             initialTranslateX.set(withTiming(0));
             initialTranslateY.set(withTiming(0));
+            hasActiveFocal.set(false);
             return;
           }
 
@@ -630,6 +656,7 @@ export const useGestureViewer = <ItemT, LC>({
           scheduleOnRN(setIsPinching, false);
         })
         .onFinalize(() => {
+          hasActiveFocal.set(false);
           scheduleOnRN(setIsPinching, false);
         }),
     [
@@ -646,6 +673,9 @@ export const useGestureViewer = <ItemT, LC>({
       constrainTranslation,
       lastFocalX,
       lastFocalY,
+      startFocalX,
+      startFocalY,
+      hasActiveFocal,
     ],
   );
 

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -1,0 +1,60 @@
+export const calculateFocalPointTranslation = ({
+  currentFocalX,
+  currentFocalY,
+  height,
+  initialScale,
+  initialTranslateX,
+  initialTranslateY,
+  nextScale,
+  startFocalX,
+  startFocalY,
+  width,
+}: {
+  currentFocalX: number;
+  currentFocalY: number;
+  height: number;
+  initialScale: number;
+  initialTranslateX: number;
+  initialTranslateY: number;
+  nextScale: number;
+  startFocalX: number;
+  startFocalY: number;
+  width: number;
+}) => {
+  'worklet';
+
+  const scaleRatio = nextScale / initialScale;
+  const currentCenterX = currentFocalX - width / 2;
+  const currentCenterY = currentFocalY - height / 2;
+  const startCenterX = startFocalX - width / 2;
+  const startCenterY = startFocalY - height / 2;
+
+  return {
+    translateX: initialTranslateX * scaleRatio + currentCenterX - startCenterX * scaleRatio,
+    translateY: initialTranslateY * scaleRatio + currentCenterY - startCenterY * scaleRatio,
+  };
+};
+
+export const shouldAcceptFocalPoint = ({
+  focalX,
+  focalY,
+  hasActiveFocal,
+  lastFocalX,
+  lastFocalY,
+  threshold,
+}: {
+  focalX: number;
+  focalY: number;
+  hasActiveFocal: boolean;
+  lastFocalX: number;
+  lastFocalY: number;
+  threshold: number;
+}) => {
+  'worklet';
+
+  if (!hasActiveFocal) {
+    return true;
+  }
+
+  return Math.abs(focalX - lastFocalX) < threshold && Math.abs(focalY - lastFocalY) < threshold;
+};


### PR DESCRIPTION
Fixes https://github.com/saseungmin/react-native-gesture-image-viewer/issues/164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pinch-zoom drift near image edges for fullscreen contained images. Zoom now follows the user’s fingers more accurately, improving precision and stability during scaling.

* **Improvements**
  * Updated the gallery example layout to better vertically align wrapped thumbnail rows for a cleaner appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saseungmin/react-native-gesture-image-viewer/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->