### PR TITLE
refactor: isolate gesture viewer paging ownership

### DIFF
--- a/.changeset/clean-gesture-viewer-paging.md
+++ b/.changeset/clean-gesture-viewer-paging.md
@@ -1,0 +1,7 @@
+---
+'react-native-gesture-image-viewer': patch
+---
+
+Refactor the gesture viewer's internal paging responsibilities into focused hooks without changing the public API.
+
+Paging shared values, transition commands, horizontal gestures, and manager bridge effects now have dedicated ownership. This keeps `useGestureViewer` focused on navigation policy and reduces the risk of inconsistent paging state during future changes.

--- a/src/__tests__/gestureViewerPaging.test.ts
+++ b/src/__tests__/gestureViewerPaging.test.ts
@@ -1,0 +1,130 @@
+import {
+  applyHorizontalEdgeResistance,
+  canMoveHorizontalPage,
+  resolveHorizontalPagingTarget,
+  resolveHorizontalSwipeDirection,
+} from '../gestureViewerPaging';
+
+describe('horizontal paging swipe direction', () => {
+  const width = 400;
+  const thresholdRatio = 0.25;
+  const velocityThreshold = 800;
+
+  it('resolves left swipes only beyond the translation or velocity thresholds', () => {
+    expect(resolveHorizontalSwipeDirection(-101, 0, width, thresholdRatio, velocityThreshold)).toBe(
+      1,
+    );
+    expect(resolveHorizontalSwipeDirection(-100, 0, width, thresholdRatio, velocityThreshold)).toBe(
+      0,
+    );
+    expect(resolveHorizontalSwipeDirection(0, -801, width, thresholdRatio, velocityThreshold)).toBe(
+      1,
+    );
+    expect(resolveHorizontalSwipeDirection(0, -800, width, thresholdRatio, velocityThreshold)).toBe(
+      0,
+    );
+  });
+
+  it('resolves right swipes only beyond the translation or velocity thresholds', () => {
+    expect(resolveHorizontalSwipeDirection(101, 0, width, thresholdRatio, velocityThreshold)).toBe(
+      -1,
+    );
+    expect(resolveHorizontalSwipeDirection(100, 0, width, thresholdRatio, velocityThreshold)).toBe(
+      0,
+    );
+    expect(resolveHorizontalSwipeDirection(0, 801, width, thresholdRatio, velocityThreshold)).toBe(
+      -1,
+    );
+    expect(resolveHorizontalSwipeDirection(0, 800, width, thresholdRatio, velocityThreshold)).toBe(
+      0,
+    );
+  });
+
+  it('returns no direction when no threshold passes', () => {
+    expect(resolveHorizontalSwipeDirection(24, 200, width, thresholdRatio, velocityThreshold)).toBe(
+      0,
+    );
+  });
+});
+
+describe('horizontal paging edge resistance', () => {
+  const resistance = 0.35;
+
+  it('dampens movement before the first non-loop item', () => {
+    expect(applyHorizontalEdgeResistance(4, 0, 4, 5, false, resistance)).toBeCloseTo(4.65);
+  });
+
+  it('dampens movement after the last non-loop item', () => {
+    expect(applyHorizontalEdgeResistance(6, 3, 4, 5, false, resistance)).toBeCloseTo(5.35);
+  });
+
+  it('keeps the raw page in loop mode', () => {
+    expect(applyHorizontalEdgeResistance(4, 0, 4, 5, true, resistance)).toBe(4);
+    expect(applyHorizontalEdgeResistance(6, 3, 4, 5, true, resistance)).toBe(6);
+  });
+
+  it('stays centered for single-item data', () => {
+    expect(applyHorizontalEdgeResistance(4, 0, 1, 5, false, resistance)).toBe(5);
+    expect(applyHorizontalEdgeResistance(6, 0, 1, 5, true, resistance)).toBe(5);
+  });
+});
+
+describe('horizontal paging movement permission', () => {
+  it('permits ordinary adjacent non-loop movement', () => {
+    expect(canMoveHorizontalPage(1, 4, 1, false)).toBe(true);
+    expect(canMoveHorizontalPage(2, 4, -1, false)).toBe(true);
+  });
+
+  it('rejects blocked non-loop edge movement', () => {
+    expect(canMoveHorizontalPage(0, 4, -1, false)).toBe(false);
+    expect(canMoveHorizontalPage(3, 4, 1, false)).toBe(false);
+  });
+
+  it('permits loop edge movement when more than one item exists', () => {
+    expect(canMoveHorizontalPage(0, 4, -1, true)).toBe(true);
+    expect(canMoveHorizontalPage(3, 4, 1, true)).toBe(true);
+  });
+
+  it('rejects no-op and single-item movement', () => {
+    expect(canMoveHorizontalPage(1, 4, 0, true)).toBe(false);
+    expect(canMoveHorizontalPage(0, 1, 1, true)).toBe(false);
+    expect(canMoveHorizontalPage(0, 1, -1, false)).toBe(false);
+  });
+});
+
+describe('horizontal paging target resolution', () => {
+  it('settles to center when no direction is chosen', () => {
+    expect(resolveHorizontalPagingTarget(5, 1, 4, 0, false)).toEqual({ kind: 'settle' });
+  });
+
+  it('returns the adjacent target virtual index when movement is allowed', () => {
+    expect(resolveHorizontalPagingTarget(5, 1, 4, 1, false)).toEqual({
+      kind: 'move',
+      targetVirtualIndex: 6,
+    });
+    expect(resolveHorizontalPagingTarget(5, 1, 4, -1, false)).toEqual({
+      kind: 'move',
+      targetVirtualIndex: 4,
+    });
+  });
+
+  it('settles when movement is blocked', () => {
+    expect(resolveHorizontalPagingTarget(5, 0, 4, -1, false)).toEqual({ kind: 'settle' });
+    expect(resolveHorizontalPagingTarget(5, 3, 4, 1, false)).toEqual({ kind: 'settle' });
+  });
+
+  it('settles for single-item data', () => {
+    expect(resolveHorizontalPagingTarget(5, 0, 1, 1, true)).toEqual({ kind: 'settle' });
+  });
+
+  it('returns loop targets at logical edges', () => {
+    expect(resolveHorizontalPagingTarget(5, 0, 4, -1, true)).toEqual({
+      kind: 'move',
+      targetVirtualIndex: 4,
+    });
+    expect(resolveHorizontalPagingTarget(5, 3, 4, 1, true)).toEqual({
+      kind: 'move',
+      targetVirtualIndex: 6,
+    });
+  });
+});

