### PR TITLE
feat!: make horizontal swipe thresholds configurable

### DIFF
--- a/.changeset/configurable-horizontal-swipe.md
+++ b/.changeset/configurable-horizontal-swipe.md
@@ -1,0 +1,43 @@
+---
+'react-native-gesture-image-viewer': major
+---
+
+Replace the boolean `enableHorizontalSwipe` prop with configurable `horizontalSwipe` options.
+
+This is a breaking API change. Migrate gesture disabling from the removed boolean prop:
+
+```tsx
+// Before
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  enableHorizontalSwipe={false}
+/>
+
+// After
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{ enabled: false }}
+/>
+```
+
+The new options also allow applications to control the distance and velocity required to change pages:
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{
+    enabled: true,
+    distanceThresholdRatio: 0.4,
+    velocityThreshold: 1200,
+  }}
+/>
+```
+
+All fields are optional. `enabled` defaults to `true`, `distanceThresholdRatio` defaults to `0.25` of the viewer width, and `velocityThreshold` defaults to `800` points per second.
+
+A page transition is committed when either the absolute drag distance is strictly greater than the configured width ratio or the absolute velocity is strictly greater than the configured velocity threshold. Finite non-negative values, including `0` and distance ratios greater than `1`, are supported. Invalid values fall back to their defaults.
+
+Setting `horizontalSwipe.enabled` to `false` disables only touch and mouse horizontal gestures. Controller navigation and autoplay continue to work.

--- a/docs/docs/3.x-beta/en/guide/migration-from-2.x.mdx
+++ b/docs/docs/3.x-beta/en/guide/migration-from-2.x.mdx
@@ -47,7 +47,16 @@ By default, v3 mounts three pages: previous, current, and next. Increase `window
 
 ### Keep programmatic navigation
 
-`goToIndex`, `goToPrevious`, and `goToNext` still work. `enableHorizontalSwipe={false}` disables only user horizontal swipe gestures; controller navigation remains available.
+`goToIndex`, `goToPrevious`, and `goToNext` still work. `horizontalSwipe={{ enabled: false }}` disables only user/mouse horizontal swipe gestures; controller navigation and autoplay remain available.
+
+```diff
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+- enableHorizontalSwipe={false}
++ horizontalSwipe={{ enabled: false }}
+/>
+```
 
 ```tsx
 const { goToIndex } = useGestureViewerController();
@@ -71,15 +80,15 @@ goToIndex(2, { animated: false });
 
 v3 no longer forwards props to `ScrollView`, `FlatList`, or `FlashList`. Move common `listProps` usage to the v3 viewer APIs instead:
 
-| 2.x `listProps` usage                                                                | v3 direction                                                                                                               |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `keyExtractor`                                                                       | Removed. The render window owns slot keys; keep stable item identity in `data` and render content through `renderItem`.    |
-| `initialScrollIndex`                                                                 | Use `initialIndex`.                                                                                                        |
-| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | Removed. Paging is gesture-owned. Use `enableHorizontalSwipe` to lock user swipes and `pageSpacing` for visible page gaps. |
-| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | Removed. Use `useGestureViewerState` for `currentIndex`/`totalCount`; use viewer events for supported viewer interactions. |
-| `ref.current.scrollToIndex(...)`                                                     | Use `useGestureViewerController().goToIndex(...)`, `goToNext()`, or `goToPrevious()`.                                      |
-| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | Replace list virtualization tuning with `windowSize`. The default mounts previous/current/next only.                       |
-| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | Removed. Compose visual content inside `renderItem` or use `pageSpacing` for inter-page gaps.                              |
+| 2.x `listProps` usage                                                                | v3 direction                                                                                                                              |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyExtractor`                                                                       | Removed. The render window owns slot keys; keep stable item identity in `data` and render content through `renderItem`.                   |
+| `initialScrollIndex`                                                                 | Use `initialIndex`.                                                                                                                       |
+| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | Removed. Paging is gesture-owned. Use `horizontalSwipe={{ enabled: false }}` to lock user swipes and `pageSpacing` for visible page gaps. |
+| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | Removed. Use `useGestureViewerState` for `currentIndex`/`totalCount`; use viewer events for supported viewer interactions.                |
+| `ref.current.scrollToIndex(...)`                                                     | Use `useGestureViewerController().goToIndex(...)`, `goToNext()`, or `goToPrevious()`.                                                     |
+| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | Replace list virtualization tuning with `windowSize`. The default mounts previous/current/next only.                                      |
+| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | Removed. Compose visual content inside `renderItem` or use `pageSpacing` for inter-page gaps.                                             |
 
 ## Notes
 

--- a/docs/docs/3.x-beta/en/guide/usage/gesture-features.mdx
+++ b/docs/docs/3.x-beta/en/guide/usage/gesture-features.mdx
@@ -17,7 +17,11 @@ function App() {
         resistance: 2,
         fadeBackdrop: true,
       }}
-      enableHorizontalSwipe={true}
+      horizontalSwipe={{
+        enabled: true,
+        distanceThresholdRatio: 0.25,
+        velocityThreshold: 800,
+      }}
       enablePinchZoom={true}
       enableDoubleTapZoom={true}
       enablePanWhenZoomed={true}
@@ -40,9 +44,47 @@ Dismiss gesture options. Controls which vertical swipe direction can trigger `on
 | `resistance`   | `resistance` controls the range of vertical movement by applying resistance during dismiss gestures.      | `number`             |   `2`   |
 | `fadeBackdrop` | By default, the background `opacity` gradually decreases as you drag in the configured dismiss direction. | `boolean`            | `true`  |
 
-### `enableHorizontalSwipe` (default: `true`)
+### `horizontalSwipe`
 
-Controls left/right swipe gestures. When `false`, horizontal gestures are disabled.
+Horizontal swipe gesture options. Controls user-driven left/right page swipe gestures. Controller navigation and autoplay remain available when disabled.
+
+| Property                 | Description                                                                                                                                                                      | Type      | Default |
+| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------- | :-----: |
+| `enabled`                | When `false`, user-driven horizontal page swipe gestures are disabled.                                                                                                           | `boolean` | `true`  |
+| `distanceThresholdRatio` | Distance threshold as a ratio of viewer width. A page commits when absolute translation is strictly greater than `width * distanceThresholdRatio`, or velocity passes threshold. | `number`  | `0.25`  |
+| `velocityThreshold`      | Horizontal velocity threshold in points per second. A page commits when absolute velocity is strictly greater than this value, or distance passes threshold.                     | `number`  |  `800`  |
+
+Distance and velocity use strict `>` OR semantics. Zero and every finite non-negative value are accepted, including `distanceThresholdRatio` values greater than `1`; negative and non-finite values fall back to defaults.
+
+```tsx
+<GestureViewer data={images} renderItem={renderImage} horizontalSwipe={{ enabled: false }} />
+```
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }}
+/>
+```
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }}
+/>
+```
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{ enabled: false }}
+  autoPlay={true}
+  autoPlayInterval={1000}
+/>
+```
 
 ### `enablePinchZoom` (default: `true`)
 

