### PR TITLE
feat: expose active state to renderItem

### DIFF
--- a/.changeset/expose-active-render-item.md
+++ b/.changeset/expose-active-render-item.md
@@ -1,0 +1,14 @@
+---
+'react-native-gesture-image-viewer': minor
+---
+
+Expose the committed active item through the third `renderItem` argument.
+
+```tsx
+<GestureViewer
+  data={mediaItems}
+  renderItem={(item, index, { isActive }) => <MediaItem item={item} paused={!isActive} />}
+/>
+```
+
+`isActive` is `true` for exactly one mounted virtual slot when data is present, including loop windows that contain duplicate logical indices. The current item remains active while an animated page transition is in progress, and the target becomes active only after the transition commits. Existing two-argument `renderItem` callbacks remain compatible.

--- a/docs/docs/3.x-beta/en/guide/usage/custom-components.mdx
+++ b/docs/docs/3.x-beta/en/guide/usage/custom-components.mdx
@@ -98,3 +98,25 @@ function App() {
   return <GestureViewer data={images} renderItem={renderImage} />;
 }
 ```
+
+For content such as video that should play or perform work only while it is visible, use `isActive` from the third `renderItem` argument. It is `true` only for the currently selected content. During a page transition, the previous content remains active; when the move finishes, the newly selected content becomes active. Use [`useGestureViewerState`](/guide/usage/gesture-viewer-state) instead when UI outside the item needs the global `currentIndex`.
+
+```tsx
+import type { GestureViewerRenderItemInfo } from 'react-native-gesture-image-viewer';
+
+const renderMedia = useCallback(
+  (item: MediaItem, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
+    return (
+      <Video
+        source={{ uri: item.uri }}
+        style={{ width: '100%', height: '100%' }}
+        paused={!isActive}
+        resizeMode="contain"
+      />
+    );
+  },
+  [],
+);
+
+return <GestureViewer data={mediaItems} renderItem={renderMedia} />;
+```

--- a/docs/docs/3.x-beta/en/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/3.x-beta/en/guide/usage/gesture-viewer-props.mdx
@@ -210,6 +210,14 @@ Controls the maximum zoom scale multiplier.
 [Go to source](https://github.com/saseungmin/react-native-gesture-image-viewer/blob/next/src/types.ts)
 
 ````tsx title="GestureViewerProps"
+export type GestureViewerRenderItemInfo = {
+  /**
+   * Whether the rendered item is currently active.
+   * @remarks The current item remains active during a page transition. When the transition finishes on another item, that item becomes active.
+   */
+  readonly isActive: boolean;
+};
+
 export interface GestureViewerProps<ItemT> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
@@ -237,8 +245,11 @@ export interface GestureViewerProps<ItemT> {
   onDismissStart?: () => void;
   /**
    * A callback function that is called to render the item.
+   * @param item - The item to render.
+   * @param index - The index of the item in `data`.
+   * @param info - Render state for this mounted slot.
    */
-  renderItem: (item: ItemT, index: number) => React.ReactElement;
+  renderItem: (item: ItemT, index: number, info: GestureViewerRenderItemInfo) => React.ReactElement;
   /**
    * A callback function that is called when a single tap is confirmed on the viewer content.
    * @remarks

--- a/docs/docs/3.x-beta/ko/guide/usage/custom-components.mdx
+++ b/docs/docs/3.x-beta/ko/guide/usage/custom-components.mdx
@@ -98,3 +98,25 @@ function App() {
   return <GestureViewer data={images} renderItem={renderImage} />;
 }
 ```
+
+비디오처럼 현재 표시 중인 콘텐츠에서만 재생이나 작업을 수행해야 한다면 세 번째 `renderItem` 인자의 `isActive`를 사용할 수 있습니다. 이 값은 현재 선택된 콘텐츠에서만 `true`입니다. 페이지 전환 중에는 기존 콘텐츠가 활성 상태를 유지하고, 이동이 완료되면 새로 선택된 콘텐츠가 활성화됩니다. 아이템 외부 UI에서 전역 `currentIndex`가 필요할 때는 [`useGestureViewerState`](/guide/usage/gesture-viewer-state)를 사용하세요.
+
+```tsx
+import type { GestureViewerRenderItemInfo } from 'react-native-gesture-image-viewer';
+
+const renderMedia = useCallback(
+  (item: MediaItem, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
+    return (
+      <Video
+        source={{ uri: item.uri }}
+        style={{ width: '100%', height: '100%' }}
+        paused={!isActive}
+        resizeMode="contain"
+      />
+    );
+  },
+  [],
+);
+
+return <GestureViewer data={mediaItems} renderItem={renderMedia} />;
+```