--- a/src/__tests__/renderWindow.test.ts
+++ b/src/__tests__/renderWindow.test.ts
@@ -1,3 +1,4 @@
+import { resolveGestureViewerRenderWindow } from '../gestureViewerRenderWindow';
 import {
   clampIndex,
   createRenderWindow,
@@ -148,6 +149,77 @@ describe('render window slot mapping', () => {
     expect(getVirtualIndexForLogicalIndex(0, 3, 4, true)).toBe(4);
     expect(getVirtualIndexForLogicalIndex(3, 0, 4, true)).toBe(-1);
     expect(getVirtualIndexForLogicalIndex(2, 0, 4, false)).toBe(2);
+  });
+});
+
+describe('gesture viewer render window resolution', () => {
+  const data = ['a', 'b', 'c', 'd'];
+
+  it('resolves adjacent slots around the current center in non-loop mode', () => {
+    const state = resolveGestureViewerRenderWindow({
+      centerVirtualIndex: 2,
+      currentIndex: 2,
+      data,
+      enableLoop: false,
+      isTriggerOpening: false,
+      windowSize: 3,
+    });
+
+    expect(state.currentIndex).toBe(2);
+    expect(state.centerVirtualIndex).toBe(2);
+    expect(state.slots.map((slot) => slot.logicalIndex)).toEqual([1, 2, 3]);
+    expect(state.slots.map((slot) => slot.virtualIndex)).toEqual([1, 2, 3]);
+  });
+
+  it('clamps out-of-range current indexes before creating slots', () => {
+    const state = resolveGestureViewerRenderWindow({
+      centerVirtualIndex: 1,
+      currentIndex: 99,
+      data,
+      enableLoop: false,
+      isTriggerOpening: false,
+      windowSize: 3,
+    });
+
+    expect(state.currentIndex).toBe(3);
+    expect(state.centerVirtualIndex).toBe(3);
+    expect(state.slots.map((slot) => slot.logicalIndex)).toEqual([2, 3]);
+  });
+
+  it('keeps only the center slot while trigger opening animation is active', () => {
+    const state = resolveGestureViewerRenderWindow({
+      centerVirtualIndex: 2,
+      currentIndex: 2,
+      data,
+      enableLoop: false,
+      isTriggerOpening: true,
+      windowSize: 5,
+    });
+
+    expect(state.slots).toEqual([
+      {
+        item: 'c',
+        logicalIndex: 2,
+        slotKey: 'slot-2',
+        virtualIndex: 2,
+      },
+    ]);
+  });
+
+  it('uses the nearest loop virtual center before creating wrapped slots', () => {
+    const state = resolveGestureViewerRenderWindow({
+      centerVirtualIndex: 4,
+      currentIndex: 0,
+      data: ['a', 'b', 'c'],
+      enableLoop: true,
+      isTriggerOpening: false,
+      windowSize: 3,
+    });
+
+    expect(state.currentIndex).toBe(0);
+    expect(state.centerVirtualIndex).toBe(3);
+    expect(state.slots.map((slot) => slot.logicalIndex)).toEqual([2, 0, 1]);
+    expect(state.slots.map((slot) => slot.virtualIndex)).toEqual([2, 3, 4]);
   });
 });
 