--- a/docs/docs/3.x-beta/en/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/3.x-beta/en/guide/usage/gesture-viewer-props.mdx
@@ -56,6 +56,78 @@ function App() {
 }
 ```
 
+### `horizontalSwipe`
+
+Controls user-driven left/right page swipe gestures. Controller navigation and autoplay remain available when disabled.
+
+Defaults:
+
+- `enabled`: `true`
+- `distanceThresholdRatio`: `0.25` of viewer width
+- `velocityThreshold`: `800` points/sec
+
+A page commits when absolute horizontal distance is strictly greater than `width * distanceThresholdRatio`, or absolute horizontal velocity is strictly greater than `velocityThreshold`. Distance and velocity use strict `>` OR semantics. Zero and every finite non-negative value are accepted, including distance ratios greater than `1`; negative and non-finite values fall back to defaults.
+
+```tsx
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      data={data}
+      renderItem={renderItem}
+      horizontalSwipe={{
+        enabled: true,
+        distanceThresholdRatio: 0.25,
+        velocityThreshold: 800,
+      }} // [!code highlight:5]
+    />
+  );
+}
+```
+
+Disable only user/mouse horizontal gestures:
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight]
+/>
+```
+
+Use a distance-focused configuration:
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }} // [!code highlight]
+/>
+```
+
+Use a velocity-focused configuration:
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }} // [!code highlight]
+/>
+```
+
+Disable user gestures while autoplay continues:
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight:3]
+  autoPlay={true}
+  autoPlayInterval={1000}
+/>
+```
+
 ### `autoPlay` (default: `false`)
 
 Enables auto play mode. When `true`, the viewer will automatically play the next item after the specified interval.
@@ -262,11 +334,28 @@ export interface GestureViewerProps<ItemT> {
     fadeBackdrop?: boolean;
   };
   /**
-   * Controls left/right swipe gestures.
-   * @remarks When `false`, horizontal gestures are disabled.
-   * @defaultValue true
+   * Horizontal swipe gesture options.
+   * @remarks Controls user-driven left/right page swipe gestures. Controller navigation and autoplay remain available when disabled.
    */
-  enableHorizontalSwipe?: boolean;
+  horizontalSwipe?: {
+    /**
+     * When `false`, user-driven horizontal page swipe gestures are disabled.
+     * @defaultValue true
+     */
+    enabled?: boolean;
+    /**
+     * Distance threshold as a ratio of viewer width.
+     * @remarks A page commits when absolute horizontal translation is strictly greater than `width * distanceThresholdRatio`, or when velocity passes `velocityThreshold`. Zero and finite values greater than `1` are accepted; negative and non-finite values fall back to the default.
+     * @defaultValue 0.25
+     */
+    distanceThresholdRatio?: number;
+    /**
+     * Horizontal velocity threshold in points per second.
+     * @remarks A page commits when absolute horizontal velocity is strictly greater than `velocityThreshold`, or when distance passes `distanceThresholdRatio`. Zero and every finite non-negative value are accepted; negative and non-finite values fall back to the default.
+     * @defaultValue 800
+     */
+    velocityThreshold?: number;
+  };
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
    * @remarks When `false`, gesture movement is disabled during zoom.

--- a/docs/docs/3.x-beta/ko/guide/migration-from-2.x.mdx
+++ b/docs/docs/3.x-beta/ko/guide/migration-from-2.x.mdx
@@ -47,7 +47,16 @@ import { Steps } from '@rspress/core/theme';
 
 ### 프로그래밍 방식 이동 유지
 
-`goToIndex`, `goToPrevious`, `goToNext`는 계속 동작합니다. `enableHorizontalSwipe={false}`는 사용자의 가로 스와이프 제스처만 비활성화하며, controller 이동은 계속 사용할 수 있습니다.
+`goToIndex`, `goToPrevious`, `goToNext`는 계속 동작합니다. `horizontalSwipe={{ enabled: false }}`는 사용자/마우스 가로 스와이프 제스처만 비활성화하며, controller 이동과 autoplay는 계속 사용할 수 있습니다.
+
+```diff
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+- enableHorizontalSwipe={false}
++ horizontalSwipe={{ enabled: false }}
+/>
+```
 
 ```tsx
 const { goToIndex } = useGestureViewerController();
@@ -71,15 +80,15 @@ goToIndex(2, { animated: false });
 
 3.x는 더 이상 `ScrollView`, `FlatList`, `FlashList`로 props를 전달하지 않습니다. 자주 쓰던 `listProps` 설정은 아래 v3 API로 옮기세요.
 
-| 2.x `listProps` 사용                                                                 | 3.x 방향                                                                                                                                       |
-| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keyExtractor`                                                                       | 제거됨. render window가 slot key를 직접 관리합니다. 아이템 식별성은 `data`에서 안정적으로 유지하고, 콘텐츠는 `renderItem`에서 렌더링하세요.    |
-| `initialScrollIndex`                                                                 | `initialIndex`를 사용하세요.                                                                                                                   |
-| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | 제거됨. 페이징은 내부 제스처가 소유합니다. 사용자 스와이프를 잠글 때는 `enableHorizontalSwipe`, 페이지 사이 간격은 `pageSpacing`을 사용하세요. |
-| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | 제거됨. `currentIndex`/`totalCount`는 `useGestureViewerState`를 사용하고, 지원되는 뷰어 인터랙션은 viewer event를 사용하세요.                  |
-| `ref.current.scrollToIndex(...)`                                                     | `useGestureViewerController().goToIndex(...)`, `goToNext()`, `goToPrevious()`를 사용하세요.                                                    |
-| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | 리스트 virtualization 튜닝 대신 `windowSize`를 사용하세요. 기본값은 이전/현재/다음만 마운트합니다.                                             |
-| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | 제거됨. 시각적 구성은 `renderItem` 내부에서 조합하거나, 페이지 사이 간격은 `pageSpacing`을 사용하세요.                                         |
+| 2.x `listProps` 사용                                                                 | 3.x 방향                                                                                                                                                      |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyExtractor`                                                                       | 제거됨. render window가 slot key를 직접 관리합니다. 아이템 식별성은 `data`에서 안정적으로 유지하고, 콘텐츠는 `renderItem`에서 렌더링하세요.                   |
+| `initialScrollIndex`                                                                 | `initialIndex`를 사용하세요.                                                                                                                                  |
+| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | 제거됨. 페이징은 내부 제스처가 소유합니다. 사용자 스와이프를 잠글 때는 `horizontalSwipe={{ enabled: false }}`, 페이지 사이 간격은 `pageSpacing`을 사용하세요. |
+| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | 제거됨. `currentIndex`/`totalCount`는 `useGestureViewerState`를 사용하고, 지원되는 뷰어 인터랙션은 viewer event를 사용하세요.                                 |
+| `ref.current.scrollToIndex(...)`                                                     | `useGestureViewerController().goToIndex(...)`, `goToNext()`, `goToPrevious()`를 사용하세요.                                                                   |
+| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | 리스트 virtualization 튜닝 대신 `windowSize`를 사용하세요. 기본값은 이전/현재/다음만 마운트합니다.                                                            |
+| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | 제거됨. 시각적 구성은 `renderItem` 내부에서 조합하거나, 페이지 사이 간격은 `pageSpacing`을 사용하세요.                                                        |
 
 ## 참고
 

--- a/docs/docs/3.x-beta/ko/guide/usage/gesture-features.mdx
+++ b/docs/docs/3.x-beta/ko/guide/usage/gesture-features.mdx
@@ -17,7 +17,11 @@ function App() {
         resistance: 2,
         fadeBackdrop: true,
       }}
-      enableHorizontalSwipe={true}
+      horizontalSwipe={{
+        enabled: true,
+        distanceThresholdRatio: 0.25,
+        velocityThreshold: 800,
+      }}
       enablePinchZoom={true}
       enableDoubleTapZoom={true}
       enablePanWhenZoomed={true}
