### PR TITLE
fix: avoid deprecated InteractionManager during initial scroll

### DIFF
--- a/.changeset/fresh-idle-scroll.md
+++ b/.changeset/fresh-idle-scroll.md
@@ -4,5 +4,7 @@
 
 Replace deprecated InteractionManager initial scroll scheduling with a cancellable idle scheduler.
 
-The viewer now uses requestIdleCallback when available and falls back to a cancellable timer so
-initialIndex still works on hosts without idle callback support.
+The viewer now uses React Native's
+[requestIdleCallback](https://reactnative.dev/docs/global-requestIdleCallback) when available and
+falls back to a cancellable timer so initialIndex still works on hosts without idle callback
+support.

--- a/.changeset/fresh-idle-scroll.md
+++ b/.changeset/fresh-idle-scroll.md
@@ -1,0 +1,8 @@
+---
+'react-native-gesture-image-viewer': patch
+---
+
+Replace deprecated InteractionManager initial scroll scheduling with a cancellable idle scheduler.
+
+The viewer now uses requestIdleCallback when available and falls back to a cancellable timer so
+initialIndex still works on hosts without idle callback support.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,10 @@
+const testPlugins = process.env.NODE_ENV === 'test' ? ['react-native-worklets/plugin'] : [];
+
 module.exports = {
   overrides: [
     {
       exclude: /\/node_modules\//,
+      plugins: testPlugins,
       presets: ['module:react-native-builder-bob/babel-preset'],
     },
     {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,0 +1,1 @@
+require('react-native-reanimated').setUpTests();

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/jest-preset": "0.85.3",
     "@react-native/metro-config": "0.85.3",
+    "@testing-library/react-native": "^14.0.1",
     "@types/babel__core": "^7.20.5",
     "@types/jest": "^29.5.14",
     "@types/react": "^19.2.15",
@@ -119,6 +120,7 @@
     "react-native-gesture-handler": "^2.31.2",
     "react-native-reanimated": "4.3.1",
     "react-native-worklets": "0.8.3",
+    "test-renderer": "^1.2.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
@@ -138,7 +140,17 @@
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
     ],
-    "preset": "@react-native/jest-preset"
+    "preset": "@react-native/jest-preset",
+    "resolver": "react-native-worklets/jest/resolver",
+    "setupFiles": [
+      "react-native-gesture-handler/jestSetup.js"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest-setup.js"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|react-native-reanimated|react-native-worklets|react-native-gesture-handler|@testing-library/react-native|test-renderer)/)"
+    ]
   },
   "packageManager": "yarn@4.17.0",
   "create-react-native-library": {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,0 @@
-it.todo('write a test');

--- a/src/__tests__/scheduleInitialScroll.test.ts
+++ b/src/__tests__/scheduleInitialScroll.test.ts
@@ -3,8 +3,12 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { INITIAL_SCROLL_IDLE_TIMEOUT_MS, scheduleInitialScroll } from '../scheduleInitialScroll';
 
 type IdleTestGlobal = typeof globalThis & {
-  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
-  cancelIdleCallback?: (handle: number) => void;
+  requestIdleCallback?: (
+    this: IdleTestGlobal,
+    callback: () => void,
+    options?: { timeout?: number },
+  ) => number;
+  cancelIdleCallback?: (this: IdleTestGlobal, handle: number) => void;
 };
 
 const idleGlobal = globalThis as IdleTestGlobal;
@@ -53,6 +57,30 @@ describe('scheduleInitialScroll', () => {
     cleanup();
 
     expect(cancelIdleCallback).toHaveBeenCalledWith(7);
+  });
+
+  it('binds idle callbacks to the scheduler global', () => {
+    const callback = jest.fn();
+    const requestIdleCallback = jest.fn(function (
+      this: IdleTestGlobal,
+      scheduledCallback: () => void,
+    ) {
+      expect(this).toBe(idleGlobal);
+      scheduledCallback();
+      return 7;
+    });
+    const cancelIdleCallback = jest.fn(function (this: IdleTestGlobal) {
+      expect(this).toBe(idleGlobal);
+    });
+
+    idleGlobal.requestIdleCallback = requestIdleCallback;
+    idleGlobal.cancelIdleCallback = cancelIdleCallback;
+
+    const cleanup = scheduleInitialScroll(callback);
+    cleanup();
+
+    expect(requestIdleCallback.mock.contexts[0]).toBe(idleGlobal);
+    expect(cancelIdleCallback.mock.contexts[0]).toBe(idleGlobal);
   });
 
   it('falls back to timeout scheduling when idle cancellation is unavailable', () => {

--- a/src/__tests__/scheduleInitialScroll.test.ts
+++ b/src/__tests__/scheduleInitialScroll.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { INITIAL_SCROLL_IDLE_TIMEOUT_MS, scheduleInitialScroll } from '../scheduleInitialScroll';
+
+type IdleTestGlobal = typeof globalThis & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+const idleGlobal = globalThis as IdleTestGlobal;
+const originalRequestIdleCallback = idleGlobal.requestIdleCallback;
+const originalCancelIdleCallback = idleGlobal.cancelIdleCallback;
+
+const restoreIdleCallbacks = () => {
+  if (originalRequestIdleCallback) {
+    idleGlobal.requestIdleCallback = originalRequestIdleCallback;
+  } else {
+    delete idleGlobal.requestIdleCallback;
+  }
+
+  if (originalCancelIdleCallback) {
+    idleGlobal.cancelIdleCallback = originalCancelIdleCallback;
+  } else {
+    delete idleGlobal.cancelIdleCallback;
+  }
+};
+
+describe('scheduleInitialScroll', () => {
+  afterEach(() => {
+    restoreIdleCallbacks();
+    jest.useRealTimers();
+  });
+
+  it('uses requestIdleCallback when scheduling and cancellation are available', () => {
+    const callback = jest.fn();
+    const requestIdleCallback = jest.fn((scheduledCallback: () => void) => {
+      scheduledCallback();
+      return 7;
+    });
+    const cancelIdleCallback = jest.fn();
+
+    idleGlobal.requestIdleCallback = requestIdleCallback;
+    idleGlobal.cancelIdleCallback = cancelIdleCallback;
+
+    const cleanup = scheduleInitialScroll(callback);
+
+    expect(requestIdleCallback).toHaveBeenCalledWith(callback, {
+      timeout: INITIAL_SCROLL_IDLE_TIMEOUT_MS,
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(cancelIdleCallback).not.toHaveBeenCalled();
+
+    cleanup();
+
+    expect(cancelIdleCallback).toHaveBeenCalledWith(7);
+  });
+
+  it('falls back to timeout scheduling when idle cancellation is unavailable', () => {
+    jest.useFakeTimers();
+
+    const callback = jest.fn();
+    const requestIdleCallback = jest.fn(() => 7);
+
+    idleGlobal.requestIdleCallback = requestIdleCallback;
+    delete idleGlobal.cancelIdleCallback;
+
+    const cleanup = scheduleInitialScroll(callback);
+
+    expect(requestIdleCallback).not.toHaveBeenCalled();
+
+    cleanup();
+    jest.runOnlyPendingTimers();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('falls back to timeout scheduling when requestIdleCallback is unavailable', () => {
+    jest.useFakeTimers();
+
+    const callback = jest.fn();
+    const cancelIdleCallback = jest.fn();
+
+    delete idleGlobal.requestIdleCallback;
+    idleGlobal.cancelIdleCallback = cancelIdleCallback;
+
+    scheduleInitialScroll(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(cancelIdleCallback).not.toHaveBeenCalled();
+
+    jest.runOnlyPendingTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to timeout scheduling when both idle callbacks are unavailable', () => {
+    jest.useFakeTimers();
+
+    const callback = jest.fn();
+
+    delete idleGlobal.requestIdleCallback;
+    delete idleGlobal.cancelIdleCallback;
+
+    scheduleInitialScroll(callback);
+
+    jest.runOnlyPendingTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/useGestureViewerInitialScroll.test.tsx
+++ b/src/__tests__/useGestureViewerInitialScroll.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react-native';
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { Text, View } from 'react-native';
+
+import { GestureViewer } from '../GestureViewer';
+import { INITIAL_SCROLL_IDLE_TIMEOUT_MS } from '../scheduleInitialScroll';
+
+type IdleTestGlobal = typeof globalThis & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+type TestListHandle = {
+  scrollToIndex: (params: { animated: boolean; index: number }) => void;
+};
+
+type TestListProps = {
+  data?: readonly string[];
+  renderItem?: (info: { item: string; index: number }) => React.ReactElement | null;
+};
+
+const idleGlobal = globalThis as IdleTestGlobal;
+const originalRequestIdleCallback = idleGlobal.requestIdleCallback;
+const originalCancelIdleCallback = idleGlobal.cancelIdleCallback;
+const scrollToIndex = jest.fn<TestListHandle['scrollToIndex']>();
+
+const TestFlashList = forwardRef<TestListHandle, TestListProps>(function TestFlashList(
+  { data, renderItem },
+  ref,
+) {
+  useImperativeHandle(ref, () => ({ scrollToIndex }), []);
+
+  return (
+    <View>
+      {data?.map((item, index) => (
+        <View key={item}>{renderItem?.({ item, index })}</View>
+      ))}
+    </View>
+  );
+});
+
+TestFlashList.displayName = 'FlashList';
+
+const restoreIdleCallbacks = () => {
+  if (originalRequestIdleCallback) {
+    idleGlobal.requestIdleCallback = originalRequestIdleCallback;
+  } else {
+    delete idleGlobal.requestIdleCallback;
+  }
+
+  if (originalCancelIdleCallback) {
+    idleGlobal.cancelIdleCallback = originalCancelIdleCallback;
+  } else {
+    delete idleGlobal.cancelIdleCallback;
+  }
+};
+
+describe('useGestureViewer initial scroll scheduling', () => {
+  beforeEach(() => {
+    scrollToIndex.mockClear();
+  });
+
+  afterEach(() => {
+    restoreIdleCallbacks();
+  });
+
+  it('schedules one non-animated initial scroll after rendering the viewer list', async () => {
+    idleGlobal.requestIdleCallback = jest.fn((callback: () => void) => {
+      callback();
+      return 10;
+    });
+    idleGlobal.cancelIdleCallback = jest.fn();
+
+    await render(
+      <GestureViewer
+        data={['first', 'second', 'third']}
+        height={480}
+        initialIndex={2}
+        ListComponent={TestFlashList}
+        renderItem={(item) => <Text>{item}</Text>}
+        width={320}
+      />,
+    );
+
+    expect(screen.getByText('third')).toBeOnTheScreen();
+    expect(idleGlobal.requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: INITIAL_SCROLL_IDLE_TIMEOUT_MS,
+    });
+    expect(scrollToIndex).toHaveBeenCalledTimes(1);
+    expect(scrollToIndex).toHaveBeenCalledWith({
+      animated: false,
+      index: 2,
+    });
+  });
+});

--- a/src/scheduleInitialScroll.ts
+++ b/src/scheduleInitialScroll.ts
@@ -1,0 +1,34 @@
+export const INITIAL_SCROLL_IDLE_TIMEOUT_MS = 100;
+
+type IdleCallbackOptions = {
+  timeout?: number;
+};
+
+type RequestIdleCallback = (callback: () => void, options?: IdleCallbackOptions) => number;
+type CancelIdleCallback = (handle: number) => void;
+
+type IdleSchedulerGlobal = typeof globalThis & {
+  requestIdleCallback?: RequestIdleCallback;
+  cancelIdleCallback?: CancelIdleCallback;
+};
+
+export const scheduleInitialScroll = (callback: () => void): (() => void) => {
+  const idleGlobal = globalThis as IdleSchedulerGlobal;
+  const { cancelIdleCallback, requestIdleCallback } = idleGlobal;
+
+  if (requestIdleCallback && cancelIdleCallback) {
+    const idleCallbackId = requestIdleCallback(callback, {
+      timeout: INITIAL_SCROLL_IDLE_TIMEOUT_MS,
+    });
+
+    return () => {
+      cancelIdleCallback(idleCallbackId);
+    };
+  }
+
+  const timeoutId = setTimeout(callback, 0);
+
+  return () => {
+    clearTimeout(timeoutId);
+  };
+};

--- a/src/scheduleInitialScroll.ts
+++ b/src/scheduleInitialScroll.ts
@@ -4,17 +4,19 @@ type IdleCallbackOptions = {
   timeout?: number;
 };
 
-type RequestIdleCallback = (callback: () => void, options?: IdleCallbackOptions) => number;
-type CancelIdleCallback = (handle: number) => void;
-
 type IdleSchedulerGlobal = typeof globalThis & {
-  requestIdleCallback?: RequestIdleCallback;
-  cancelIdleCallback?: CancelIdleCallback;
+  requestIdleCallback?: (
+    this: IdleSchedulerGlobal,
+    callback: () => void,
+    options?: IdleCallbackOptions,
+  ) => number;
+  cancelIdleCallback?: (this: IdleSchedulerGlobal, handle: number) => void;
 };
 
 export const scheduleInitialScroll = (callback: () => void): (() => void) => {
   const idleGlobal = globalThis as IdleSchedulerGlobal;
-  const { cancelIdleCallback, requestIdleCallback } = idleGlobal;
+  const requestIdleCallback = idleGlobal.requestIdleCallback?.bind(idleGlobal);
+  const cancelIdleCallback = idleGlobal.cancelIdleCallback?.bind(idleGlobal);
 
   if (requestIdleCallback && cancelIdleCallback) {
     const idleCallbackId = requestIdleCallback(callback, {

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, Platform, type View, useWindowDimensions } from 'react-native';
+import { Platform, type View, useWindowDimensions } from 'react-native';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import {
   Easing,
@@ -14,6 +14,7 @@ import { scheduleOnRN } from 'react-native-worklets';
 
 import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
+import { scheduleInitialScroll } from './scheduleInitialScroll';
 import type { GestureViewerProps, TriggerRect } from './types';
 import { useGestureViewerPaging } from './useGestureViewerPaging';
 import { createBoundsConstraint, createScrollAction } from './utils';
@@ -301,13 +302,9 @@ export const useGestureViewer = <ItemT, LC>({
       return;
     }
 
-    const runAfterInteractions = InteractionManager.runAfterInteractions(() => {
+    return scheduleInitialScroll(() => {
       scrollTo(adjustedInitialIndex, false);
     });
-
-    return () => {
-      runAfterInteractions?.cancel();
-    };
   }, [
     adjustedInitialIndex,
     translateY,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,6 +2699,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/diff-sequences@npm:30.4.0":
+  version: 30.4.0
+  resolution: "@jest/diff-sequences@npm:30.4.0"
+  checksum: 10/65c27937c10a7157899dad5d176806104286f9d55464f318955a0cee98db8aed6b8f70ad4aee7133468087146422cdd391d49b1e101ec543db3283ee4eb59c06
+  languageName: node
+  linkType: hard
+
 "@jest/environment@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/environment@npm:29.7.0"
@@ -2741,6 +2748,13 @@ __metadata:
     jest-mock: "npm:^29.7.0"
     jest-util: "npm:^29.7.0"
   checksum: 10/9b394e04ffc46f91725ecfdff34c4e043eb7a16e1d78964094c9db3fde0b1c8803e45943a980e8c740d0a3d45661906de1416ca5891a538b0660481a3a828c27
+  languageName: node
+  linkType: hard
+
+"@jest/get-type@npm:30.1.0":
+  version: 30.1.0
+  resolution: "@jest/get-type@npm:30.1.0"
+  checksum: 10/e2a95fbb49ce2d15547db8af5602626caf9b05f62a5e583b4a2de9bd93a2bfe7175f9bbb2b8a5c3909ce261d467b6991d7265bb1d547cb60e7e97f571f361a70
   languageName: node
   linkType: hard
 
@@ -2790,6 +2804,15 @@ __metadata:
     node-notifier:
       optional: true
   checksum: 10/a17d1644b26dea14445cedd45567f4ba7834f980be2ef74447204e14238f121b50d8b858fde648083d2cd8f305f81ba434ba49e37a5f4237a6f2a61180cc73dc
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/schemas@npm:30.4.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10/86e62c8fd8fc77535085f1ede3a416430a3740f78b8f88ec7d0ee4516b22daf3326ffc1ade9d5f7839bbde923aaf1b5ac430a42ed4bb1a38edc3de5005a58f51
   languageName: node
   linkType: hard
 
@@ -4007,6 +4030,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinclair/typebox@npm:^0.34.0":
+  version: 0.34.49
+  resolution: "@sinclair/typebox@npm:0.34.49"
+  checksum: 10/5eb77de66c9deff83d43aa1f667832e2468f4dbd0ba91b80684f741a2e1e4120ffedb779be1578ae5b848250c3fbeffc032dc726947c5e42f3393903c1358cb9
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/merge-streams@npm:^2.1.0":
   version: 2.3.0
   resolution: "@sindresorhus/merge-streams@npm:2.3.0"
@@ -4038,6 +4068,26 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10/899c9761e827d5bf504bd02067596cfe59ad6c7d6b6f0691a2fb05acf3e6c2954ddece7e15d4a6a81e8d95c81500652e6abec326c6c9bbb50bc3e2141696de43
+  languageName: node
+  linkType: hard
+
+"@testing-library/react-native@npm:^14.0.1":
+  version: 14.0.1
+  resolution: "@testing-library/react-native@npm:14.0.1"
+  dependencies:
+    jest-matcher-utils: "npm:^30.4.1"
+    picocolors: "npm:^1.1.1"
+    pretty-format: "npm:^30.4.1"
+    redent: "npm:^3.0.0"
+  peerDependencies:
+    jest: ">=29.0.0"
+    react: ">=19.0.0"
+    react-native: ">=0.78"
+    test-renderer: ^1.0.0
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: 10/6f65b9566cce6f9737c3fff8beb0b6e7b623f3e440f286b0d652e2a8ae58eec854ec455ac297f6c736a3f7c289869c5f9fe07eddf4286f95751934a4fd27c3ee
   languageName: node
   linkType: hard
 
@@ -4212,6 +4262,15 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 10/1f916a06fff02faadb09a16ed6e31820ce170798b202ef0b14fc244bfbd721938c54a3a99836e185e4414ca461fe96c5bb5c67c3d248f153555b7e6347f061dd
+  languageName: node
+  linkType: hard
+
+"@types/react-reconciler@npm:~0.33.0":
+  version: 0.33.0
+  resolution: "@types/react-reconciler@npm:0.33.0"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/b65408e08f9e9924a6040fb7a4820ed12efdad598dccb9e08efc70a7101199cce4a5aa1f8695a82d8efe7b503bd9b8dc5122db8a23bac39f9bc473d595873ba4
   languageName: node
   linkType: hard
 
@@ -4430,7 +4489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.0.0":
+"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: 10/d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
@@ -7069,6 +7128,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"indent-string@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "indent-string@npm:4.0.0"
+  checksum: 10/cd3f5cbc9ca2d624c6a1f53f12e6b341659aba0e2d3254ae2b4464aaea8b4294cdb09616abbc59458f980531f2429784ed6a420d48d245bcad0811980c9efae9
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -7538,6 +7604,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-diff@npm:30.4.1"
+  dependencies:
+    "@jest/diff-sequences": "npm:30.4.0"
+    "@jest/get-type": "npm:30.1.0"
+    chalk: "npm:^4.1.2"
+    pretty-format: "npm:30.4.1"
+  checksum: 10/594212df96bf101170afdb7eebd188d6d7d27241cbdd18b61d95f1142a3c94ae3b270377d15e719fb3c5efe4458d32acba8ad13dd6230dd7d6917a9eebb32625
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
@@ -7635,6 +7713,18 @@ __metadata:
     jest-get-type: "npm:^29.6.3"
     pretty-format: "npm:^29.7.0"
   checksum: 10/981904a494299cf1e3baed352f8a3bd8b50a8c13a662c509b6a53c31461f94ea3bfeffa9d5efcfeb248e384e318c87de7e3baa6af0f79674e987482aa189af40
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^30.4.1":
+  version: 30.4.1
+  resolution: "jest-matcher-utils@npm:30.4.1"
+  dependencies:
+    "@jest/get-type": "npm:30.1.0"
+    chalk: "npm:^4.1.2"
+    jest-diff: "npm:30.4.1"
+    pretty-format: "npm:30.4.1"
+  checksum: 10/4da6e5c7fe5903fae7394233ea4b892567fb027065670c03096d01be0b389f858055c5ade20d59e82fedec6f3287e6f1720de526cd9a9ad3495432320adb9194
   languageName: node
   linkType: hard
 
@@ -9338,6 +9428,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10/bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.2.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
@@ -10250,6 +10347,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:30.4.1, pretty-format@npm:^30.4.1":
+  version: 30.4.1
+  resolution: "pretty-format@npm:30.4.1"
+  dependencies:
+    "@jest/schemas": "npm:30.4.1"
+    ansi-styles: "npm:^5.2.0"
+    react-is-18: "npm:react-is@^18.3.1"
+    react-is-19: "npm:react-is@^19.2.5"
+  checksum: 10/60311ef47a646eeaec0432efe66290cb6f0d2eccb123a28ad4ab6d7e53087bc62db91cfd54c3cc00c89d6875aefb2bf6264381b6c9411ce6bff3d6aa8280abad
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -10413,17 +10522,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is-18@npm:react-is@^18.3.1, react-is@npm:^18.0.0":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+  languageName: node
+  linkType: hard
+
+"react-is-19@npm:react-is@^19.2.5":
+  version: 19.2.7
+  resolution: "react-is@npm:19.2.7"
+  checksum: 10/ae0d3ae7638aa2fa2a82a78a817daf2806e57fa0aef357d07e1e8d1e9a301902e5967168e9334b5816db0df8fa980a725cd57569ba5a9e6e76a71e117b18be04
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10/5aa564a1cde7d391ac980bedee21202fc90bdea3b399952117f54fb71a932af1e5902020144fb354b4690b2414a0c7aafe798eb617b76a3d441d956db7726fdf
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^18.0.0":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
   languageName: node
   linkType: hard
 
@@ -10522,6 +10638,7 @@ __metadata:
     "@react-native/babel-preset": "npm:0.85.3"
     "@react-native/jest-preset": "npm:0.85.3"
     "@react-native/metro-config": "npm:0.85.3"
+    "@testing-library/react-native": "npm:^14.0.1"
     "@types/babel__core": "npm:^7.20.5"
     "@types/jest": "npm:^29.5.14"
     "@types/react": "npm:^19.2.15"
@@ -10536,6 +10653,7 @@ __metadata:
     react-native-gesture-handler: "npm:^2.31.2"
     react-native-reanimated: "npm:4.3.1"
     react-native-worklets: "npm:0.8.3"
+    test-renderer: "npm:^1.2.0"
     typescript: "npm:^5.9.3"
   peerDependencies:
     react: ">=18.0.0"
@@ -10684,7 +10802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-reconciler@npm:0.33.0":
+"react-reconciler@npm:0.33.0, react-reconciler@npm:~0.33.0":
   version: 0.33.0
   resolution: "react-reconciler@npm:0.33.0"
   dependencies:
@@ -10821,6 +10939,16 @@ __metadata:
     unified: "npm:^11.0.0"
     vfile: "npm:^6.0.0"
   checksum: 10/4ab6f0416296fd6b1a6180e74e19ec110b3fa6f0b3a434468e84092e8c36db99a3a77bd6412cf7a4c8d69b1701ab38aed7d0fd466588802ca295765892d2d361
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10/fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
   languageName: node
   linkType: hard
 
@@ -11641,6 +11769,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10/18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -11777,6 +11914,18 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10/8fccb2cb6c8fcb6bb4115394feb833f8b6cf4b9503ec2485c2c90febf435cac62abe882a0c5c51a37b9bbe70640cdd05acf5f45e486ac4583389f4b0855f69e5
+  languageName: node
+  linkType: hard
+
+"test-renderer@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "test-renderer@npm:1.2.0"
+  dependencies:
+    "@types/react-reconciler": "npm:~0.33.0"
+    react-reconciler: "npm:~0.33.0"
+  peerDependencies:
+    react: ^19.0.0
+  checksum: 10/65be16c35ce1e0e2cef6b6f28043de96954077c303016fad98feee5d8fafd81ca62c215d566780e99b0f80064c40a92364122fbc96ec672e647f3f40fc365830
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
React Native now warns that [InteractionManager](https://reactnative.dev/docs/interactionmanager) is deprecated.
Initial non-animated scroll now uses a cancellable idle scheduler.

If the idle pair is unavailable, a cancellable timer preserves initialIndex behavior on older hosts.

Tests cover scheduler branches and the rendered GestureViewer path with RNTL/RNGH/Reanimated setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initial image scrolling now waits for the app to be idle when possible, helping the viewer open more smoothly.

* **Bug Fixes**
  * Improved reliability of the viewer’s starting position across platforms, including cases without idle-callback support.
  * Preserved correct opening behavior when jumping to a non-default image.

* **Tests**
  * Added coverage for initial-scroll scheduling and viewer startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->