--- a/src/__tests__/useGestureViewerPaging.test.ts
+++ b/src/__tests__/useGestureViewerPaging.test.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { PAGE_TRANSITION_CONFIG } from '../gestureViewerAnimation';
+import { useGestureViewerPaging } from '../useGestureViewerPaging';
+
+const createPagingOptions = ({
+  clearPendingWebSingleTap = jest.fn(),
+  commitVirtualIndexOnly = jest.fn(),
+}: {
+  clearPendingWebSingleTap?: jest.Mock;
+  commitVirtualIndexOnly?: jest.Mock;
+} = {}) => ({
+  centerVirtualIndex: 0,
+  clearPendingWebSingleTap,
+  commitVirtualIndexOnly,
+  currentIndex: 0,
+  dataLength: 4,
+  enableHorizontalSwipe: true,
+  enableLoop: false,
+  initialPage: 0,
+  isPinching: false,
+  isRotated: false,
+  isTriggerOpening: false,
+  isZoomed: false,
+  pageStride: 320,
+  width: 320,
+});
+
+describe('useGestureViewerPaging commands', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('snaps to a virtual page and clears transition state immediately', async () => {
+    const clearPendingWebSingleTap = jest.fn();
+    const commitVirtualIndexOnly = jest.fn();
+    const { result } = await renderHook(() =>
+      useGestureViewerPaging(
+        createPagingOptions({
+          clearPendingWebSingleTap,
+          commitVirtualIndexOnly,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      result.current.snapToVirtualPage(2);
+    });
+
+    expect(result.current.visualPage.get()).toBe(2);
+    expect(commitVirtualIndexOnly).toHaveBeenCalledWith(2);
+    expect(result.current.isPageTransitioningRef.current).toBe(false);
+    expect(result.current.pageTransitionLocked.get()).toBe(false);
+    expect(clearPendingWebSingleTap).toHaveBeenCalledTimes(1);
+  });
+
+  it('animates to a virtual page and clears transition state on finish', async () => {
+    jest.useFakeTimers();
+
+    const commitVirtualIndexOnly = jest.fn();
+    const { result } = await renderHook(() =>
+      useGestureViewerPaging(
+        createPagingOptions({
+          commitVirtualIndexOnly,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      result.current.animateToVirtualPage(3);
+    });
+
+    expect(result.current.isPageTransitioningRef.current).toBe(true);
+    expect(result.current.pageTransitionLocked.get()).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(PAGE_TRANSITION_CONFIG.duration);
+    });
+
+    expect(result.current.visualPage.get()).toBe(3);
+    expect(commitVirtualIndexOnly).toHaveBeenCalledWith(3);
+    expect(result.current.isPageTransitioningRef.current).toBe(false);
+    expect(result.current.pageTransitionLocked.get()).toBe(false);
+  });
+
+  it('cancels an active paging animation without committing a target', async () => {
+    jest.useFakeTimers();
+
+    const commitVirtualIndexOnly = jest.fn();
+    const { result } = await renderHook(() =>
+      useGestureViewerPaging(
+        createPagingOptions({
+          commitVirtualIndexOnly,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      result.current.animateToVirtualPage(3);
+    });
+
+    await act(async () => {
+      result.current.cancelPagingInteraction();
+    });
+
+    expect(commitVirtualIndexOnly).not.toHaveBeenCalled();
+    expect(result.current.isPageTransitioningRef.current).toBe(false);
+    expect(result.current.pageTransitionLocked.get()).toBe(false);
+  });
+});

--- a/src/gestureViewerAnimation.ts
+++ b/src/gestureViewerAnimation.ts
@@ -1,0 +1,18 @@
+import { Easing } from 'react-native-reanimated';
+
+export const PAGE_TRANSITION_CONFIG = {
+  duration: 240,
+  easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+};
+
+export const PAGE_SPRING_CONFIG = {
+  damping: 35,
+  energyThreshold: 6e-9,
+  mass: 1,
+  overshootClamping: false,
+  stiffness: 360,
+};
+
+export const SWIPE_THRESHOLD_RATIO = 0.25;
+export const SWIPE_VELOCITY_THRESHOLD = 800;
+export const EDGE_RESISTANCE = 0.35;

--- a/src/gestureViewerPaging.ts
+++ b/src/gestureViewerPaging.ts
@@ -1,0 +1,101 @@
+export type HorizontalSwipeDirection = -1 | 0 | 1;
+
+export type HorizontalPagingTarget =
+  | {
+      kind: 'move';
+      targetVirtualIndex: number;
+    }
+  | {
+      kind: 'settle';
+    };
+
+export function resolveHorizontalSwipeDirection(
+  translationX: number,
+  velocityX: number,
+  width: number,
+  thresholdRatio: number,
+  velocityThreshold: number,
+): HorizontalSwipeDirection {
+  'worklet';
+
+  const translationThreshold = width * thresholdRatio;
+
+  if (-translationX > translationThreshold || velocityX < -velocityThreshold) {
+    return 1;
+  }
+
+  if (translationX > translationThreshold || velocityX > velocityThreshold) {
+    return -1;
+  }
+
+  return 0;
+}
+
+export function applyHorizontalEdgeResistance(
+  nextPage: number,
+  currentIndex: number,
+  dataLength: number,
+  centerVirtualIndex: number,
+  enableLoop: boolean,
+  resistance: number,
+): number {
+  'worklet';
+
+  if (dataLength <= 1) {
+    return centerVirtualIndex;
+  }
+
+  if (enableLoop) {
+    return nextPage;
+  }
+
+  if (currentIndex <= 0 && nextPage < centerVirtualIndex) {
+    return centerVirtualIndex + (nextPage - centerVirtualIndex) * resistance;
+  }
+
+  if (currentIndex >= dataLength - 1 && nextPage > centerVirtualIndex) {
+    return centerVirtualIndex + (nextPage - centerVirtualIndex) * resistance;
+  }
+
+  return nextPage;
+}
+
+export function canMoveHorizontalPage(
+  currentIndex: number,
+  dataLength: number,
+  direction: HorizontalSwipeDirection,
+  enableLoop: boolean,
+): boolean {
+  'worklet';
+
+  if (direction === 0 || dataLength <= 1) {
+    return false;
+  }
+
+  if (enableLoop) {
+    return true;
+  }
+
+  const nextIndex = currentIndex + direction;
+
+  return nextIndex >= 0 && nextIndex < dataLength;
+}
+
+export function resolveHorizontalPagingTarget(
+  centerVirtualIndex: number,
+  currentIndex: number,
+  dataLength: number,
+  direction: HorizontalSwipeDirection,
+  enableLoop: boolean,
+): HorizontalPagingTarget {
+  'worklet';
+
+  if (!canMoveHorizontalPage(currentIndex, dataLength, direction, enableLoop)) {
+    return { kind: 'settle' };
+  }
+
+  return {
+    kind: 'move',
+    targetVirtualIndex: centerVirtualIndex + direction,
+  };
+}

--- a/src/gestureViewerRenderWindow.ts
+++ b/src/gestureViewerRenderWindow.ts
@@ -1,0 +1,56 @@
+import {
+  type RenderWindowSlot,
+  clampIndex,
+  createRenderWindow,
+  getVirtualIndexForLogicalIndex,
+  normalizeWindowSize,
+} from './renderWindow';
+
+export type GestureViewerRenderWindowState<ItemT> = {
+  centerVirtualIndex: number;
+  currentIndex: number;
+  slots: RenderWindowSlot<ItemT>[];
+};
+
+export function resolveGestureViewerRenderWindow<ItemT>({
+  centerVirtualIndex,
+  currentIndex,
+  data,
+  enableLoop,
+  isTriggerOpening,
+  windowSize,
+}: {
+  centerVirtualIndex: number;
+  currentIndex: number;
+  data: ItemT[];
+  enableLoop: boolean;
+  isTriggerOpening: boolean;
+  windowSize?: number;
+}): GestureViewerRenderWindowState<ItemT> {
+  const dataLength = data.length;
+  const normalizedWindowSize = normalizeWindowSize(windowSize);
+  const renderCurrentIndex = clampIndex(currentIndex, dataLength);
+  const renderCenterVirtualIndex =
+    getVirtualIndexForLogicalIndex(
+      renderCurrentIndex,
+      centerVirtualIndex,
+      dataLength,
+      enableLoop,
+    ) ?? renderCurrentIndex;
+
+  const fullSlots = createRenderWindow({
+    centerVirtualIndex: renderCenterVirtualIndex,
+    data,
+    enableLoop,
+    windowSize: normalizedWindowSize,
+  });
+  const slots = isTriggerOpening
+    ? fullSlots.filter((slot) => slot.virtualIndex === renderCenterVirtualIndex)
+    : fullSlots;
+
+  return {
+    centerVirtualIndex: renderCenterVirtualIndex,
+    currentIndex: renderCurrentIndex,
+    slots,
+  };
+}

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -13,45 +13,30 @@ import {
 } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 
+import { PAGE_SPRING_CONFIG } from './gestureViewerAnimation';
 import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
+import { resolveGestureViewerRenderWindow } from './gestureViewerRenderWindow';
 import { enableNativeTapGestures } from './platformTapGestures';
 import {
   type NavigationOptions,
-  clampIndex,
-  createRenderWindow,
   getLogicalIndex,
   getPageStride,
   getVirtualIndexForLogicalIndex,
   normalizePageSpacing,
-  normalizeWindowSize,
+  clampIndex,
   resolveNavigation,
   shouldRunNavigationDuringTransition,
 } from './renderWindow';
 import type { GestureViewerProps, TriggerRect } from './types';
+import { useGestureViewerManagerBridge } from './useGestureViewerManagerBridge';
+import { useGestureViewerPaging } from './useGestureViewerPaging';
 import { type EmitSingleTap, useWebClickHandler } from './useWebClickHandler';
 import { useWebSingleTapTimer } from './useWebSingleTapTimer';
 import { createBoundsConstraint } from './utils';
 import { getDismissDistance, shouldDismissByDirection } from './utils/dismiss';
 import { applyTapZoomAtPoint } from './utils/tapZoom';
 import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from './utils/zoom';
-
-const PAGE_TRANSITION_CONFIG = {
-  duration: 240,
-  easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-};
-
-const PAGE_SPRING_CONFIG = {
-  damping: 35,
-  energyThreshold: 6e-9,
-  mass: 1,
-  overshootClamping: false,
-  stiffness: 360,
-};
-
-const SWIPE_THRESHOLD_RATIO = 0.25;
-const SWIPE_VELOCITY_THRESHOLD = 800;
-const EDGE_RESISTANCE = 0.35;
 
 const isValidTriggerRect = (rect: TriggerRect | null): rect is TriggerRect => {
   return !!rect && rect.width > 0 && rect.height > 0;
@@ -89,7 +74,6 @@ export const useGestureViewer = <ItemT>({
   const height = customHeight || screenHeight;
   const dataLength = data?.length || 0;
   const normalizedPageSpacing = normalizePageSpacing(pageSpacing);
-  const normalizedWindowSize = normalizeWindowSize(windowSize);
   const pageStride = getPageStride(width, normalizedPageSpacing);
   const initialCurrentIndex = clampIndex(initialIndex, dataLength);
 
@@ -99,7 +83,6 @@ export const useGestureViewer = <ItemT>({
   const [isRotated, setIsRotated] = useState(false);
   const [isPinching, setIsPinching] = useState(false);
   const [shouldStartTriggerAnimation, setShouldStartTriggerAnimation] = useState(false);
-  const [manager, setManager] = useState<GestureViewerManager | null>(null);
   const [currentIndex, setCurrentIndex] = useState(initialCurrentIndex);
   const [centerVirtualIndex, setCenterVirtualIndex] = useState(initialCurrentIndex);
   const [activeTriggerNode, setActiveTriggerNode] = useState<View | null>(() =>
@@ -120,8 +103,7 @@ export const useGestureViewer = <ItemT>({
   const dataRef = useRef(data);
   const dataLengthRef = useRef(dataLength);
   const enableLoopRef = useRef(enableLoop);
-  const managerRef = useRef(manager);
-  const isTransitioningRef = useRef(false);
+  const managerRef = useRef<GestureViewerManager | null>(null);
   const isZoomedRef = useRef(isZoomed);
   const isRotatedRef = useRef(isRotated);
   const isPinchingRef = useRef(isPinching);
@@ -140,11 +122,6 @@ export const useGestureViewer = <ItemT>({
   const triggerTranslateY = useSharedValue(0);
   const triggerOpacity = useSharedValue(activeTriggerNode ? 0 : 1);
 
-  const visualPage = useSharedValue(initialCurrentIndex);
-  const pagingStartPage = useSharedValue(initialCurrentIndex);
-  const pagingAnimationActive = useSharedValue(false);
-  const pagingGestureActive = useSharedValue(false);
-  const pageTransitionLocked = useSharedValue(false);
   const hasZoomChangeListeners = useSharedValue(false);
   const hasRotationChangeListeners = useSharedValue(false);
 
@@ -181,48 +158,23 @@ export const useGestureViewer = <ItemT>({
     ],
   );
 
-  const renderCurrentIndex = clampIndex(currentIndex, dataLength);
-  const renderCenterVirtualIndex =
-    getVirtualIndexForLogicalIndex(
-      renderCurrentIndex,
-      centerVirtualIndex,
-      dataLength,
-      enableLoop,
-    ) ?? renderCurrentIndex;
-
-  const fullRenderWindowSlots = createRenderWindow({
+  const {
     centerVirtualIndex: renderCenterVirtualIndex,
+    currentIndex: renderCurrentIndex,
+    slots: renderWindowSlots,
+  } = resolveGestureViewerRenderWindow({
+    centerVirtualIndex,
+    currentIndex,
     data,
     enableLoop,
-    windowSize: normalizedWindowSize,
+    isTriggerOpening,
+    windowSize,
   });
-  const renderWindowSlots = isTriggerOpening
-    ? fullRenderWindowSlots.filter((slot) => slot.virtualIndex === renderCenterVirtualIndex)
-    : fullRenderWindowSlots;
 
   const constrainTranslation = useMemo(
     () => createBoundsConstraint({ height, width }),
     [width, height],
   );
-
-  const setTransitioning = useCallback(
-    (nextTransitioning: boolean) => {
-      isTransitioningRef.current = nextTransitioning;
-      pageTransitionLocked.set(nextTransitioning);
-
-      if (nextTransitioning) {
-        clearPendingWebSingleTap();
-      }
-    },
-    [clearPendingWebSingleTap, pageTransitionLocked],
-  );
-
-  const cancelPagingInteraction = useCallback(() => {
-    clearPendingWebSingleTap();
-    pagingAnimationActive.set(false);
-    pagingGestureActive.set(false);
-    setTransitioning(false);
-  }, [clearPendingWebSingleTap, pagingAnimationActive, pagingGestureActive, setTransitioning]);
 
   const resetTransformState = useCallback(() => {
     translateX.set(withTiming(0));
@@ -258,15 +210,13 @@ export const useGestureViewer = <ItemT>({
     managerRef.current?.notifyStateChange();
   }, []);
 
-  const commitVirtualIndex = useCallback(
+  const commitVirtualIndexOnly = useCallback(
     (nextVirtualIndex: number) => {
       const nextLogicalIndex = getLogicalIndex(
         nextVirtualIndex,
         dataLengthRef.current,
         enableLoopRef.current,
       );
-
-      setTransitioning(false);
 
       if (nextLogicalIndex === null) {
         return;
@@ -276,8 +226,32 @@ export const useGestureViewer = <ItemT>({
       setCenterVirtualIndex(nextVirtualIndex);
       commitCurrentIndex(nextLogicalIndex);
     },
-    [commitCurrentIndex, setTransitioning],
+    [commitCurrentIndex],
   );
+
+  const {
+    animateToVirtualPage,
+    horizontalPagingGesture,
+    isPageTransitioningRef,
+    pageTransitionLocked,
+    snapToVirtualPage,
+    visualPage,
+  } = useGestureViewerPaging({
+    centerVirtualIndex,
+    clearPendingWebSingleTap,
+    commitVirtualIndexOnly,
+    currentIndex,
+    dataLength,
+    enableHorizontalSwipe,
+    enableLoop,
+    initialPage: initialCurrentIndex,
+    isPinching,
+    isRotated,
+    isTriggerOpening,
+    isZoomed,
+    pageStride,
+    width,
+  });
 
   const navigateToIndex = useCallback(
     (targetIndex: number, options?: NavigationOptions, preferredDirection?: -1 | 1) => {
@@ -293,7 +267,10 @@ export const useGestureViewer = <ItemT>({
         return;
       }
 
-      if (isTransitioningRef.current && !shouldRunNavigationDuringTransition(resolution, options)) {
+      if (
+        isPageTransitioningRef.current &&
+        !shouldRunNavigationDuringTransition(resolution, options)
+      ) {
         return;
       }
 
@@ -311,38 +288,21 @@ export const useGestureViewer = <ItemT>({
         return;
       }
 
-      cancelAnimation(visualPage);
-
       if (resolution.kind !== 'step' || options?.animated === false) {
         resetTransformStateImmediately();
-        cancelPagingInteraction();
-        visualPage.set(targetVirtualIndex);
-        commitVirtualIndex(targetVirtualIndex);
+        snapToVirtualPage(targetVirtualIndex);
         return;
       }
 
       resetTransformState();
-      pagingAnimationActive.set(false);
-      setTransitioning(true);
-      visualPage.set(
-        withTiming(targetVirtualIndex, PAGE_TRANSITION_CONFIG, (finished) => {
-          if (finished) {
-            scheduleOnRN(commitVirtualIndex, targetVirtualIndex);
-            return;
-          }
-
-          scheduleOnRN(setTransitioning, false);
-        }),
-      );
+      animateToVirtualPage(targetVirtualIndex);
     },
     [
-      cancelPagingInteraction,
-      commitVirtualIndex,
-      pagingAnimationActive,
+      animateToVirtualPage,
+      isPageTransitioningRef,
       resetTransformStateImmediately,
       resetTransformState,
-      setTransitioning,
-      visualPage,
+      snapToVirtualPage,
     ],
   );
 
@@ -377,6 +337,25 @@ export const useGestureViewer = <ItemT>({
   const navigateToPrevious = useCallback(() => {
     navigateByDirection(-1);
   }, [navigateByDirection]);
+
+  useGestureViewerManagerBridge({
+    currentIndexRef,
+    dataLengthRef,
+    goToIndex: navigateToIndex,
+    goToNext: navigateToNext,
+    goToPrevious: navigateToPrevious,
+    hasRotationChangeListeners,
+    hasZoomChangeListeners,
+    height,
+    id,
+    managerRef,
+    maxZoomScale,
+    rotation,
+    scale,
+    translateX,
+    translateY,
+    width,
+  });
 
   const emitZoomChange = useCallback((currentScale: number, prevScale: number | null) => {
     managerRef.current?.emitZoomChange(currentScale, prevScale);
@@ -424,13 +403,6 @@ export const useGestureViewer = <ItemT>({
   );
 
   useEffect(() => {
-    return registry.subscribeToManager(id, (managerInstance) => {
-      managerRef.current = managerInstance;
-      setManager(managerInstance);
-    });
-  }, [id]);
-
-  useEffect(() => {
     return registry.subscribeToActiveTrigger(id, (node) => {
       setActiveTriggerNode(node);
 
@@ -464,68 +436,6 @@ export const useGestureViewer = <ItemT>({
     onAnimationCompleteRef.current = triggerAnimation?.onAnimationComplete;
   }, [triggerAnimation?.onAnimationComplete]);
 
-  useEffect(() => {
-    if (!manager) {
-      return;
-    }
-
-    manager.setWidth(width);
-    manager.setHeight(height);
-    manager.setZoomSharedValues(scale, translateX, translateY, maxZoomScale);
-    manager.setRotation(rotation);
-  }, [height, manager, maxZoomScale, rotation, scale, translateX, translateY, width]);
-
-  useEffect(() => {
-    if (!manager) {
-      hasZoomChangeListeners.set(false);
-      hasRotationChangeListeners.set(false);
-      return;
-    }
-
-    return manager.subscribeToEventListenerPresence((eventType, hasListeners) => {
-      if (eventType === 'zoomChange') {
-        hasZoomChangeListeners.set(hasListeners);
-        return;
-      }
-
-      if (eventType === 'rotationChange') {
-        hasRotationChangeListeners.set(hasListeners);
-      }
-    });
-  }, [hasRotationChangeListeners, hasZoomChangeListeners, manager]);
-
-  useEffect(() => {
-    if (!manager) {
-      return;
-    }
-
-    manager.setStateReader(() => ({
-      currentIndex: currentIndexRef.current,
-      totalCount: dataLengthRef.current,
-    }));
-    manager.notifyStateChange();
-
-    return () => {
-      manager.setStateReader(null);
-    };
-  }, [manager]);
-
-  useEffect(() => {
-    if (!manager) {
-      return;
-    }
-
-    manager.setNavigationAdapter({
-      goToIndex: navigateToIndex,
-      goToNext: navigateToNext,
-      goToPrevious: navigateToPrevious,
-    });
-
-    return () => {
-      manager.setNavigationAdapter(null);
-    };
-  }, [manager, navigateToIndex, navigateToNext, navigateToPrevious]);
-
   useLayoutEffect(() => {
     const initialIndexChanged = previousInitialIndexRef.current !== initialIndex;
     const shouldResolveInitialIndex =
@@ -552,23 +462,26 @@ export const useGestureViewer = <ItemT>({
     const previousIndex = currentIndexRef.current;
     const previousVirtualIndex = centerVirtualIndexRef.current;
     const shouldSyncVirtualPage =
-      isTransitioningRef.current || previousVirtualIndex !== nextVirtualIndex;
+      isPageTransitioningRef.current || previousVirtualIndex !== nextVirtualIndex;
     const shouldResetTransform =
       initialIndexChanged || previousIndex !== nextIndex || shouldSyncVirtualPage;
 
     if (shouldSyncVirtualPage) {
-      cancelAnimation(visualPage);
-      cancelPagingInteraction();
-      visualPage.set(nextVirtualIndex);
-      centerVirtualIndexRef.current = nextVirtualIndex;
-      setCenterVirtualIndex(nextVirtualIndex);
+      snapToVirtualPage(nextVirtualIndex);
+
+      if (dataLength === 0) {
+        centerVirtualIndexRef.current = nextVirtualIndex;
+        setCenterVirtualIndex(nextVirtualIndex);
+      }
     }
 
-    if (previousIndex !== nextIndex) {
+    const shouldCommitIndexOutsidePaging = !shouldSyncVirtualPage || dataLength === 0;
+
+    if (shouldCommitIndexOutsidePaging && previousIndex !== nextIndex) {
       commitCurrentIndex(nextIndex);
     }
 
-    if (previousIndex === nextIndex) {
+    if (shouldCommitIndexOutsidePaging && previousIndex === nextIndex) {
       managerRef.current?.notifyStateChange();
     }
 
@@ -576,13 +489,13 @@ export const useGestureViewer = <ItemT>({
       resetTransformState();
     }
   }, [
-    cancelPagingInteraction,
     commitCurrentIndex,
     dataLength,
     enableLoop,
     initialIndex,
+    isPageTransitioningRef,
     resetTransformState,
-    visualPage,
+    snapToVirtualPage,
   ]);
 
   useEffect(() => {
@@ -613,7 +526,7 @@ export const useGestureViewer = <ItemT>({
 
     const timer = setInterval(() => {
       if (
-        isTransitioningRef.current ||
+        isPageTransitioningRef.current ||
         isZoomedRef.current ||
         isRotatedRef.current ||
         isPinchingRef.current
@@ -646,6 +559,7 @@ export const useGestureViewer = <ItemT>({
     isRotated,
     isTriggerOpening,
     isZoomed,
+    isPageTransitioningRef,
     navigateToIndex,
   ]);
 
@@ -764,7 +678,7 @@ export const useGestureViewer = <ItemT>({
   }, [onDismiss]);
 
   const handleDismiss = useCallback(() => {
-    if (isTransitioningRef.current) {
+    if (isPageTransitioningRef.current) {
       return;
     }
 
@@ -803,7 +717,7 @@ export const useGestureViewer = <ItemT>({
     }
 
     dismissWithoutTrigger();
-  }, [animateDismissToRect, dismissWithoutTrigger, id, onDismissStart]);
+  }, [animateDismissToRect, dismissWithoutTrigger, id, isPageTransitioningRef, onDismissStart]);
 
   const dismissGesture = useMemo(() => {
     const canDismiss = !isTriggerOpening && !isZoomed && dismissOptions.enabled;
@@ -845,153 +759,97 @@ export const useGestureViewer = <ItemT>({
       });
   }, [translateY, dismissOptions, handleDismiss, isTriggerOpening, isZoomed, pageTransitionLocked]);
 
-  const horizontalPagingGesture = useMemo(() => {
-    const canSwipe =
-      enableHorizontalSwipe &&
-      dataLength > 1 &&
-      !isTriggerOpening &&
-      !isZoomed &&
-      !isRotated &&
-      !isPinching &&
-      pageStride > 0;
-    const settleToCenter = () => {
-      'worklet';
-      pagingAnimationActive.set(true);
-      visualPage.set(
-        withSpring(centerVirtualIndex, PAGE_SPRING_CONFIG, (finished) => {
-          pagingAnimationActive.set(false);
-          if (finished) {
-            scheduleOnRN(setTransitioning, false);
+  const getCurrentTapTarget = useCallback((): { index: number; item: ItemT } | null => {
+    const index = pendingIndexRef.current;
+
+    if (index < 0 || index >= dataRef.current.length || !(index in dataRef.current)) {
+      return null;
+    }
+
+    return { index, item: dataRef.current[index] as ItemT };
+  }, []);
+
+  const isWebInteractionLocked = useCallback(
+    () => isPageTransitioningRef.current || pageTransitionLocked.get(),
+    [isPageTransitioningRef, pageTransitionLocked],
+  );
+
+  const emitSingleTap = useCallback<EmitSingleTap<ItemT>>(
+    (x, y, tapTarget) => {
+      if (isPageTransitioningRef.current) {
+        return;
+      }
+
+      const target = tapTarget ?? getCurrentTapTarget();
+
+      if (!target) {
+        return;
+      }
+
+      const { index: targetIndex, item: targetItem } = target;
+
+      if (targetIndex < 0) {
+        return;
+      }
+
+      managerRef.current?.emitTap({ kind: 'single', x, y, index: targetIndex });
+      onSingleTapRef.current?.({ x, y, index: targetIndex, item: targetItem });
+    },
+    [getCurrentTapTarget, isPageTransitioningRef],
+  );
+
+  const singleTapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .enabled(enableNativeTapGestures)
+        .numberOfTaps(1)
+        .onEnd((event, success) => {
+          if (!success || pageTransitionLocked.get()) {
+            return;
           }
+
+          scheduleOnRN(emitSingleTap, event.x, event.y);
         }),
-      );
-    };
+    [emitSingleTap, pageTransitionLocked],
+  );
 
-    return Gesture.Pan()
-      .minDistance(10)
-      .averageTouches(true)
-      .activeCursor('grabbing')
-      .activeOffsetX([-10, 10])
-      .failOffsetY([-10, 10])
-      .enabled(canSwipe)
-      .onStart(() => {
-        if (pageTransitionLocked.get()) {
-          return;
-        }
-
-        // Pan enters BEGAN for ordinary taps, so lock paging only after swipe activation.
-        cancelAnimation(visualPage);
-        pagingAnimationActive.set(false);
-        pagingGestureActive.set(true);
-        pageTransitionLocked.set(true);
-        pagingStartPage.set(visualPage.get());
-        scheduleOnRN(setTransitioning, true);
-      })
-      .onUpdate((event) => {
-        if (!pagingGestureActive.get()) {
-          return;
-        }
-
-        const dragPageDelta = -event.translationX / pageStride;
-        const basePage = pagingStartPage.get();
-        let nextPage = basePage + dragPageDelta;
-
-        if (!enableLoop) {
-          if (currentIndex === 0 && nextPage < centerVirtualIndex) {
-            nextPage = centerVirtualIndex + (nextPage - centerVirtualIndex) * EDGE_RESISTANCE;
+  const doubleTapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .enabled(enableDoubleTapZoom && enableNativeTapGestures)
+        .numberOfTaps(2)
+        .onEnd((event) => {
+          if (pageTransitionLocked.get()) {
+            return;
           }
 
-          if (currentIndex === dataLength - 1 && nextPage > centerVirtualIndex) {
-            nextPage = centerVirtualIndex + (nextPage - centerVirtualIndex) * EDGE_RESISTANCE;
-          }
-        }
+          applyTapZoomAtPoint({
+            x: event.x,
+            y: event.y,
+            width,
+            height,
+            maxZoomScale,
+            scale,
+            translateX,
+            translateY,
+          });
+        }),
+    [
+      enableDoubleTapZoom,
+      height,
+      maxZoomScale,
+      pageTransitionLocked,
+      scale,
+      translateX,
+      translateY,
+      width,
+    ],
+  );
 
-        visualPage.set(nextPage);
-      })
-      .onEnd((event) => {
-        if (!pagingGestureActive.get()) {
-          return;
-        }
-
-        pagingGestureActive.set(false);
-
-        const passedLeftThreshold =
-          -event.translationX > width * SWIPE_THRESHOLD_RATIO ||
-          event.velocityX < -SWIPE_VELOCITY_THRESHOLD;
-        const passedRightThreshold =
-          event.translationX > width * SWIPE_THRESHOLD_RATIO ||
-          event.velocityX > SWIPE_VELOCITY_THRESHOLD;
-        const direction = passedLeftThreshold ? 1 : passedRightThreshold ? -1 : 0;
-
-        if (direction === 0) {
-          settleToCenter();
-          return;
-        }
-
-        const nextIndex = currentIndex + direction;
-        const canMove =
-          enableLoop ||
-          (direction === 1 && nextIndex < dataLength) ||
-          (direction === -1 && nextIndex >= 0);
-
-        if (!canMove) {
-          settleToCenter();
-          return;
-        }
-
-        const targetVirtualIndex = centerVirtualIndex + direction;
-
-        pagingAnimationActive.set(true);
-        visualPage.set(
-          withTiming(targetVirtualIndex, PAGE_TRANSITION_CONFIG, (finished) => {
-            pagingAnimationActive.set(false);
-            if (finished) {
-              scheduleOnRN(commitVirtualIndex, targetVirtualIndex);
-              return;
-            }
-
-            scheduleOnRN(setTransitioning, false);
-          }),
-        );
-      })
-      .onFinalize(() => {
-        if (pagingAnimationActive.get()) {
-          return;
-        }
-
-        if (!pagingGestureActive.get()) {
-          return;
-        }
-
-        pagingGestureActive.set(false);
-
-        if (Math.abs(visualPage.get() - centerVirtualIndex) > 0.001) {
-          settleToCenter();
-          return;
-        }
-
-        scheduleOnRN(setTransitioning, false);
-      });
-  }, [
-    centerVirtualIndex,
-    commitVirtualIndex,
-    currentIndex,
-    dataLength,
-    enableHorizontalSwipe,
-    enableLoop,
-    isTriggerOpening,
-    isPinching,
-    isRotated,
-    isZoomed,
-    pagingAnimationActive,
-    pagingGestureActive,
-    pageTransitionLocked,
-    pageStride,
-    pagingStartPage,
-    setTransitioning,
-    visualPage,
-    width,
-  ]);
+  const tapGesture = useMemo(
+    () => Gesture.Exclusive(doubleTapGesture, singleTapGesture),
+    [doubleTapGesture, singleTapGesture],
+  );
 
   const zoomPinchGesture = useMemo(
     () =>
@@ -1213,98 +1071,6 @@ export const useGestureViewer = <ItemT>({
       constrainTranslation,
       pageTransitionLocked,
     ],
-  );
-
-  const getCurrentTapTarget = useCallback((): { index: number; item: ItemT } | null => {
-    const index = pendingIndexRef.current;
-
-    if (index < 0 || index >= dataRef.current.length || !(index in dataRef.current)) {
-      return null;
-    }
-
-    return { index, item: dataRef.current[index] as ItemT };
-  }, []);
-
-  const isWebInteractionLocked = useCallback(
-    () => isTransitioningRef.current || pageTransitionLocked.get(),
-    [pageTransitionLocked],
-  );
-
-  const emitSingleTap = useCallback<EmitSingleTap<ItemT>>(
-    (x, y, tapTarget) => {
-      if (isTransitioningRef.current) {
-        return;
-      }
-
-      const target = tapTarget ?? getCurrentTapTarget();
-
-      if (!target) {
-        return;
-      }
-
-      const { index: targetIndex, item: targetItem } = target;
-
-      if (targetIndex < 0) {
-        return;
-      }
-
-      managerRef.current?.emitTap({ kind: 'single', x, y, index: targetIndex });
-      onSingleTapRef.current?.({ x, y, index: targetIndex, item: targetItem });
-    },
-    [getCurrentTapTarget],
-  );
-
-  const singleTapGesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .enabled(enableNativeTapGestures)
-        .numberOfTaps(1)
-        .onEnd((event, success) => {
-          if (!success || pageTransitionLocked.get()) {
-            return;
-          }
-
-          scheduleOnRN(emitSingleTap, event.x, event.y);
-        }),
-    [emitSingleTap, pageTransitionLocked],
-  );
-
-  const doubleTapGesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .enabled(enableDoubleTapZoom && enableNativeTapGestures)
-        .numberOfTaps(2)
-        .onEnd((event) => {
-          if (pageTransitionLocked.get()) {
-            return;
-          }
-
-          applyTapZoomAtPoint({
-            x: event.x,
-            y: event.y,
-            width,
-            height,
-            maxZoomScale,
-            scale,
-            translateX,
-            translateY,
-          });
-        }),
-    [
-      enableDoubleTapZoom,
-      height,
-      maxZoomScale,
-      pageTransitionLocked,
-      scale,
-      translateX,
-      translateY,
-      width,
-    ],
-  );
-
-  const tapGesture = useMemo(
-    () => Gesture.Exclusive(doubleTapGesture, singleTapGesture),
-    [doubleTapGesture, singleTapGesture],
   );
 
   const zoomGesture = useMemo(

--- a/src/useGestureViewerManagerBridge.ts
+++ b/src/useGestureViewerManagerBridge.ts
@@ -1,0 +1,118 @@
+import { useEffect, useState, type RefObject } from 'react';
+import type { SharedValue } from 'react-native-reanimated';
+
+import type GestureViewerManager from './GestureViewerManager';
+import type { GestureViewerNavigationOptions } from './GestureViewerManager';
+import { registry } from './GestureViewerRegistry';
+
+type UseGestureViewerManagerBridgeOptions = {
+  currentIndexRef: RefObject<number>;
+  dataLengthRef: RefObject<number>;
+  goToIndex: (index: number, options?: GestureViewerNavigationOptions) => void;
+  goToNext: () => void;
+  goToPrevious: () => void;
+  hasRotationChangeListeners: SharedValue<boolean>;
+  hasZoomChangeListeners: SharedValue<boolean>;
+  height: number;
+  id: string;
+  managerRef: RefObject<GestureViewerManager | null>;
+  maxZoomScale: number;
+  rotation: SharedValue<number>;
+  scale: SharedValue<number>;
+  translateX: SharedValue<number>;
+  translateY: SharedValue<number>;
+  width: number;
+};
+
+/**
+ * Owns the registry-to-manager bridge side effects for one viewer instance.
+ */
+export function useGestureViewerManagerBridge({
+  currentIndexRef,
+  dataLengthRef,
+  goToIndex,
+  goToNext,
+  goToPrevious,
+  hasRotationChangeListeners,
+  hasZoomChangeListeners,
+  height,
+  id,
+  managerRef,
+  maxZoomScale,
+  rotation,
+  scale,
+  translateX,
+  translateY,
+  width,
+}: UseGestureViewerManagerBridgeOptions) {
+  const [manager, setManager] = useState<GestureViewerManager | null>(null);
+
+  useEffect(() => {
+    return registry.subscribeToManager(id, (managerInstance) => {
+      managerRef.current = managerInstance;
+      setManager(managerInstance);
+    });
+  }, [id, managerRef]);
+
+  useEffect(() => {
+    if (!manager) {
+      return;
+    }
+
+    manager.setWidth(width);
+    manager.setHeight(height);
+    manager.setZoomSharedValues(scale, translateX, translateY, maxZoomScale);
+    manager.setRotation(rotation);
+  }, [height, manager, maxZoomScale, rotation, scale, translateX, translateY, width]);
+
+  useEffect(() => {
+    if (!manager) {
+      hasZoomChangeListeners.set(false);
+      hasRotationChangeListeners.set(false);
+      return;
+    }
+
+    return manager.subscribeToEventListenerPresence((eventType, hasListeners) => {
+      if (eventType === 'zoomChange') {
+        hasZoomChangeListeners.set(hasListeners);
+        return;
+      }
+
+      if (eventType === 'rotationChange') {
+        hasRotationChangeListeners.set(hasListeners);
+      }
+    });
+  }, [hasRotationChangeListeners, hasZoomChangeListeners, manager]);
+
+  useEffect(() => {
+    if (!manager) {
+      return;
+    }
+
+    manager.setStateReader(() => ({
+      currentIndex: currentIndexRef.current,
+      totalCount: dataLengthRef.current,
+    }));
+    manager.notifyStateChange();
+
+    return () => {
+      manager.setStateReader(null);
+    };
+  }, [currentIndexRef, dataLengthRef, manager]);
+
+  useEffect(() => {
+    if (!manager) {
+      return;
+    }
+
+    manager.setNavigationAdapter({
+      goToIndex,
+      goToNext,
+      goToPrevious,
+    });
+
+    return () => {
+      manager.setNavigationAdapter(null);
+    };
+  }, [goToIndex, goToNext, goToPrevious, manager]);
+}

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -1,0 +1,303 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { Gesture } from 'react-native-gesture-handler';
+import { cancelAnimation, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
+
+import {
+  EDGE_RESISTANCE,
+  PAGE_SPRING_CONFIG,
+  PAGE_TRANSITION_CONFIG,
+  SWIPE_THRESHOLD_RATIO,
+  SWIPE_VELOCITY_THRESHOLD,
+} from './gestureViewerAnimation';
+import {
+  applyHorizontalEdgeResistance,
+  resolveHorizontalPagingTarget,
+  resolveHorizontalSwipeDirection,
+} from './gestureViewerPaging';
+
+type UseGestureViewerPagingOptions = {
+  centerVirtualIndex: number;
+  clearPendingWebSingleTap: () => void;
+  commitVirtualIndexOnly: (targetVirtualIndex: number) => void;
+  currentIndex: number;
+  dataLength: number;
+  enableHorizontalSwipe: boolean;
+  enableLoop: boolean;
+  initialPage: number;
+  isPinching: boolean;
+  isRotated: boolean;
+  isTriggerOpening: boolean;
+  isZoomed: boolean;
+  pageStride: number;
+  width: number;
+};
+
+/**
+ * Owns horizontal paging shared values, transition state, and paging commands.
+ */
+export function useGestureViewerPaging({
+  centerVirtualIndex,
+  clearPendingWebSingleTap,
+  commitVirtualIndexOnly,
+  currentIndex,
+  dataLength,
+  enableHorizontalSwipe,
+  enableLoop,
+  initialPage,
+  isPinching,
+  isRotated,
+  isTriggerOpening,
+  isZoomed,
+  pageStride,
+  width,
+}: UseGestureViewerPagingOptions) {
+  const visualPage = useSharedValue(initialPage);
+  const pagingStartPage = useSharedValue(initialPage);
+  const pagingAnimationActive = useSharedValue(false);
+  const pagingGestureActive = useSharedValue(false);
+  const pageTransitionLocked = useSharedValue(false);
+  const isPageTransitioningRef = useRef(false);
+
+  const setPageTransitioning = useCallback(
+    (nextTransitioning: boolean) => {
+      isPageTransitioningRef.current = nextTransitioning;
+      pageTransitionLocked.set(nextTransitioning);
+
+      if (nextTransitioning) {
+        clearPendingWebSingleTap();
+      }
+    },
+    [clearPendingWebSingleTap, pageTransitionLocked],
+  );
+
+  const clearPagingFlags = useCallback(() => {
+    pagingAnimationActive.set(false);
+    pagingGestureActive.set(false);
+  }, [pagingAnimationActive, pagingGestureActive]);
+
+  const cancelPagingInteraction = useCallback(() => {
+    clearPendingWebSingleTap();
+    cancelAnimation(visualPage);
+    clearPagingFlags();
+    setPageTransitioning(false);
+  }, [clearPendingWebSingleTap, clearPagingFlags, setPageTransitioning, visualPage]);
+
+  const snapToVirtualPage = useCallback(
+    (targetVirtualIndex: number) => {
+      clearPendingWebSingleTap();
+      cancelAnimation(visualPage);
+      clearPagingFlags();
+      visualPage.set(targetVirtualIndex);
+      commitVirtualIndexOnly(targetVirtualIndex);
+      setPageTransitioning(false);
+    },
+    [
+      clearPendingWebSingleTap,
+      clearPagingFlags,
+      commitVirtualIndexOnly,
+      setPageTransitioning,
+      visualPage,
+    ],
+  );
+
+  const completeAnimatedVirtualPage = useCallback(
+    (targetVirtualIndex: number) => {
+      commitVirtualIndexOnly(targetVirtualIndex);
+      setPageTransitioning(false);
+    },
+    [commitVirtualIndexOnly, setPageTransitioning],
+  );
+
+  const cancelAnimatedVirtualPage = useCallback(() => {
+    setPageTransitioning(false);
+  }, [setPageTransitioning]);
+
+  const animateToVirtualPage = useCallback(
+    (targetVirtualIndex: number) => {
+      cancelAnimation(visualPage);
+      clearPagingFlags();
+      pagingAnimationActive.set(true);
+      setPageTransitioning(true);
+      visualPage.set(
+        withTiming(targetVirtualIndex, PAGE_TRANSITION_CONFIG, (finished) => {
+          pagingAnimationActive.set(false);
+
+          if (finished) {
+            scheduleOnRN(completeAnimatedVirtualPage, targetVirtualIndex);
+            return;
+          }
+
+          scheduleOnRN(cancelAnimatedVirtualPage);
+        }),
+      );
+    },
+    [
+      cancelAnimatedVirtualPage,
+      clearPagingFlags,
+      completeAnimatedVirtualPage,
+      pagingAnimationActive,
+      setPageTransitioning,
+      visualPage,
+    ],
+  );
+
+  const horizontalPagingGesture = useMemo(() => {
+    const canSwipe =
+      enableHorizontalSwipe &&
+      dataLength > 1 &&
+      !isTriggerOpening &&
+      !isZoomed &&
+      !isRotated &&
+      !isPinching &&
+      pageStride > 0;
+    const settleToCenter = () => {
+      'worklet';
+      pagingAnimationActive.set(true);
+      visualPage.set(
+        withSpring(centerVirtualIndex, PAGE_SPRING_CONFIG, (finished) => {
+          pagingAnimationActive.set(false);
+
+          if (finished) {
+            scheduleOnRN(setPageTransitioning, false);
+          }
+        }),
+      );
+    };
+
+    return Gesture.Pan()
+      .minDistance(10)
+      .averageTouches(true)
+      .activeCursor('grabbing')
+      .activeOffsetX([-10, 10])
+      .failOffsetY([-10, 10])
+      .enabled(canSwipe)
+      .onStart(() => {
+        if (pageTransitionLocked.get()) {
+          return;
+        }
+
+        // Pan enters BEGAN for ordinary taps, so lock paging only after swipe activation.
+        cancelAnimation(visualPage);
+        pagingAnimationActive.set(false);
+        pagingGestureActive.set(true);
+        pagingStartPage.set(visualPage.get());
+        scheduleOnRN(setPageTransitioning, true);
+      })
+      .onUpdate((event) => {
+        if (!pagingGestureActive.get()) {
+          return;
+        }
+
+        const dragPageDelta = -event.translationX / pageStride;
+        const basePage = pagingStartPage.get();
+        const nextPage = applyHorizontalEdgeResistance(
+          basePage + dragPageDelta,
+          currentIndex,
+          dataLength,
+          centerVirtualIndex,
+          enableLoop,
+          EDGE_RESISTANCE,
+        );
+
+        visualPage.set(nextPage);
+      })
+      .onEnd((event) => {
+        if (!pagingGestureActive.get()) {
+          return;
+        }
+
+        pagingGestureActive.set(false);
+
+        const direction = resolveHorizontalSwipeDirection(
+          event.translationX,
+          event.velocityX,
+          width,
+          SWIPE_THRESHOLD_RATIO,
+          SWIPE_VELOCITY_THRESHOLD,
+        );
+
+        if (direction === 0) {
+          settleToCenter();
+          return;
+        }
+
+        const pagingTarget = resolveHorizontalPagingTarget(
+          centerVirtualIndex,
+          currentIndex,
+          dataLength,
+          direction,
+          enableLoop,
+        );
+
+        if (pagingTarget.kind === 'settle') {
+          settleToCenter();
+          return;
+        }
+
+        const targetVirtualIndex = pagingTarget.targetVirtualIndex;
+
+        pagingAnimationActive.set(true);
+        visualPage.set(
+          withTiming(targetVirtualIndex, PAGE_TRANSITION_CONFIG, (finished) => {
+            pagingAnimationActive.set(false);
+
+            if (finished) {
+              scheduleOnRN(completeAnimatedVirtualPage, targetVirtualIndex);
+              return;
+            }
+
+            scheduleOnRN(cancelAnimatedVirtualPage);
+          }),
+        );
+      })
+      .onFinalize(() => {
+        if (pagingAnimationActive.get()) {
+          return;
+        }
+
+        if (!pagingGestureActive.get()) {
+          return;
+        }
+
+        pagingGestureActive.set(false);
+
+        if (Math.abs(visualPage.get() - centerVirtualIndex) > 0.001) {
+          settleToCenter();
+          return;
+        }
+
+        scheduleOnRN(setPageTransitioning, false);
+      });
+  }, [
+    cancelAnimatedVirtualPage,
+    centerVirtualIndex,
+    completeAnimatedVirtualPage,
+    currentIndex,
+    dataLength,
+    enableHorizontalSwipe,
+    enableLoop,
+    isTriggerOpening,
+    isPinching,
+    isRotated,
+    isZoomed,
+    pageTransitionLocked,
+    pageStride,
+    pagingAnimationActive,
+    pagingGestureActive,
+    pagingStartPage,
+    setPageTransitioning,
+    visualPage,
+    width,
+  ]);
+
+  return {
+    animateToVirtualPage,
+    cancelPagingInteraction,
+    horizontalPagingGesture,
+    isPageTransitioningRef,
+    pageTransitionLocked,
+    snapToVirtualPage,
+    visualPage,
+  };
+}


### PR DESCRIPTION
## Summary
- move manager bridge effects into `useGestureViewerManagerBridge`
- move paging shared values and command lifecycle into `useGestureViewerPaging`
- keep parent navigation orchestration in `useGestureViewer` while routing paging mutation through commands
- add render-window and paging helper coverage

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test src/__tests__/gestureViewerPaging.test.ts src/__tests__/useGestureViewerPaging.test.ts src/__tests__/renderWindow.test.ts --runInBand`
- `git diff --check`

## Notes
- `example/src/assets` is intentionally excluded and remains local test data
- native gesture timing still benefits from simulator/device smoke testing