@@ -40,9 +44,47 @@ function App() {
 | `resistance`   | `resistance`는 dismiss 제스처 중에 저항을 적용하여 수직 이동 범위를 제어합니다.                        | `number`             |  `2`   |
 | `fadeBackdrop` | 기본적으로 설정된 dismiss 방향으로 드래그하는 동안 배경 `opacity`가 1에서 0으로 점진적으로 감소합니다. | `boolean`            | `true` |
 
-### `enableHorizontalSwipe` (기본값: `true`)
+### `horizontalSwipe`
 
-좌우 스와이프 제스처를 제어합니다. `false`일 때 가로 제스처가 비활성화됩니다.
+가로 스와이프 제스처 옵션입니다. 사용자가 직접 수행하는 좌우 페이지 스와이프 제스처를 제어합니다. 비활성화해도 controller 이동과 autoplay는 계속 사용할 수 있습니다.
+
+| 속성                     | 설명                                                                                                                                                  | 타입      | 기본값 |
+| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- | :-------- | :----: |
+| `enabled`                | `false`이면 사용자가 직접 수행하는 가로 페이지 스와이프 제스처가 비활성화됩니다.                                                                      | `boolean` | `true` |
+| `distanceThresholdRatio` | 뷰어 너비에 대한 거리 임계값 비율입니다. 절대 이동 거리가 `width * distanceThresholdRatio`보다 엄격히 클 때, 또는 속도가 임계값을 넘을 때 전환됩니다. | `number`  | `0.25` |
+| `velocityThreshold`      | 초당 points 단위의 가로 속도 임계값입니다. 절대 속도가 이 값보다 엄격히 클 때, 또는 거리가 임계값을 넘을 때 전환됩니다.                               | `number`  | `800`  |
+
+거리와 속도는 엄격한 `>` OR 조건으로 동작합니다. `0`과 모든 유한한 0 이상의 값은 허용되며, `1`보다 큰 `distanceThresholdRatio` 값도 허용됩니다. 음수와 유한하지 않은 값은 기본값으로 대체됩니다.
+
+```tsx
+<GestureViewer data={images} renderItem={renderImage} horizontalSwipe={{ enabled: false }} />
+```
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }}
+/>
+```
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }}
+/>
+```
+
+```tsx
+<GestureViewer
+  data={images}
+  renderItem={renderImage}
+  horizontalSwipe={{ enabled: false }}
+  autoPlay={true}
+  autoPlayInterval={1000}
+/>
+```
 
 ### `enablePinchZoom` (기본값: `true`)
 