--- a/docs/docs/3.x-beta/ko/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/3.x-beta/ko/guide/usage/gesture-viewer-props.mdx
@@ -210,6 +210,14 @@ function App() {
 [Go to source](https://github.com/saseungmin/react-native-gesture-image-viewer/blob/next/src/types.ts)
 
 ````tsx title="GestureViewerProps"
+export type GestureViewerRenderItemInfo = {
+  /**
+   * 렌더링된 아이템이 현재 활성 상태인지 여부입니다.
+   * @remarks 페이지 전환 중에는 기존 아이템이 활성 상태를 유지합니다. 전환이 완료되어 다른 아이템으로 이동하면 해당 아이템이 활성화됩니다.
+   */
+  readonly isActive: boolean;
+};
+
 export interface GestureViewerProps<ItemT> {
   /**
    * 여러 개의 `GestureViewer` 인스턴스를 효율적으로 관리하고 싶다면 `id` prop을 사용해 각각의 `GestureViewer`를 구분할 수 있습니다.
@@ -237,8 +245,11 @@ export interface GestureViewerProps<ItemT> {
   onDismissStart?: () => void;
   /**
    * 아이템을 렌더링할 때 호출되는 콜백 함수입니다.
+   * @param item - 렌더링할 아이템입니다.
+   * @param index - `data` 배열에서 아이템의 인덱스입니다.
+   * @param info - 마운트된 이 slot의 렌더링 상태입니다.
    */
-  renderItem: (item: ItemT, index: number) => React.ReactElement;
+  renderItem: (item: ItemT, index: number, info: GestureViewerRenderItemInfo) => React.ReactElement;
   /**
    * 뷰어 콘텐츠에서 싱글 탭이 확정되었을 때 호출되는 콜백 함수입니다.
    * @remarks

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -6,6 +6,7 @@ import {
   GestureTrigger,
   GestureViewer,
   type GestureViewerProps,
+  type GestureViewerRenderItemInfo,
   useGestureViewerController,
   useGestureViewerEvent,
   useGestureViewerState,
@@ -119,16 +120,21 @@ function Example() {
     }
   });
 
-  const renderImage = useCallback((imageUrl: string) => {
-    return (
-      <Image
-        source={{ uri: imageUrl }}
-        style={{ width: '100%', height: '100%' }}
-        pointerEvents="none"
-        contentFit="contain"
-      />
-    );
-  }, []);
+  const renderImage = useCallback(
+    (imageUrl: string, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
+      return (
+        <Image
+          accessibilityLabel={isActive ? 'Current image' : undefined}
+          accessible={isActive}
+          contentFit="contain"
+          pointerEvents="none"
+          source={{ uri: imageUrl }}
+          style={{ width: '100%', height: '100%' }}
+        />
+      );
+    },
+    [],
+  );
 
   return (
     <View style={styles.container}>

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { StyleSheet, useWindowDimensions, View, type ViewStyle } from 'react-native';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 import Animated, {
@@ -18,7 +18,7 @@ type RenderWindowSlotViewProps<ItemT> = {
   height: number;
   isActive: boolean;
   pageStride: number;
-  renderItem: (item: ItemT, index: number) => ReactElement;
+  renderItem: GestureViewerProps<ItemT>['renderItem'];
   slot: RenderWindowSlot<ItemT>;
   visualPage: SharedValue<number>;
   width: number;
@@ -51,7 +51,7 @@ function RenderWindowSlotView<ItemT>({
     >
       <Animated.View style={[styles.page, isActive && animatedStyle]}>
         <View style={[styles.item, { height, width }]}>
-          {renderItem(slot.item, slot.logicalIndex)}
+          {renderItem(slot.item, slot.logicalIndex, { isActive })}
         </View>
       </Animated.View>
     </Animated.View>

--- a/src/__tests__/GestureViewer.integration.test.tsx
+++ b/src/__tests__/GestureViewer.integration.test.tsx
@@ -41,6 +41,9 @@ const data = ['first', 'second', 'third', 'fourth'];
 
 let controller: GestureViewerController | null = null;
 
+type RenderedGestureViewer = Awaited<ReturnType<typeof render>>;
+type ActiveState = 'active' | 'inactive';
+
 type HarnessProps = {
   autoPlay?: boolean;
   autoPlayInterval?: number;
@@ -49,7 +52,9 @@ type HarnessProps = {
   horizontalSwipe?: GestureViewerProps<string | undefined>['horizontalSwipe'];
   initialIndex?: number;
   onSingleTap?: (event: { x: number; y: number; index: number; item: string | undefined }) => void;
+  renderItem?: GestureViewerProps<string | undefined>['renderItem'];
   viewerId: string;
+  windowSize?: number;
 };
 
 function Harness({
@@ -60,7 +65,9 @@ function Harness({
   horizontalSwipe,
   initialIndex = 0,
   onSingleTap,
+  renderItem,
   viewerId,
+  windowSize,
 }: HarnessProps) {
   controller = useGestureViewerController(viewerId);
   const state = useGestureViewerState(viewerId);
@@ -80,9 +87,23 @@ function Harness({
         id={viewerId}
         initialIndex={initialIndex}
         onSingleTap={onSingleTap}
-        renderItem={(item, index) => <Text testID={`${viewerId}-item-${index}`}>{item}</Text>}
+        renderItem={
+          renderItem ?? ((item, index) => <Text testID={`${viewerId}-item-${index}`}>{item}</Text>)
+        }
         width={320}
+        windowSize={windowSize}
       />
+    </>
+  );
+}
+
+function createActiveStateRenderer(
+  viewerId: string,
+): GestureViewerProps<string | undefined>['renderItem'] {
+  return (item, index, { isActive }) => (
+    <>
+      <Text>{item}</Text>
+      <Text testID={`${viewerId}-active-${index}`}>{isActive ? 'active' : 'inactive'}</Text>
     </>
   );
 }
@@ -95,17 +116,39 @@ function getController() {
   return controller;
 }
 
-async function expectState(
-  rendered: Awaited<ReturnType<typeof render>>,
-  viewerId: string,
-  state: string,
-) {
+async function expectState(rendered: RenderedGestureViewer, viewerId: string, state: string) {
   await waitFor(() => {
     const children = rendered.getByTestId(`${viewerId}-state`).props.children;
     const stateText = Array.isArray(children) ? children.join('') : children;
 
     expect(stateText).toBe(state);
   });
+}
+
+function expectActiveState(
+  rendered: RenderedGestureViewer,
+  viewerId: string,
+  index: number,
+  activeState: ActiveState,
+): void {
+  expect(rendered.getByTestId(`${viewerId}-active-${index}`).props.children).toBe(activeState);
+}
+
+function expectActiveSlotCounts(
+  rendered: RenderedGestureViewer,
+  viewerId: string,
+  index: number,
+  expectedCounts: Record<ActiveState, number>,
+): void {
+  const slots = rendered.getAllByTestId(`${viewerId}-active-${index}`);
+
+  expect(slots).toHaveLength(expectedCounts.active + expectedCounts.inactive);
+  expect(slots.filter((slot) => slot.props.children === 'active')).toHaveLength(
+    expectedCounts.active,
+  );
+  expect(slots.filter((slot) => slot.props.children === 'inactive')).toHaveLength(
+    expectedCounts.inactive,
+  );
 }
 
 describe('GestureViewer render-window integration', () => {
@@ -129,6 +172,102 @@ describe('GestureViewer render-window integration', () => {
     expect(rendered.getByText('third')).toBeTruthy();
     expect(rendered.getByText('fourth')).toBeTruthy();
     expect(rendered.queryByText('first')).toBeNull();
+  });
+
+  it('provides active state for the committed render-window slot', async () => {
+    const viewerId = 'active-state';
+    const rendered = await render(
+      <Harness
+        initialIndex={1}
+        renderItem={createActiveStateRenderer(viewerId)}
+        viewerId={viewerId}
+      />,
+    );
+
+    await expectState(rendered, viewerId, '1/4');
+
+    expectActiveState(rendered, viewerId, 0, 'inactive');
+    expectActiveState(rendered, viewerId, 1, 'active');
+    expectActiveState(rendered, viewerId, 2, 'inactive');
+
+    await act(async () => {
+      getController().goToIndex(2, { animated: false });
+    });
+
+    await expectState(rendered, viewerId, '2/4');
+
+    expectActiveState(rendered, viewerId, 1, 'inactive');
+    expectActiveState(rendered, viewerId, 2, 'active');
+    expectActiveState(rendered, viewerId, 3, 'inactive');
+  });
+
+  it('keeps the current item active until animated navigation commits', async () => {
+    jest.useFakeTimers();
+
+    const viewerId = 'active-state-transition';
+    const rendered = await render(
+      <Harness
+        initialIndex={1}
+        renderItem={createActiveStateRenderer(viewerId)}
+        viewerId={viewerId}
+      />,
+    );
+
+    await expectState(rendered, viewerId, '1/4');
+
+    await act(async () => {
+      getController().goToNext();
+    });
+
+    expectActiveState(rendered, viewerId, 1, 'active');
+    expectActiveState(rendered, viewerId, 2, 'inactive');
+
+    await act(async () => {
+      jest.advanceTimersByTime(PAGE_TRANSITION_CONFIG.duration);
+    });
+
+    await expectState(rendered, viewerId, '2/4');
+
+    expectActiveState(rendered, viewerId, 1, 'inactive');
+    expectActiveState(rendered, viewerId, 2, 'active');
+  });
+
+  it('keeps exactly one virtual slot active when loop mode repeats a logical item', async () => {
+    const viewerId = 'active-state-loop';
+    const rendered = await render(
+      <Harness
+        data={['first', 'second']}
+        enableLoop
+        renderItem={createActiveStateRenderer(viewerId)}
+        viewerId={viewerId}
+        windowSize={5}
+      />,
+    );
+
+    await expectState(rendered, viewerId, '0/2');
+
+    expectActiveSlotCounts(rendered, viewerId, 0, { active: 1, inactive: 2 });
+    expectActiveSlotCounts(rendered, viewerId, 1, { active: 0, inactive: 2 });
+  });
+
+  it('renders no active slot for empty data and one active slot for a single item', async () => {
+    const viewerId = 'active-state-data-size';
+    const renderItem = jest.fn(createActiveStateRenderer(viewerId));
+    const rendered = await render(
+      <Harness data={[]} renderItem={renderItem} viewerId={viewerId} />,
+    );
+
+    await expectState(rendered, viewerId, '0/0');
+    expect(renderItem).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await rendered.rerender(
+        <Harness data={['only']} renderItem={renderItem} viewerId={viewerId} />,
+      );
+    });
+
+    await expectState(rendered, viewerId, '0/1');
+    expectActiveState(rendered, viewerId, 0, 'active');
   });
 
   it('updates state and render-window slots through immediate controller navigation', async () => {
@@ -200,17 +339,21 @@ describe('GestureViewer render-window integration', () => {
   it('keeps autoplay available when horizontal swipe is disabled', async () => {
     jest.useFakeTimers();
 
+    const viewerId = 'autoplay-locked-swipe';
+
     const rendered = await render(
       <Harness
         autoPlay
         autoPlayInterval={1000}
         data={['first', 'second']}
         horizontalSwipe={{ enabled: false }}
-        viewerId="autoplay-locked-swipe"
+        renderItem={createActiveStateRenderer(viewerId)}
+        viewerId={viewerId}
       />,
     );
 
-    await expectState(rendered, 'autoplay-locked-swipe', '0/2');
+    await expectState(rendered, viewerId, '0/2');
+    expectActiveState(rendered, viewerId, 0, 'active');
 
     await act(async () => {
       jest.advanceTimersByTime(1000);
@@ -220,7 +363,9 @@ describe('GestureViewer render-window integration', () => {
       jest.advanceTimersByTime(PAGE_TRANSITION_CONFIG.duration);
     });
 
-    await expectState(rendered, 'autoplay-locked-swipe', '1/2');
+    await expectState(rendered, viewerId, '1/2');
+    expectActiveState(rendered, viewerId, 0, 'inactive');
+    expectActiveState(rendered, viewerId, 1, 'active');
   });
 
   it('preserves tap events for explicit undefined items', async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ export type {
   GestureViewerEventData,
   GestureViewerEventType,
   GestureViewerProps,
+  GestureViewerRenderItemInfo,
   GestureViewerState,
   GestureViewerSingleTapEvent,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,14 @@ export type GestureViewerSingleTapEvent<ItemT> = {
   item: ItemT;
 };
 
+export type GestureViewerRenderItemInfo = {
+  /**
+   * Whether the rendered item is currently active.
+   * @remarks The current item remains active during a page transition. When the transition finishes on another item, that item becomes active.
+   */
+  readonly isActive: boolean;
+};
+
 export type GestureViewerDismissDirection = 'down' | 'up' | 'both';
 
 export interface TriggerAnimationConfig extends WithTimingConfig {
@@ -62,8 +70,11 @@ export interface GestureViewerProps<ItemT> {
   onDismissStart?: () => void;
   /**
    * A callback function that is called to render the item.
+   * @param item - The item to render.
+   * @param index - The index of the item in `data`.
+   * @param info - Render state for this mounted slot.
    */
-  renderItem: (item: ItemT, index: number) => React.ReactElement;
+  renderItem: (item: ItemT, index: number, info: GestureViewerRenderItemInfo) => React.ReactElement;
   /**
    * A callback function that is called when a single tap is confirmed on the viewer content.
    * @remarks


### PR DESCRIPTION
## Summary

- add `GestureViewerRenderItemInfo.isActive` as the third `renderItem` argument
- keep the current item active during a page transition and activate the target after it finishes
- preserve compatibility with existing two-argument render callbacks
- document video playback usage in the English and Korean v3 beta guides
- add a minor changeset for the public API addition

## API

```tsx
const renderItem = (item, index, { isActive }) => (
  <Video source={{ uri: item.uri }} paused={!isActive} />
);
```

Use `useGestureViewerState` when UI outside the rendered item needs the global `currentIndex`.

## Verification

- `pnpm test --runInBand` (10 suites, 118 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm docs:build`
- `git diff --cached --check`

## Testing gap

- Physical iOS and Android devices were not tested.