### PR TITLE
fix: prevent duplicate prerelease publish attempts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Setup npm for trusted publishing
-        run: npm install -g npm@latest
-
       - name: Build
         run: pnpm build
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.31.0",
+    "@changesets/cli": "^2.31.1",
     "@commitlint/config-conventional": "^21.0.2",
     "@evilmartians/lefthook": "^2.1.9",
     "@react-native/babel-preset": "0.85.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       '@changesets/cli':
-        specifier: ^2.31.0
-        version: 2.31.0(@types/node@24.12.4)
+        specifier: ^2.31.1
+        version: 2.31.1(@types/node@24.12.4)
       '@commitlint/config-conventional':
         specifier: ^21.0.2
         version: 21.0.2
@@ -882,8 +882,8 @@ packages:
   '@changesets/changelog-github@0.7.0':
     resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
 
-  '@changesets/cli@2.31.0':
-    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
     hasBin: true
 
   '@changesets/config@3.1.4':
@@ -5953,7 +5953,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.31.0(@types/node@24.12.4)':
+  '@changesets/cli@2.31.1(@types/node@24.12.4)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10


### PR DESCRIPTION
## Summary

- Remove the redundant `npm@latest` installation from the release workflow.
- Upgrade `@changesets/cli` from `2.31.0` to `2.31.1`.
- Keep the existing OIDC `id-token: write` permission for npm trusted publishing.

## Root cause

The release workflow installed `npm@latest`, which moved the job to npm 12. npm 12 wraps successful `npm info --json` output in an array, while Changesets 2.31.0 expected a single object. It therefore treated the already-published `3.0.0-beta.0` as unpublished, attempted to publish it again, and then failed while processing npm's duplicate-version error.

Node 24.16.0 already bundles npm 11.13.0, which meets npm trusted publishing's minimum CLI requirement. Installing another npm version in the release job is unnecessary. Changesets 2.31.1 is retained because it normalizes npm 12 registry responses if that format is encountered later.

## Impact

Release runs with no pending changesets can recognize existing prerelease versions and finish without attempting a duplicate npm publish.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check .github/workflows/release.yml package.json`
- `pnpm test --runInBand` (118 tests passed)
- Confirmed through a read-only npm 12 registry query that `3.0.0-beta.0` is already published

A live npm publish was intentionally not executed.