--- a/docs/docs/3.x-beta/ko/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/3.x-beta/ko/guide/usage/gesture-viewer-props.mdx
@@ -56,6 +56,78 @@ function App() {
 }
 ```
 
+### `horizontalSwipe`
+
+사용자가 직접 수행하는 좌우 페이지 스와이프 제스처를 제어합니다. 비활성화해도 controller 이동과 autoplay는 계속 사용할 수 있습니다.
+
+기본값:
+
+- `enabled`: `true`
+- `distanceThresholdRatio`: 뷰어 너비의 `0.25`
+- `velocityThreshold`: 초당 `800` points
+
+절대 가로 이동 거리가 `width * distanceThresholdRatio`보다 엄격히 클 때, 또는 절대 가로 속도가 `velocityThreshold`보다 엄격히 클 때 페이지가 전환됩니다. 거리와 속도는 엄격한 `>` OR 조건으로 동작합니다. `0`과 모든 유한한 0 이상의 값은 허용되며, `1`보다 큰 거리 비율도 허용됩니다. 음수와 유한하지 않은 값은 기본값으로 대체됩니다.
+
+```tsx
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      data={data}
+      renderItem={renderItem}
+      horizontalSwipe={{
+        enabled: true,
+        distanceThresholdRatio: 0.25,
+        velocityThreshold: 800,
+      }} // [!code highlight:5]
+    />
+  );
+}
+```
+
+사용자/마우스 가로 제스처만 비활성화합니다.
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight]
+/>
+```
+
+거리 중심 설정을 사용합니다.
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }} // [!code highlight]
+/>
+```
+
+속도 중심 설정을 사용합니다.
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }} // [!code highlight]
+/>
+```
+
+사용자 제스처를 비활성화해도 autoplay는 계속 동작합니다.
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight:3]
+  autoPlay={true}
+  autoPlayInterval={1000}
+/>
+```
+
 ### `autoPlay` (기본값: `false`)
 
 자동 재생 모드를 활성화합니다. `true`일 때 지정된 간격 후 다음 아이템으로 자동으로 재생됩니다.
@@ -262,11 +334,28 @@ export interface GestureViewerProps<ItemT> {
     fadeBackdrop?: boolean;
   };
   /**
-   * 좌우 스와이프 제스처를 제어합니다.
-   * @remarks `false`이면 가로 제스처가 비활성화됩니다.
-   * @defaultValue true
+   * 가로 스와이프 제스처 옵션입니다.
+   * @remarks 사용자가 직접 수행하는 좌우 페이지 스와이프 제스처를 제어합니다. 비활성화해도 controller 이동과 autoplay는 계속 사용할 수 있습니다.
    */
-  enableHorizontalSwipe?: boolean;
+  horizontalSwipe?: {
+    /**
+     * `false`이면 사용자가 직접 수행하는 가로 페이지 스와이프 제스처가 비활성화됩니다.
+     * @defaultValue true
+     */
+    enabled?: boolean;
+    /**
+     * 뷰어 너비에 대한 거리 임계값 비율입니다.
+     * @remarks 절대 가로 이동 거리가 `width * distanceThresholdRatio`보다 엄격히 클 때, 또는 속도가 `velocityThreshold`를 넘을 때 페이지가 전환됩니다. `0`과 `1`보다 큰 유한한 값은 허용되며, 음수와 유한하지 않은 값은 기본값으로 대체됩니다.
+     * @defaultValue 0.25
+     */
+    distanceThresholdRatio?: number;
+    /**
+     * 초당 points 단위의 가로 속도 임계값입니다.
+     * @remarks 절대 가로 속도가 `velocityThreshold`보다 엄격히 클 때, 또는 거리가 `distanceThresholdRatio`를 넘을 때 페이지가 전환됩니다. `0`과 모든 유한한 0 이상의 값은 허용되며, 음수와 유한하지 않은 값은 기본값으로 대체됩니다.
+     * @defaultValue 800
+     */
+    velocityThreshold?: number;
+  };
   /**
    * 줌이 활성화된 경우에만 동작하며, 확대된 상태에서 아이템 위치를 이동할 수 있게 합니다.
    * @remarks `false`이면 줌 중 제스처 이동이 비활성화됩니다.

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -5,6 +5,7 @@ import { Button, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import {
   GestureTrigger,
   GestureViewer,
+  type GestureViewerProps,
   useGestureViewerController,
   useGestureViewerEvent,
   useGestureViewerState,
@@ -34,11 +35,61 @@ const photos = [
   },
 ] as const;
 
+type HorizontalSwipeOptions = GestureViewerProps<string>['horizontalSwipe'];
+
+type ScenarioId = 'default' | 'disabled' | 'distance' | 'velocity' | 'disabledAutoplay';
+
+type Scenario = {
+  label: string;
+  description: string;
+  horizontalSwipe?: HorizontalSwipeOptions;
+  autoPlay?: boolean;
+  autoPlayInterval?: number;
+};
+
+const scenarios: Record<ScenarioId, Scenario> = {
+  default: {
+    label: 'Default',
+    description: 'Omitted horizontalSwipe prop',
+  },
+  disabled: {
+    label: 'Disabled',
+    description: 'Horizontal drag disabled; controls still work',
+    horizontalSwipe: { enabled: false },
+  },
+  distance: {
+    label: 'Distance',
+    description: 'ratio 0.5, velocity 100000',
+    horizontalSwipe: { distanceThresholdRatio: 0.5, velocityThreshold: 100_000 },
+  },
+  velocity: {
+    label: 'Velocity',
+    description: 'ratio 10, velocity 100',
+    horizontalSwipe: { distanceThresholdRatio: 10, velocityThreshold: 100 },
+  },
+  disabledAutoplay: {
+    label: 'No drag + autoplay',
+    description: 'Drag disabled, autoplay every 1000ms',
+    autoPlay: true,
+    autoPlayInterval: 1000,
+    horizontalSwipe: { enabled: false },
+  },
+};
+
+const scenarioIds: ScenarioId[] = [
+  'default',
+  'disabled',
+  'distance',
+  'velocity',
+  'disabledAutoplay',
+];
+
 function Example() {
   const [visible, setVisible] = useState(false);
   const [enableLoop, setEnableLoop] = useState(false);
   const [showExternalUI, setShowExternalUI] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedScenarioId, setSelectedScenarioId] = useState<ScenarioId>('default');
 
   const { goToIndex, goToPrevious, goToNext, zoomIn, zoomOut, resetZoom, rotate } =
     useGestureViewerController();
@@ -46,6 +97,7 @@ function Example() {
   const { currentIndex, totalCount } = useGestureViewerState();
 
   const insets = useSafeAreaInsets();
+  const selectedScenario = scenarios[selectedScenarioId];
 
   const modalOpen = useCallback((index: number) => {
     setSelectedIndex(index);
@@ -85,6 +137,33 @@ function Example() {
           title={`Loop: ${enableLoop ? 'ON' : 'OFF'}`}
           onPress={() => setEnableLoop(!enableLoop)}
         />
+        <View style={styles.scenarioGroup}>
+          <Text style={styles.scenarioTitle}>Horizontal swipe preset</Text>
+          <View style={styles.scenarioOptions}>
+            {scenarioIds.map((scenarioId) => {
+              const scenario = scenarios[scenarioId];
+              const selected = scenarioId === selectedScenarioId;
+
+              return (
+                <Pressable
+                  key={scenarioId}
+                  onPress={() => setSelectedScenarioId(scenarioId)}
+                  style={[styles.scenarioButton, selected && styles.scenarioButtonSelected]}
+                >
+                  <Text
+                    style={[
+                      styles.scenarioButtonText,
+                      selected && styles.scenarioButtonTextSelected,
+                    ]}
+                  >
+                    {scenario.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <Text style={styles.subtext}>{selectedScenario.description}</Text>
+        </View>
         <Text style={styles.text}>Click on a thumbnail to open the viewer.</Text>
         <View style={styles.galleryContainer}>
           {photos.map(({ uri }, index) => (
@@ -108,9 +187,14 @@ function Example() {
             initialIndex={selectedIndex}
             onDismiss={() => setVisible(false)}
             onDismissStart={() => setShowExternalUI(false)}
+            autoPlay={selectedScenario.autoPlay}
+            autoPlayInterval={selectedScenario.autoPlayInterval}
             enableLoop={enableLoop}
             pageSpacing={16}
             renderItem={renderImage}
+            {...(selectedScenario.horizontalSwipe
+              ? { horizontalSwipe: selectedScenario.horizontalSwipe }
+              : {})}
             dismiss={{
               direction: 'both',
             }}
@@ -282,6 +366,42 @@ const styles = StyleSheet.create({
     color: '#222',
     fontSize: 22,
     fontWeight: 'bold',
+  },
+  scenarioButton: {
+    borderColor: '#aaa',
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  scenarioButtonSelected: {
+    backgroundColor: '#222',
+    borderColor: '#222',
+  },
+  scenarioButtonText: {
+    color: '#222',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  scenarioButtonTextSelected: {
+    color: 'white',
+  },
+  scenarioGroup: {
+    width: '100%',
+    alignItems: 'center',
+    gap: 8,
+  },
+  scenarioOptions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    justifyContent: 'center',
+  },
+  scenarioTitle: {
+    color: '#222',
+    fontSize: 16,
+    fontWeight: '700',
+    textAlign: 'center',
   },
   subtext: {
     textAlign: 'center',

--- a/src/__tests__/GestureViewer.integration.test.tsx
+++ b/src/__tests__/GestureViewer.integration.test.tsx
@@ -2,8 +2,9 @@ import { act, cleanup, render, waitFor } from '@testing-library/react-native';
 import { Text, type View } from 'react-native';
 
 import { GestureViewer } from '../GestureViewer';
+import { PAGE_TRANSITION_CONFIG } from '../gestureViewerAnimation';
 import { registry } from '../GestureViewerRegistry';
-import type { GestureViewerController } from '../types';
+import type { GestureViewerController, GestureViewerProps } from '../types';
 import { useGestureViewerController } from '../useGestureViewerController';
 import { useGestureViewerState } from '../useGestureViewerState';
 
@@ -44,8 +45,8 @@ type HarnessProps = {
   autoPlay?: boolean;
   autoPlayInterval?: number;
   data?: Array<string | undefined>;
-  enableHorizontalSwipe?: boolean;
   enableLoop?: boolean;
+  horizontalSwipe?: GestureViewerProps<string | undefined>['horizontalSwipe'];
   initialIndex?: number;
   onSingleTap?: (event: { x: number; y: number; index: number; item: string | undefined }) => void;
   viewerId: string;
@@ -55,8 +56,8 @@ function Harness({
   autoPlay = false,
   autoPlayInterval,
   data: viewerData = data,
-  enableHorizontalSwipe = true,
   enableLoop = false,
+  horizontalSwipe,
   initialIndex = 0,
   onSingleTap,
   viewerId,
@@ -73,9 +74,9 @@ function Harness({
         autoPlay={autoPlay}
         autoPlayInterval={autoPlayInterval}
         data={viewerData}
-        enableHorizontalSwipe={enableHorizontalSwipe}
         enableLoop={enableLoop}
         height={240}
+        horizontalSwipe={horizontalSwipe}
         id={viewerId}
         initialIndex={initialIndex}
         onSingleTap={onSingleTap}
@@ -164,10 +165,26 @@ describe('GestureViewer render-window integration', () => {
 
   it('keeps controller navigation available when horizontal swipe is disabled', async () => {
     const rendered = await render(
-      <Harness enableHorizontalSwipe={false} viewerId="controller-locked-swipe" />,
+      <Harness
+        horizontalSwipe={{ enabled: false }}
+        initialIndex={1}
+        viewerId="controller-locked-swipe"
+      />,
     );
 
+    await expectState(rendered, 'controller-locked-swipe', '1/4');
+
+    await act(async () => {
+      getController().goToPrevious();
+    });
+
     await expectState(rendered, 'controller-locked-swipe', '0/4');
+
+    await act(async () => {
+      getController().goToNext();
+    });
+
+    await expectState(rendered, 'controller-locked-swipe', '1/4');
 
     await act(async () => {
       getController().goToIndex(2, { animated: false });
@@ -178,6 +195,32 @@ describe('GestureViewer render-window integration', () => {
     expect(rendered.getByText('second')).toBeTruthy();
     expect(rendered.getByText('third')).toBeTruthy();
     expect(rendered.getByText('fourth')).toBeTruthy();
+  });
+
+  it('keeps autoplay available when horizontal swipe is disabled', async () => {
+    jest.useFakeTimers();
+
+    const rendered = await render(
+      <Harness
+        autoPlay
+        autoPlayInterval={1000}
+        data={['first', 'second']}
+        horizontalSwipe={{ enabled: false }}
+        viewerId="autoplay-locked-swipe"
+      />,
+    );
+
+    await expectState(rendered, 'autoplay-locked-swipe', '0/2');
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(PAGE_TRANSITION_CONFIG.duration);
+    });
+
+    await expectState(rendered, 'autoplay-locked-swipe', '1/2');
   });
 
   it('preserves tap events for explicit undefined items', async () => {

--- a/src/__tests__/gestureViewerPaging.test.ts
+++ b/src/__tests__/gestureViewerPaging.test.ts
@@ -1,9 +1,67 @@
+import type React from 'react';
+
 import {
   applyHorizontalEdgeResistance,
   canMoveHorizontalPage,
+  normalizeHorizontalSwipeThreshold,
   resolveHorizontalPagingTarget,
   resolveHorizontalSwipeDirection,
 } from '../gestureViewerPaging';
+import type { GestureViewerProps } from '../types';
+
+const acceptedHorizontalSwipeProps = {
+  data: ['item'],
+  renderItem: () => ({}) as React.ReactElement,
+  horizontalSwipe: {
+    enabled: true,
+    distanceThresholdRatio: 0.5,
+    velocityThreshold: 1000,
+  },
+} satisfies GestureViewerProps<string>;
+
+const rejectedEnableHorizontalSwipeProps = {
+  data: ['item'],
+  renderItem: () => ({}) as React.ReactElement,
+  // @ts-expect-error enableHorizontalSwipe was removed in favor of horizontalSwipe.enabled.
+  enableHorizontalSwipe: false,
+} satisfies GestureViewerProps<string>;
+
+void acceptedHorizontalSwipeProps;
+void rejectedEnableHorizontalSwipeProps;
+
+describe('GestureViewerProps horizontal swipe contract', () => {
+  it('accepts horizontalSwipe and rejects enableHorizontalSwipe at compile time', () => {
+    expect(true).toBe(true);
+  });
+});
+
+describe('horizontal swipe threshold normalization', () => {
+  it.each([
+    ['undefined', undefined, 0.25],
+    ['valid positive finite number', 0.5, 0.5],
+    ['zero', 0, 0],
+    ['ratio greater than 1', 1.5, 1.5],
+    ['negative number', -0.1, 0.25],
+    ['NaN', NaN, 0.25],
+    ['Infinity', Infinity, 0.25],
+    ['-Infinity', -Infinity, 0.25],
+  ] as const)('normalizes distance threshold ratio: %s', (_label, value, expected) => {
+    expect(normalizeHorizontalSwipeThreshold(value, 0.25)).toBe(expected);
+  });
+
+  it.each([
+    ['undefined', undefined, 800],
+    ['valid positive finite number', 1200, 1200],
+    ['zero', 0, 0],
+    ['greater than 1', 100_000, 100_000],
+    ['negative number', -1, 800],
+    ['NaN', NaN, 800],
+    ['Infinity', Infinity, 800],
+    ['-Infinity', -Infinity, 800],
+  ] as const)('normalizes velocity threshold: %s', (_label, value, expected) => {
+    expect(normalizeHorizontalSwipeThreshold(value, 800)).toBe(expected);
+  });
+});
 
 describe('horizontal paging swipe direction', () => {
   const width = 400;
@@ -44,6 +102,27 @@ describe('horizontal paging swipe direction', () => {
     expect(resolveHorizontalSwipeDirection(24, 200, width, thresholdRatio, velocityThreshold)).toBe(
       0,
     );
+  });
+
+  it('commits by distance only when velocity stays below threshold', () => {
+    expect(resolveHorizontalSwipeDirection(-201, -10, width, 0.5, 100_000)).toBe(1);
+    expect(resolveHorizontalSwipeDirection(201, 10, width, 0.5, 100_000)).toBe(-1);
+  });
+
+  it('commits by velocity only when distance stays below threshold', () => {
+    expect(resolveHorizontalSwipeDirection(-10, -101, width, 10, 100)).toBe(1);
+    expect(resolveHorizontalSwipeDirection(10, 101, width, 10, 100)).toBe(-1);
+  });
+
+  it('settles at exact custom distance and velocity boundaries', () => {
+    expect(resolveHorizontalSwipeDirection(-200, -100, width, 0.5, 100)).toBe(0);
+    expect(resolveHorizontalSwipeDirection(200, 100, width, 0.5, 100)).toBe(0);
+  });
+
+  it('accepts zero thresholds while preserving strict greater-than checks', () => {
+    expect(resolveHorizontalSwipeDirection(0, 0, width, 0, 0)).toBe(0);
+    expect(resolveHorizontalSwipeDirection(-1, 0, width, 0, 0)).toBe(1);
+    expect(resolveHorizontalSwipeDirection(0, 1, width, 0, 0)).toBe(-1);
   });
 });
 

--- a/src/__tests__/useGestureViewer.test.tsx
+++ b/src/__tests__/useGestureViewer.test.tsx
@@ -1,0 +1,359 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react-native';
+import { Text, View } from 'react-native';
+import {
+  GestureDetector,
+  GestureHandlerRootView,
+  type GestureType,
+} from 'react-native-gesture-handler';
+import { fireGestureHandler } from 'react-native-gesture-handler/jest-utils';
+
+import { PAGE_TRANSITION_CONFIG } from '../gestureViewerAnimation';
+import { registry } from '../GestureViewerRegistry';
+import type { GestureViewerProps, GestureViewerState } from '../types';
+import { useGestureViewer } from '../useGestureViewer';
+
+type HorizontalSwipeOptions = GestureViewerProps<string>['horizontalSwipe'];
+
+type HarnessProps = {
+  horizontalSwipe?: HorizontalSwipeOptions;
+  onGestureChange: (gesture: GestureType) => void;
+  viewerId: string;
+};
+
+const createdManagerIds = new Set<string>();
+
+function Harness({ horizontalSwipe, onGestureChange, viewerId }: HarnessProps) {
+  const { currentIndex, dataLength, horizontalPagingGesture } = useGestureViewer({
+    data: ['first', 'second', 'third', 'fourth'],
+    height: 240,
+    horizontalSwipe,
+    id: viewerId,
+    initialIndex: 0,
+    width: 320,
+  });
+
+  onGestureChange(horizontalPagingGesture);
+
+  return (
+    <GestureHandlerRootView>
+      <GestureDetector gesture={horizontalPagingGesture}>
+        <View testID={`${viewerId}-gesture-target`} />
+      </GestureDetector>
+      <Text testID={`${viewerId}-state`}>
+        {currentIndex}/{dataLength}
+      </Text>
+    </GestureHandlerRootView>
+  );
+}
+
+async function renderHarness({
+  horizontalSwipe,
+  viewerId,
+}: {
+  horizontalSwipe?: HorizontalSwipeOptions;
+  viewerId: string;
+}) {
+  registry.createManager(viewerId);
+  createdManagerIds.add(viewerId);
+
+  const gestures: GestureType[] = [];
+  const rendered = await render(
+    <Harness
+      horizontalSwipe={horizontalSwipe}
+      onGestureChange={(gesture) => gestures.push(gesture)}
+      viewerId={viewerId}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(registry.getManager(viewerId)?.getState()).toEqual({
+      currentIndex: 0,
+      totalCount: 4,
+    });
+  });
+
+  return {
+    get gesture() {
+      const gesture = gestures.at(-1);
+
+      if (!gesture) {
+        throw new Error('Horizontal paging gesture was not captured');
+      }
+
+      return gesture;
+    },
+    rendered,
+  };
+}
+
+async function rerenderHarness({
+  horizontalSwipe,
+  rendered,
+  viewerId,
+}: {
+  horizontalSwipe?: HorizontalSwipeOptions;
+  rendered: Awaited<ReturnType<typeof render>>;
+  viewerId: string;
+}) {
+  const gestures: GestureType[] = [];
+
+  await act(async () => {
+    await rendered.rerender(
+      <Harness
+        horizontalSwipe={horizontalSwipe}
+        onGestureChange={(gesture) => gestures.push(gesture)}
+        viewerId={viewerId}
+      />,
+    );
+  });
+
+  const gesture = gestures.at(-1);
+
+  if (!gesture) {
+    throw new Error('Horizontal paging gesture was not captured after rerender');
+  }
+
+  return gesture;
+}
+
+function subscribeToManager(viewerId: string) {
+  const manager = registry.getManager(viewerId);
+  const listener = jest.fn<void, [GestureViewerState]>();
+
+  if (!manager) {
+    throw new Error('GestureViewer manager was not registered');
+  }
+
+  const unsubscribe = manager.subscribe(listener);
+
+  listener.mockClear();
+
+  return { listener, manager, unsubscribe };
+}
+
+async function fireHorizontalPan(
+  gesture: GestureType,
+  event: { translationX: number; velocityX: number },
+) {
+  await act(async () => {
+    fireGestureHandler(gesture, [event]);
+  });
+}
+
+async function advancePageTransition() {
+  await act(async () => {
+    jest.advanceTimersByTime(PAGE_TRANSITION_CONFIG.duration);
+  });
+}
+
+describe('useGestureViewer horizontal swipe options', () => {
+  afterEach(() => {
+    cleanup();
+    createdManagerIds.forEach((viewerId) => registry.deleteManager(viewerId));
+    createdManagerIds.clear();
+    jest.useRealTimers();
+  });
+
+  it('uses default thresholds when horizontalSwipe is omitted and settles at equality', async () => {
+    jest.useFakeTimers();
+
+    const viewerId = 'default-omitted';
+    const { gesture } = await renderHarness({ viewerId });
+    const { listener, manager, unsubscribe } = subscribeToManager(viewerId);
+
+    await fireHorizontalPan(gesture, { translationX: -80, velocityX: -800 });
+    await advancePageTransition();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(manager.getState()).toEqual({ currentIndex: 0, totalCount: 4 });
+
+    unsubscribe();
+  });
+
+  it('uses default thresholds when horizontalSwipe is empty and commits beyond equality', async () => {
+    jest.useFakeTimers();
+
+    const viewerId = 'default-empty';
+    const { gesture } = await renderHarness({ horizontalSwipe: {}, viewerId });
+    const { listener, manager, unsubscribe } = subscribeToManager(viewerId);
+
+    await fireHorizontalPan(gesture, { translationX: -81, velocityX: 0 });
+    await advancePageTransition();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith({ currentIndex: 1, totalCount: 4 });
+    expect(manager.getState()).toEqual({ currentIndex: 1, totalCount: 4 });
+
+    unsubscribe();
+  });
+
+  it('uses custom distance thresholds without swapping velocity', async () => {
+    jest.useFakeTimers();
+
+    const settleViewerId = 'custom-distance-settle';
+    const settleHarness = await renderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0.5, velocityThreshold: 100_000 },
+      viewerId: settleViewerId,
+    });
+    const settle = subscribeToManager(settleViewerId);
+
+    await fireHorizontalPan(settleHarness.gesture, { translationX: -160, velocityX: -10 });
+    await advancePageTransition();
+
+    expect(settle.listener).not.toHaveBeenCalled();
+    expect(settle.manager.getState()).toEqual({ currentIndex: 0, totalCount: 4 });
+    settle.unsubscribe();
+
+    const commitViewerId = 'custom-distance-commit';
+    const commitHarness = await renderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0.5, velocityThreshold: 100_000 },
+      viewerId: commitViewerId,
+    });
+    const commit = subscribeToManager(commitViewerId);
+
+    await fireHorizontalPan(commitHarness.gesture, { translationX: -161, velocityX: -10 });
+    await advancePageTransition();
+
+    expect(commit.listener).toHaveBeenCalledTimes(1);
+    expect(commit.listener).toHaveBeenLastCalledWith({ currentIndex: 1, totalCount: 4 });
+    expect(commit.manager.getState()).toEqual({ currentIndex: 1, totalCount: 4 });
+    commit.unsubscribe();
+  });
+
+  it('uses custom velocity thresholds without swapping distance', async () => {
+    jest.useFakeTimers();
+
+    const settleViewerId = 'custom-velocity-settle';
+    const settleHarness = await renderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 10, velocityThreshold: 100 },
+      viewerId: settleViewerId,
+    });
+    const settle = subscribeToManager(settleViewerId);
+
+    await fireHorizontalPan(settleHarness.gesture, { translationX: -10, velocityX: -100 });
+    await advancePageTransition();
+
+    expect(settle.listener).not.toHaveBeenCalled();
+    expect(settle.manager.getState()).toEqual({ currentIndex: 0, totalCount: 4 });
+    settle.unsubscribe();
+
+    const commitViewerId = 'custom-velocity-commit';
+    const commitHarness = await renderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 10, velocityThreshold: 100 },
+      viewerId: commitViewerId,
+    });
+    const commit = subscribeToManager(commitViewerId);
+
+    await fireHorizontalPan(commitHarness.gesture, { translationX: -10, velocityX: -101 });
+    await advancePageTransition();
+
+    expect(commit.listener).toHaveBeenCalledTimes(1);
+    expect(commit.listener).toHaveBeenLastCalledWith({ currentIndex: 1, totalCount: 4 });
+    expect(commit.manager.getState()).toEqual({ currentIndex: 1, totalCount: 4 });
+    commit.unsubscribe();
+  });
+
+  it('falls back for invalid thresholds and accepts zero thresholds', async () => {
+    jest.useFakeTimers();
+
+    const invalidViewerId = 'invalid-thresholds';
+    const invalidHarness = await renderHarness({
+      horizontalSwipe: {
+        distanceThresholdRatio: Number.NaN,
+        velocityThreshold: Number.POSITIVE_INFINITY,
+      },
+      viewerId: invalidViewerId,
+    });
+    const invalid = subscribeToManager(invalidViewerId);
+
+    await fireHorizontalPan(invalidHarness.gesture, { translationX: -80, velocityX: -800 });
+    await advancePageTransition();
+
+    expect(invalid.listener).not.toHaveBeenCalled();
+    expect(invalid.manager.getState()).toEqual({ currentIndex: 0, totalCount: 4 });
+    invalid.unsubscribe();
+
+    const zeroViewerId = 'zero-thresholds';
+    const zeroHarness = await renderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0, velocityThreshold: 0 },
+      viewerId: zeroViewerId,
+    });
+    const zero = subscribeToManager(zeroViewerId);
+
+    await fireHorizontalPan(zeroHarness.gesture, { translationX: -1, velocityX: 0 });
+    await advancePageTransition();
+
+    expect(zero.listener).toHaveBeenCalledTimes(1);
+    expect(zero.listener).toHaveBeenLastCalledWith({ currentIndex: 1, totalCount: 4 });
+    expect(zero.manager.getState()).toEqual({ currentIndex: 1, totalCount: 4 });
+    zero.unsubscribe();
+  });
+
+  it('preserves gesture identity for equivalent primitive values and rebuilds on threshold change', async () => {
+    const viewerId = 'gesture-identity';
+    const { gesture, rendered } = await renderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0.5, velocityThreshold: 100_000 },
+      viewerId,
+    });
+
+    const equivalentGesture = await rerenderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0.5, velocityThreshold: 100_000 },
+      rendered,
+      viewerId,
+    });
+
+    expect(equivalentGesture).toBe(gesture);
+
+    const changedGesture = await rerenderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0.25, velocityThreshold: 100_000 },
+      rendered,
+      viewerId,
+    });
+
+    expect(changedGesture).not.toBe(gesture);
+  });
+
+  it('uses changed threshold closure values after rebuilding the gesture', async () => {
+    jest.useFakeTimers();
+
+    const viewerId = 'changed-threshold-closure';
+    const { rendered } = await renderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0.5, velocityThreshold: 100_000 },
+      viewerId,
+    });
+    const gesture = await rerenderHarness({
+      horizontalSwipe: { distanceThresholdRatio: 0.25, velocityThreshold: 100_000 },
+      rendered,
+      viewerId,
+    });
+    const { listener, manager, unsubscribe } = subscribeToManager(viewerId);
+
+    await fireHorizontalPan(gesture, { translationX: -81, velocityX: -10 });
+    await advancePageTransition();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith({ currentIndex: 1, totalCount: 4 });
+    expect(manager.getState()).toEqual({ currentIndex: 1, totalCount: 4 });
+
+    unsubscribe();
+  });
+
+  it('does not commit fired pan events when horizontal swipe is disabled', async () => {
+    jest.useFakeTimers();
+
+    const viewerId = 'disabled-horizontal-swipe';
+    const { gesture } = await renderHarness({
+      horizontalSwipe: { enabled: false },
+      viewerId,
+    });
+    const { listener, manager, unsubscribe } = subscribeToManager(viewerId);
+
+    await fireHorizontalPan(gesture, { translationX: -320, velocityX: -10_000 });
+    await advancePageTransition();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(manager.getState()).toEqual({ currentIndex: 0, totalCount: 4 });
+
+    unsubscribe();
+  });
+});

--- a/src/__tests__/useGestureViewerPaging.test.ts
+++ b/src/__tests__/useGestureViewerPaging.test.ts
@@ -1,4 +1,8 @@
-import { act, renderHook } from '@testing-library/react-native';
+import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { View } from 'react-native';
+import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
+import { fireGestureHandler } from 'react-native-gesture-handler/jest-utils';
 
 import { PAGE_TRANSITION_CONFIG } from '../gestureViewerAnimation';
 import { useGestureViewerPaging } from '../useGestureViewerPaging';
@@ -6,18 +10,30 @@ import { useGestureViewerPaging } from '../useGestureViewerPaging';
 const createPagingOptions = ({
   clearPendingWebSingleTap = jest.fn(),
   commitVirtualIndexOnly = jest.fn(),
+  currentIndex = 0,
+  horizontalSwipeDistanceThresholdRatio = 0.25,
+  horizontalSwipeEnabled = true,
+  horizontalSwipeVelocityThreshold = 800,
+  initialPage = 0,
 }: {
   clearPendingWebSingleTap?: jest.Mock;
   commitVirtualIndexOnly?: jest.Mock;
+  currentIndex?: number;
+  horizontalSwipeDistanceThresholdRatio?: number;
+  horizontalSwipeEnabled?: boolean;
+  horizontalSwipeVelocityThreshold?: number;
+  initialPage?: number;
 } = {}) => ({
   centerVirtualIndex: 0,
   clearPendingWebSingleTap,
   commitVirtualIndexOnly,
-  currentIndex: 0,
+  currentIndex,
   dataLength: 4,
-  enableHorizontalSwipe: true,
   enableLoop: false,
-  initialPage: 0,
+  horizontalSwipeDistanceThresholdRatio,
+  horizontalSwipeEnabled,
+  horizontalSwipeVelocityThreshold,
+  initialPage,
   isPinching: false,
   isRotated: false,
   isTriggerOpening: false,
@@ -26,8 +42,68 @@ const createPagingOptions = ({
   width: 320,
 });
 
+type PagingResult = ReturnType<typeof useGestureViewerPaging>;
+type PagingOptions = ReturnType<typeof createPagingOptions>;
+
+function PagingGestureHarness({
+  onResult,
+  options,
+}: {
+  onResult: (result: PagingResult) => void;
+  options: PagingOptions;
+}) {
+  const result = useGestureViewerPaging(options);
+
+  onResult(result);
+
+  return React.createElement(
+    GestureHandlerRootView,
+    null,
+    React.createElement(
+      GestureDetector,
+      { gesture: result.horizontalPagingGesture },
+      React.createElement(View, { testID: 'paging-gesture-target' }),
+    ),
+  );
+}
+
+async function renderPagingGesture(options: PagingOptions) {
+  const results: PagingResult[] = [];
+
+  const rendered = await render(
+    React.createElement(PagingGestureHarness, {
+      onResult: (result) => results.push(result),
+      options,
+    }),
+  );
+
+  await waitFor(() => {
+    expect(results.at(-1)).toBeDefined();
+  });
+
+  return {
+    get result() {
+      const result = results.at(-1);
+
+      if (!result) {
+        throw new Error('Paging hook result was not captured');
+      }
+
+      return result;
+    },
+    rendered,
+  };
+}
+
+async function advancePageTransition() {
+  await act(async () => {
+    jest.advanceTimersByTime(PAGE_TRANSITION_CONFIG.duration);
+  });
+}
+
 describe('useGestureViewerPaging commands', () => {
   afterEach(() => {
+    cleanup();
     jest.useRealTimers();
   });
 
@@ -106,5 +182,96 @@ describe('useGestureViewerPaging commands', () => {
     expect(commitVirtualIndexOnly).not.toHaveBeenCalled();
     expect(result.current.isPageTransitioningRef.current).toBe(false);
     expect(result.current.pageTransitionLocked.get()).toBe(false);
+  });
+});
+
+describe('useGestureViewerPaging horizontal gesture thresholds', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('settles at the custom distance boundary and commits beyond it', async () => {
+    jest.useFakeTimers();
+
+    const commitVirtualIndexOnly = jest.fn();
+    const { result } = await renderPagingGesture(
+      createPagingOptions({
+        commitVirtualIndexOnly,
+        horizontalSwipeDistanceThresholdRatio: 0.5,
+        horizontalSwipeVelocityThreshold: 100_000,
+      }),
+    );
+
+    await act(async () => {
+      fireGestureHandler(result.horizontalPagingGesture, [{ translationX: -160, velocityX: 0 }]);
+    });
+    await advancePageTransition();
+
+    expect(commitVirtualIndexOnly).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireGestureHandler(result.horizontalPagingGesture, [{ translationX: -161, velocityX: 0 }]);
+    });
+    await advancePageTransition();
+
+    expect(commitVirtualIndexOnly).toHaveBeenCalledWith(1);
+  });
+
+  it('settles at the custom velocity boundary and commits beyond it', async () => {
+    jest.useFakeTimers();
+
+    const commitVirtualIndexOnly = jest.fn();
+    const { result } = await renderPagingGesture(
+      createPagingOptions({
+        commitVirtualIndexOnly,
+        horizontalSwipeDistanceThresholdRatio: 10,
+        horizontalSwipeVelocityThreshold: 100,
+      }),
+    );
+
+    await act(async () => {
+      fireGestureHandler(result.horizontalPagingGesture, [{ translationX: -10, velocityX: -100 }]);
+    });
+    await advancePageTransition();
+
+    expect(commitVirtualIndexOnly).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireGestureHandler(result.horizontalPagingGesture, [{ translationX: -10, velocityX: -101 }]);
+    });
+    await advancePageTransition();
+
+    expect(commitVirtualIndexOnly).toHaveBeenCalledWith(1);
+  });
+
+  it('uses custom thresholds for previous-page movement', async () => {
+    jest.useFakeTimers();
+
+    const commitVirtualIndexOnly = jest.fn();
+    const { result } = await renderPagingGesture(
+      createPagingOptions({
+        commitVirtualIndexOnly,
+        currentIndex: 1,
+        horizontalSwipeDistanceThresholdRatio: 0.5,
+        horizontalSwipeVelocityThreshold: 100_000,
+        initialPage: 0,
+      }),
+    );
+
+    await act(async () => {
+      fireGestureHandler(result.horizontalPagingGesture, [{ translationX: 161, velocityX: 0 }]);
+    });
+    await advancePageTransition();
+
+    expect(commitVirtualIndexOnly).toHaveBeenCalledWith(-1);
+  });
+
+  it('disables the pan gesture when horizontal swipe is disabled', async () => {
+    const { result } = await renderHook(() =>
+      useGestureViewerPaging(createPagingOptions({ horizontalSwipeEnabled: false })),
+    );
+    const gestureConfig = result.current.horizontalPagingGesture.config;
+
+    expect(gestureConfig.enabled).toBe(false);
   });
 });

--- a/src/gestureViewerPaging.ts
+++ b/src/gestureViewerPaging.ts
@@ -9,6 +9,21 @@ export type HorizontalPagingTarget =
       kind: 'settle';
     };
 
+export function normalizeHorizontalSwipeThreshold(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+
+  return fallback;
+}
+
 export function resolveHorizontalSwipeDirection(
   translationX: number,
   velocityX: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,11 +159,28 @@ export interface GestureViewerProps<ItemT> {
     fadeBackdrop?: boolean;
   };
   /**
-   * Controls left/right swipe gestures.
-   * @remarks When `false`, horizontal gestures are disabled.
-   * @defaultValue true
+   * Horizontal swipe gesture options.
+   * @remarks Controls user-driven left/right page swipe gestures. Controller navigation and autoplay remain available when disabled.
    */
-  enableHorizontalSwipe?: boolean;
+  horizontalSwipe?: {
+    /**
+     * When `false`, user-driven horizontal page swipe gestures are disabled.
+     * @defaultValue true
+     */
+    enabled?: boolean;
+    /**
+     * Distance threshold as a ratio of viewer width.
+     * @remarks A page commits when absolute horizontal translation is strictly greater than `width * distanceThresholdRatio`, or when velocity passes `velocityThreshold`. Zero and finite values greater than `1` are accepted; negative and non-finite values fall back to the default.
+     * @defaultValue 0.25
+     */
+    distanceThresholdRatio?: number;
+    /**
+     * Horizontal velocity threshold in points per second.
+     * @remarks A page commits when absolute horizontal velocity is strictly greater than `velocityThreshold`, or when distance passes `distanceThresholdRatio`. Zero and every finite non-negative value are accepted; negative and non-finite values fall back to the default.
+     * @defaultValue 800
+     */
+    velocityThreshold?: number;
+  };
   /**
    * Only works when zoom is active, allows moving item position when zoomed.
    * @remarks When `false`, gesture movement is disabled during zoom.

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -13,8 +13,13 @@ import {
 } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 
-import { PAGE_SPRING_CONFIG } from './gestureViewerAnimation';
+import {
+  PAGE_SPRING_CONFIG,
+  SWIPE_THRESHOLD_RATIO,
+  SWIPE_VELOCITY_THRESHOLD,
+} from './gestureViewerAnimation';
 import type GestureViewerManager from './GestureViewerManager';
+import { normalizeHorizontalSwipeThreshold } from './gestureViewerPaging';
 import { registry } from './GestureViewerRegistry';
 import { resolveGestureViewerRenderWindow } from './gestureViewerRenderWindow';
 import { enableNativeTapGestures } from './platformTapGestures';
@@ -56,7 +61,7 @@ export const useGestureViewer = <ItemT>({
   dismiss,
   enableDoubleTapZoom = true,
   enablePinchZoom = true,
-  enableHorizontalSwipe = true,
+  horizontalSwipe,
   enablePanWhenZoomed = true,
   enableLoop = false,
   maxZoomScale = 2,
@@ -76,6 +81,15 @@ export const useGestureViewer = <ItemT>({
   const normalizedPageSpacing = normalizePageSpacing(pageSpacing);
   const pageStride = getPageStride(width, normalizedPageSpacing);
   const initialCurrentIndex = clampIndex(initialIndex, dataLength);
+  const horizontalSwipeEnabled = horizontalSwipe?.enabled ?? true;
+  const horizontalSwipeDistanceThresholdRatio = normalizeHorizontalSwipeThreshold(
+    horizontalSwipe?.distanceThresholdRatio,
+    SWIPE_THRESHOLD_RATIO,
+  );
+  const horizontalSwipeVelocityThreshold = normalizeHorizontalSwipeThreshold(
+    horizontalSwipe?.velocityThreshold,
+    SWIPE_VELOCITY_THRESHOLD,
+  );
 
   const dismissGestureRef = useRef<GestureType>(undefined);
 
@@ -242,8 +256,10 @@ export const useGestureViewer = <ItemT>({
     commitVirtualIndexOnly,
     currentIndex,
     dataLength,
-    enableHorizontalSwipe,
     enableLoop,
+    horizontalSwipeDistanceThresholdRatio,
+    horizontalSwipeEnabled,
+    horizontalSwipeVelocityThreshold,
     initialPage: initialCurrentIndex,
     isPinching,
     isRotated,

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -7,8 +7,6 @@ import {
   EDGE_RESISTANCE,
   PAGE_SPRING_CONFIG,
   PAGE_TRANSITION_CONFIG,
-  SWIPE_THRESHOLD_RATIO,
-  SWIPE_VELOCITY_THRESHOLD,
 } from './gestureViewerAnimation';
 import {
   applyHorizontalEdgeResistance,
@@ -22,8 +20,10 @@ type UseGestureViewerPagingOptions = {
   commitVirtualIndexOnly: (targetVirtualIndex: number) => void;
   currentIndex: number;
   dataLength: number;
-  enableHorizontalSwipe: boolean;
   enableLoop: boolean;
+  horizontalSwipeDistanceThresholdRatio: number;
+  horizontalSwipeEnabled: boolean;
+  horizontalSwipeVelocityThreshold: number;
   initialPage: number;
   isPinching: boolean;
   isRotated: boolean;
@@ -42,8 +42,10 @@ export function useGestureViewerPaging({
   commitVirtualIndexOnly,
   currentIndex,
   dataLength,
-  enableHorizontalSwipe,
   enableLoop,
+  horizontalSwipeDistanceThresholdRatio,
+  horizontalSwipeEnabled,
+  horizontalSwipeVelocityThreshold,
   initialPage,
   isPinching,
   isRotated,
@@ -144,7 +146,7 @@ export function useGestureViewerPaging({
 
   const horizontalPagingGesture = useMemo(() => {
     const canSwipe =
-      enableHorizontalSwipe &&
+      horizontalSwipeEnabled &&
       dataLength > 1 &&
       !isTriggerOpening &&
       !isZoomed &&
@@ -213,8 +215,8 @@ export function useGestureViewerPaging({
           event.translationX,
           event.velocityX,
           width,
-          SWIPE_THRESHOLD_RATIO,
-          SWIPE_VELOCITY_THRESHOLD,
+          horizontalSwipeDistanceThresholdRatio,
+          horizontalSwipeVelocityThreshold,
         );
 
         if (direction === 0) {
@@ -275,8 +277,10 @@ export function useGestureViewerPaging({
     completeAnimatedVirtualPage,
     currentIndex,
     dataLength,
-    enableHorizontalSwipe,
     enableLoop,
+    horizontalSwipeDistanceThresholdRatio,
+    horizontalSwipeEnabled,
+    horizontalSwipeVelocityThreshold,
     isTriggerOpening,
     isPinching,
     isRotated,


### PR DESCRIPTION
## Summary

- replace the boolean `enableHorizontalSwipe` prop with grouped `horizontalSwipe` options
- expose configurable distance and velocity thresholds for horizontal page transitions
- keep gesture disabling independent from controller navigation and autoplay
- document the breaking migration in the v3 beta English and Korean guides
- add example presets, focused regression coverage, and a standalone major changeset

## Why

Horizontal paging previously used fixed distance and velocity thresholds. Consumers could disable the gesture, but they could not tune swipe sensitivity for different products or interaction requirements.

The new object API keeps related horizontal swipe controls together without adding more top-level props.

## API

```tsx
// Before
<GestureViewer
  data={images}
  renderItem={renderImage}
  enableHorizontalSwipe={false}
/>

// After
<GestureViewer
  data={images}
  renderItem={renderImage}
  horizontalSwipe={{
    enabled: false,
    distanceThresholdRatio: 0.4,
    velocityThreshold: 1200,
  }}
/>
```

All options are optional:

| Option | Default | Behavior |
| --- | ---: | --- |
| `enabled` | `true` | Enables touch and mouse horizontal paging gestures. |
| `distanceThresholdRatio` | `0.25` | Commits after translation exceeds this ratio of viewer width. |
| `velocityThreshold` | `800` | Commits after horizontal velocity exceeds this value in points per second. |

Distance and velocity use strict `>` OR semantics. Finite non-negative values are accepted, including `0` and distance ratios greater than `1`; invalid values fall back to defaults.

When `horizontalSwipe.enabled` is `false`, controller navigation and autoplay remain available.

## Breaking Change

`enableHorizontalSwipe` is removed. Consumers using it must migrate to `horizontalSwipe.enabled`. A separate major changeset records this API change for the v3 beta release.

## Validation

- full Jest suite: 10 suites, 114 tests passed
- focused horizontal paging suites: 4 suites, 65 tests passed
- typecheck, lint, formatting, library build, docs build, and example build passed
- changeset status reports a major package bump
- iOS, Android, and web gesture smoke tests passed
- Android repeated paging recording showed no blank or black transition frames
- independent code and architecture reviews returned `APPROVE` and `CLEAR`
