### PR TITLE
feat: expose active render item state in v2

### DIFF
--- a/.changeset/v2-render-item-active-state.md
+++ b/.changeset/v2-render-item-active-state.md
@@ -1,0 +1,17 @@
+---
+'react-native-gesture-image-viewer': minor
+---
+
+Expose the settled active list item through the third `renderItem` argument.
+
+```tsx
+<GestureViewer
+  data={mediaItems}
+  renderItem={(item, index, { isActive }) => <MediaItem item={item} paused={!isActive} />}
+/>
+```
+
+`isActive` is `true` for exactly one rendered list cell when data is present. The current item
+remains active while a page transition is in progress, and the target becomes active only after the
+transition settles. Loop sentinels resolve to the canonical list cell, and existing two-argument
+`renderItem` callbacks remain compatible.

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -9,6 +9,7 @@ import {
   useGestureViewerController,
   useGestureViewerEvent,
   useGestureViewerState,
+  type GestureViewerRenderItemInfo,
 } from 'react-native-gesture-image-viewer';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -68,16 +69,19 @@ function Example() {
     }
   });
 
-  const renderImage = useCallback((imageUrl: string) => {
-    return (
-      <Image
-        source={{ uri: imageUrl }}
-        style={{ width: '100%', height: '100%' }}
-        pointerEvents="none"
-        contentFit="contain"
-      />
-    );
-  }, []);
+  const renderImage = useCallback(
+    (imageUrl: string, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
+      return (
+        <Image
+          source={{ uri: imageUrl }}
+          style={{ width: '100%', height: '100%', opacity: isActive ? 1 : 0.5 }}
+          pointerEvents="none"
+          contentFit="contain"
+        />
+      );
+    },
+    [],
+  );
 
   return (
     <View style={styles.container}>

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -50,6 +50,7 @@ export function GestureViewer<ItemT, LC>({
   const loopData = useMemo(() => createLoopData(dataRef, enableLoop), [enableLoop]);
 
   const isScrollView = isScrollViewLike(Component);
+  const isFlashList = isFlashListLike(Component);
 
   const {
     activeListIndex,
@@ -90,7 +91,7 @@ export function GestureViewer<ItemT, LC>({
   );
 
   const renderItem = useCallback(
-    ({ item, index }: { item: ItemT; index: number }) => {
+    ({ item, index, target }: { item: ItemT; index: number; target?: string }) => {
       return (
         <View
           key={isScrollView ? keyExtractor(item, index) : undefined}
@@ -103,11 +104,22 @@ export function GestureViewer<ItemT, LC>({
             styles.item,
           ]}
         >
-          {renderItemProp(item, index, { isActive: index === activeListIndex })}
+          {renderItemProp(item, index, {
+            isActive: index === activeListIndex && (!isFlashList || target !== 'Measurement'),
+          })}
         </View>
       );
     },
-    [activeListIndex, width, itemSpacing, renderItemProp, keyExtractor, isScrollView, height],
+    [
+      activeListIndex,
+      width,
+      itemSpacing,
+      renderItemProp,
+      keyExtractor,
+      isScrollView,
+      isFlashList,
+      height,
+    ],
   );
 
   const getItemLayout = useCallback(
@@ -196,7 +208,7 @@ export function GestureViewer<ItemT, LC>({
               onClick: onWebClick,
             })}
             {...(Platform.OS === 'web' &&
-              isFlashListLike(Component) && { dataSet: { 'flash-list-paging-enabled-fix': true } })}
+              isFlashList && { dataSet: { 'flash-list-paging-enabled-fix': true } })}
           >
             {isScrollView
               ? maybeWrapWithNativeScrollGesture(
@@ -215,7 +227,7 @@ export function GestureViewer<ItemT, LC>({
                       enableLoop && data.length > 1 ? initialIndex + 1 : initialIndex
                     }
                     keyExtractor={keyExtractor}
-                    {...(isFlashListLike(Component)
+                    {...(isFlashList
                       ? // NOTE - Deprecated estimatedItemSize for FlashList V2 (https://shopify.github.io/flash-list/docs/v2-changes#deprecated)
                         { estimatedItemSize: width + itemSpacing }
                       : { windowSize: 3, maxToRenderPerBatch: 3, getItemLayout })}

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -52,6 +52,7 @@ export function GestureViewer<ItemT, LC>({
   const isScrollView = isScrollViewLike(Component);
 
   const {
+    activeListIndex,
     listRef,
     isZoomed,
     isRotated,
@@ -102,11 +103,11 @@ export function GestureViewer<ItemT, LC>({
             styles.item,
           ]}
         >
-          {renderItemProp(item, index)}
+          {renderItemProp(item, index, { isActive: index === activeListIndex })}
         </View>
       );
     },
-    [width, itemSpacing, renderItemProp, keyExtractor, isScrollView, height],
+    [activeListIndex, width, itemSpacing, renderItemProp, keyExtractor, isScrollView, height],
   );
 
   const getItemLayout = useCallback(

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -92,6 +92,8 @@ export function GestureViewer<ItemT, LC>({
 
   const renderItem = useCallback(
     ({ item, index, target }: { item: ItemT; index: number; target?: string }) => {
+      const isFlashListCell = !isFlashList || target === undefined || target === 'Cell';
+
       return (
         <View
           key={isScrollView ? keyExtractor(item, index) : undefined}
@@ -105,7 +107,7 @@ export function GestureViewer<ItemT, LC>({
           ]}
         >
           {renderItemProp(item, index, {
-            isActive: index === activeListIndex && (!isFlashList || target !== 'Measurement'),
+            isActive: index === activeListIndex && isFlashListCell,
           })}
         </View>
       );

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -1,0 +1,239 @@
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  type RenderResult,
+} from '@testing-library/react-native';
+import { forwardRef, memo, useImperativeHandle, type ReactElement } from 'react';
+import {
+  Text,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  type ScrollViewProps,
+  View,
+} from 'react-native';
+
+import { GestureViewer } from '../GestureViewer';
+import { registry } from '../GestureViewerRegistry';
+
+type TestListHandle = {
+  scrollToIndex: (params: { animated: boolean; index: number }) => void;
+};
+
+type TestListProps = {
+  data?: readonly string[];
+  extraData?: unknown;
+  onMomentumScrollEnd?: ScrollViewProps['onMomentumScrollEnd'];
+  onScroll?: ScrollViewProps['onScroll'];
+  renderItem?: (info: { item: string; index: number }) => ReactElement | null;
+};
+
+const PAGE_WIDTH = 320;
+const scrollToIndex = jest.fn<
+  ReturnType<TestListHandle['scrollToIndex']>,
+  Parameters<TestListHandle['scrollToIndex']>
+>();
+
+let latestListProps: TestListProps | null = null;
+
+const TestFlashList = memo(
+  forwardRef<TestListHandle, TestListProps>(function TestFlashList(props, ref) {
+    latestListProps = props;
+    useImperativeHandle(ref, () => ({ scrollToIndex }), []);
+
+    const itemOccurrences = new Map<string, number>();
+
+    return (
+      <View>
+        {props.data?.map((item, index) => {
+          const occurrence = itemOccurrences.get(item) ?? 0;
+
+          itemOccurrences.set(item, occurrence + 1);
+
+          return <View key={`${item}-${occurrence}`}>{props.renderItem?.({ item, index })}</View>;
+        })}
+      </View>
+    );
+  }),
+);
+
+TestFlashList.displayName = 'FlashList';
+
+function getListProps(): TestListProps {
+  if (!latestListProps) {
+    throw new Error('The test list has not rendered');
+  }
+
+  return latestListProps;
+}
+
+function createScrollEvent(offsetX: number): NativeSyntheticEvent<NativeScrollEvent> {
+  return {
+    nativeEvent: {
+      contentOffset: { x: offsetX, y: 0 },
+    },
+  } as NativeSyntheticEvent<NativeScrollEvent>;
+}
+
+function ActiveItem({ index, isActive }: { index: number; isActive: boolean }): ReactElement {
+  return <Text testID={`active-${index}`}>{isActive ? 'active' : 'inactive'}</Text>;
+}
+
+function expectActiveStates(states: Array<'active' | 'inactive'>): void {
+  states.forEach((state, index) => {
+    expect(screen.getByTestId(`active-${index}`).props.children).toBe(state);
+  });
+}
+
+async function renderActiveViewer({
+  data = ['first', 'second', 'third'],
+  enableLoop = false,
+  id,
+  initialIndex = 0,
+}: {
+  data?: string[];
+  enableLoop?: boolean;
+  id: string;
+  initialIndex?: number;
+}): Promise<RenderResult> {
+  return render(
+    <GestureViewer
+      data={data}
+      enableLoop={enableLoop}
+      height={480}
+      id={id}
+      initialIndex={initialIndex}
+      ListComponent={TestFlashList}
+      renderItem={(_item, index, { isActive }) => <ActiveItem index={index} isActive={isActive} />}
+      width={PAGE_WIDTH}
+    />,
+  );
+}
+
+describe('GestureViewer renderItem active state', () => {
+  afterEach(async () => {
+    await cleanup();
+    latestListProps = null;
+    scrollToIndex.mockClear();
+  });
+
+  it('marks only the initial list cell as active', async () => {
+    await renderActiveViewer({ id: 'initial-active', initialIndex: 1 });
+
+    expectActiveStates(['inactive', 'active', 'inactive']);
+  });
+
+  it('keeps the current cell active until native momentum settles', async () => {
+    await renderActiveViewer({ id: 'native-active' });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH));
+    });
+
+    expectActiveStates(['active', 'inactive', 'inactive']);
+
+    await act(async () => {
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH));
+    });
+
+    expectActiveStates(['inactive', 'active', 'inactive']);
+  });
+
+  it('waits for programmatic scrolling to settle before activating the target cell', async () => {
+    const id = 'programmatic-active';
+
+    await renderActiveViewer({ id });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+    });
+
+    await act(async () => {
+      registry.getManager(id)?.goToIndex(2);
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ animated: true, index: 2 });
+    expectActiveStates(['active', 'inactive', 'inactive']);
+
+    await act(async () => {
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expectActiveStates(['inactive', 'inactive', 'active']);
+  });
+
+  it('activates one canonical cell after settling through a loop sentinel', async () => {
+    await renderActiveViewer({
+      data: ['first', 'second'],
+      enableLoop: true,
+      id: 'loop-active',
+      initialIndex: 1,
+    });
+
+    expectActiveStates(['inactive', 'inactive', 'active', 'inactive']);
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 3));
+    });
+
+    expectActiveStates(['inactive', 'inactive', 'active', 'inactive']);
+
+    await act(async () => {
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 3));
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    expectActiveStates(['inactive', 'active', 'inactive', 'inactive']);
+  });
+
+  it('keeps one cell active during a programmatic loop transition', async () => {
+    const id = 'programmatic-loop-active';
+
+    await renderActiveViewer({
+      data: ['first', 'second'],
+      enableLoop: true,
+      id,
+      initialIndex: 1,
+    });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+    });
+
+    await act(async () => {
+      registry.getManager(id)?.goToNext();
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ animated: true, index: 3 });
+    expectActiveStates(['inactive', 'inactive', 'active', 'inactive']);
+
+    await act(async () => {
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 3));
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    expectActiveStates(['inactive', 'active', 'inactive', 'inactive']);
+  });
+
+  it('keeps two-argument render callbacks and consumer extraData intact', async () => {
+    const extraData = { selected: 'consumer-value' };
+
+    await render(
+      <GestureViewer
+        data={['first', 'second']}
+        height={480}
+        id="callback-compatibility"
+        ListComponent={TestFlashList}
+        listProps={{ extraData }}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(screen.getByText('0:first')).toBeTruthy();
+    expect(screen.getByText('1:second')).toBeTruthy();
+    expect(getListProps().extraData).toBe(extraData);
+  });
+});

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -249,6 +249,7 @@ describe('GestureViewer renderItem active state', () => {
     });
 
     expectActiveStates(['inactive', 'inactive', 'active', 'inactive']);
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
   });
 
   it('keeps FlashList measurement renders inactive', async () => {

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -30,6 +30,7 @@ type TestListProps = {
   onScroll?: ScrollViewProps['onScroll'];
   renderItem?: (info: { item: string; index: number; target?: string }) => ReactElement | null;
   renderMeasurement?: boolean;
+  renderStickyHeader?: boolean;
 };
 
 const PAGE_WIDTH = 320;
@@ -59,6 +60,11 @@ const TestFlashList = memo(
         {props.renderMeasurement && props.data?.[0] !== undefined ? (
           <View testID="measurement-render">
             {props.renderItem?.({ item: props.data[0], index: 0, target: 'Measurement' })}
+          </View>
+        ) : null}
+        {props.renderStickyHeader && props.data?.[0] !== undefined ? (
+          <View testID="sticky-header-render">
+            {props.renderItem?.({ item: props.data[0], index: 0, target: 'StickyHeader' })}
           </View>
         ) : null}
       </View>
@@ -252,14 +258,14 @@ describe('GestureViewer renderItem active state', () => {
     expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
   });
 
-  it('keeps FlashList measurement renders inactive', async () => {
+  it('keeps FlashList measurement and sticky header renders inactive', async () => {
     await render(
       <GestureViewer
         data={['first', 'second']}
         height={480}
         id="measurement-active"
         ListComponent={TestFlashList}
-        listProps={{ renderMeasurement: true }}
+        listProps={{ renderMeasurement: true, renderStickyHeader: true }}
         renderItem={(_item, index, { isActive }) => (
           <ActiveItem index={index} isActive={isActive} />
         )}
@@ -268,8 +274,10 @@ describe('GestureViewer renderItem active state', () => {
     );
 
     const measurement = within(screen.getByTestId('measurement-render'));
+    const stickyHeader = within(screen.getByTestId('sticky-header-render'));
 
     expect(measurement.getByTestId('active-0').props.children).toBe('inactive');
+    expect(stickyHeader.getByTestId('active-0').props.children).toBe('inactive');
     expect(screen.getAllByText('active')).toHaveLength(1);
   });
 

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
   type RenderResult,
 } from '@testing-library/react-native';
 import { forwardRef, memo, useImperativeHandle, type ReactElement } from 'react';
@@ -27,7 +28,8 @@ type TestListProps = {
   extraData?: unknown;
   onMomentumScrollEnd?: ScrollViewProps['onMomentumScrollEnd'];
   onScroll?: ScrollViewProps['onScroll'];
-  renderItem?: (info: { item: string; index: number }) => ReactElement | null;
+  renderItem?: (info: { item: string; index: number; target?: string }) => ReactElement | null;
+  renderMeasurement?: boolean;
 };
 
 const PAGE_WIDTH = 320;
@@ -54,6 +56,11 @@ const TestFlashList = memo(
 
           return <View key={`${item}-${occurrence}`}>{props.renderItem?.({ item, index })}</View>;
         })}
+        {props.renderMeasurement && props.data?.[0] !== undefined ? (
+          <View testID="measurement-render">
+            {props.renderItem?.({ item: props.data[0], index: 0, target: 'Measurement' })}
+          </View>
+        ) : null}
       </View>
     );
   }),
@@ -215,6 +222,54 @@ describe('GestureViewer renderItem active state', () => {
 
     expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
     expectActiveStates(['inactive', 'active', 'inactive', 'inactive']);
+  });
+
+  it('activates the settled cell when a programmatic loop transition stops before a sentinel', async () => {
+    const id = 'interrupted-programmatic-loop-active';
+
+    await renderActiveViewer({
+      data: ['first', 'second'],
+      enableLoop: true,
+      id,
+    });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+    });
+
+    await act(async () => {
+      registry.getManager(id)?.goToPrevious();
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ animated: true, index: 0 });
+    expectActiveStates(['inactive', 'active', 'inactive', 'inactive']);
+
+    await act(async () => {
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expectActiveStates(['inactive', 'inactive', 'active', 'inactive']);
+  });
+
+  it('keeps FlashList measurement renders inactive', async () => {
+    await render(
+      <GestureViewer
+        data={['first', 'second']}
+        height={480}
+        id="measurement-active"
+        ListComponent={TestFlashList}
+        listProps={{ renderMeasurement: true }}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    const measurement = within(screen.getByTestId('measurement-render'));
+
+    expect(measurement.getByTestId('active-0').props.children).toBe('inactive');
+    expect(screen.getAllByText('active')).toHaveLength(1);
   });
 
   it('keeps two-argument render callbacks and consumer extraData intact', async () => {

--- a/src/__tests__/useGestureViewerInitialScroll.test.tsx
+++ b/src/__tests__/useGestureViewerInitialScroll.test.tsx
@@ -143,5 +143,17 @@ describe('useGestureViewer initial scroll scheduling', () => {
       animated: false,
       index: 0,
     });
+
+    await rerender(
+      <GestureViewer
+        data={[]}
+        height={480}
+        ListComponent={TestFlashList}
+        renderItem={renderItem}
+        width={400}
+      />,
+    );
+
+    expect(scrollToIndex).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/useGestureViewerInitialScroll.test.tsx
+++ b/src/__tests__/useGestureViewerInitialScroll.test.tsx
@@ -95,4 +95,53 @@ describe('useGestureViewer initial scroll scheduling', () => {
       index: 2,
     });
   });
+
+  it('scrolls to the initial page when the data length changes', async () => {
+    idleGlobal.requestIdleCallback = jest.fn((callback: () => void) => {
+      callback();
+      return 10;
+    });
+    idleGlobal.cancelIdleCallback = jest.fn();
+
+    const renderItem = (item: string) => <Text>{item}</Text>;
+    const { rerender } = await render(
+      <GestureViewer
+        data={['first', 'second', 'third']}
+        height={480}
+        ListComponent={TestFlashList}
+        renderItem={renderItem}
+        width={320}
+      />,
+    );
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    await rerender(
+      <GestureViewer
+        data={['first', 'second', 'third']}
+        height={480}
+        ListComponent={TestFlashList}
+        renderItem={renderItem}
+        width={400}
+      />,
+    );
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    await rerender(
+      <GestureViewer
+        data={['first', 'second', 'third', 'fourth']}
+        height={480}
+        ListComponent={TestFlashList}
+        renderItem={renderItem}
+        width={400}
+      />,
+    );
+
+    expect(scrollToIndex).toHaveBeenCalledTimes(1);
+    expect(scrollToIndex).toHaveBeenCalledWith({
+      animated: false,
+      index: 0,
+    });
+  });
 });

--- a/src/__tests__/useGestureViewerPaging.test.tsx
+++ b/src/__tests__/useGestureViewerPaging.test.tsx
@@ -2,11 +2,11 @@ import { act, renderHook } from '@testing-library/react-native';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 
+import { useGestureViewerPaging } from '../useGestureViewerPaging';
 import type {
   UseGestureViewerPagingArgs,
   UseGestureViewerPagingResult,
 } from '../useGestureViewerPaging.types';
-import { useGestureViewerPaging } from '../useGestureViewerPaging.web';
 
 function createScrollEvent(offsetX: number): NativeSyntheticEvent<NativeScrollEvent> {
   return {
@@ -52,49 +52,41 @@ function createArgs(
   };
 }
 
-describe('useGestureViewerPaging web active state', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
-  });
-
-  it('keeps the previous cell active until the web scroll settles', async () => {
-    const syncCurrentIndex = jest.fn();
-    const { result } = await renderHook(() =>
-      useGestureViewerPaging(createArgs({ syncCurrentIndex })),
+describe('useGestureViewerPaging native active state', () => {
+  it('resets the active cell when the page layout changes', async () => {
+    const { rerender, result } = await renderHook<UseGestureViewerPagingResult, { width: number }>(
+      ({ width }) => useGestureViewerPaging(createArgs({ adjustedInitialIndex: 1, width })),
+      {
+        initialProps: { width: 320 },
+      },
     );
 
-    expect(result.current.activeListIndex).toBe(0);
-
     await act(async () => {
-      result.current.onScroll?.(createScrollEvent(320));
+      result.current.onMomentumScrollEnd?.(createScrollEvent(640));
     });
 
-    expect(result.current.activeListIndex).toBe(0);
+    expect(result.current.activeListIndex).toBe(2);
 
-    await act(async () => {
-      jest.advanceTimersByTime(180);
-    });
+    await rerender({ width: 400 });
 
-    expect(syncCurrentIndex).toHaveBeenCalledWith(1);
     expect(result.current.activeListIndex).toBe(1);
   });
 
-  it('resets the active cell when the adjusted initial index changes', async () => {
-    const { rerender, result } = await renderHook<
-      UseGestureViewerPagingResult,
-      { adjustedInitialIndex: number }
-    >(({ adjustedInitialIndex }) => useGestureViewerPaging(createArgs({ adjustedInitialIndex })), {
-      initialProps: { adjustedInitialIndex: 0 },
+  it('keeps the settled cell when a layout change does not reschedule initial scrolling', async () => {
+    const { rerender, result } = await renderHook<UseGestureViewerPagingResult, { width: number }>(
+      ({ width }) => useGestureViewerPaging(createArgs({ width })),
+      {
+        initialProps: { width: 320 },
+      },
+    );
+
+    await act(async () => {
+      result.current.onMomentumScrollEnd?.(createScrollEvent(640));
     });
 
-    expect(result.current.activeListIndex).toBe(0);
+    expect(result.current.activeListIndex).toBe(2);
 
-    await rerender({ adjustedInitialIndex: 2 });
+    await rerender({ width: 400 });
 
     expect(result.current.activeListIndex).toBe(2);
   });
@@ -108,8 +100,7 @@ describe('useGestureViewerPaging web active state', () => {
     });
 
     await act(async () => {
-      result.current.onScroll?.(createScrollEvent(640));
-      jest.advanceTimersByTime(180);
+      result.current.onMomentumScrollEnd?.(createScrollEvent(640));
     });
 
     expect(result.current.activeListIndex).toBe(2);
@@ -117,30 +108,5 @@ describe('useGestureViewerPaging web active state', () => {
     await rerender({ dataLength: 1 });
 
     expect(result.current.activeListIndex).toBe(0);
-  });
-
-  it('normalizes a loop sentinel to the canonical cell after settling', async () => {
-    const scrollTo = jest.fn();
-    const syncCurrentIndex = jest.fn();
-    const { result } = await renderHook(() =>
-      useGestureViewerPaging(
-        createArgs({
-          adjustedInitialIndex: 1,
-          dataLength: 2,
-          enableLoop: true,
-          scrollTo,
-          syncCurrentIndex,
-        }),
-      ),
-    );
-
-    await act(async () => {
-      result.current.onScroll?.(createScrollEvent(0));
-      jest.advanceTimersByTime(180);
-    });
-
-    expect(scrollTo).toHaveBeenCalledWith(2, false);
-    expect(syncCurrentIndex).toHaveBeenCalledWith(1);
-    expect(result.current.activeListIndex).toBe(2);
   });
 });

--- a/src/__tests__/useGestureViewerPaging.web.test.tsx
+++ b/src/__tests__/useGestureViewerPaging.web.test.tsx
@@ -1,0 +1,101 @@
+import { act, renderHook } from '@testing-library/react-native';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
+
+import type {
+  UseGestureViewerPagingArgs,
+  UseGestureViewerPagingResult,
+} from '../useGestureViewerPaging.types';
+import { useGestureViewerPaging } from '../useGestureViewerPaging.web';
+
+function createScrollEvent(offsetX: number): NativeSyntheticEvent<NativeScrollEvent> {
+  return {
+    nativeEvent: {
+      contentOffset: { x: offsetX, y: 0 },
+    },
+  } as NativeSyntheticEvent<NativeScrollEvent>;
+}
+
+function createSharedValue(value: number): SharedValue<number> {
+  return {
+    get: () => value,
+    set: jest.fn(),
+  } as unknown as SharedValue<number>;
+}
+
+function createArgs(
+  overrides: Partial<UseGestureViewerPagingArgs> = {},
+): UseGestureViewerPagingArgs {
+  return {
+    adjustedInitialIndex: 0,
+    autoPlay: false,
+    autoPlayInterval: 3000,
+    currentIndex: 0,
+    dataLength: 3,
+    enableDoubleTapZoom: true,
+    enableHorizontalSwipe: true,
+    enableLoop: false,
+    height: 480,
+    isRotated: false,
+    isZoomed: false,
+    itemSpacing: 0,
+    manager: null,
+    maxZoomScale: 2,
+    scale: createSharedValue(1),
+    scrollTo: jest.fn(),
+    syncCurrentIndex: jest.fn(),
+    syncPendingIndex: jest.fn(),
+    translateX: createSharedValue(0),
+    translateY: createSharedValue(0),
+    width: 320,
+    ...overrides,
+  };
+}
+
+describe('useGestureViewerPaging web active state', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('keeps the previous cell active until the web scroll settles', async () => {
+    const syncCurrentIndex = jest.fn();
+    const { result } = await renderHook(() =>
+      useGestureViewerPaging(createArgs({ syncCurrentIndex })),
+    );
+
+    expect(result.current.activeListIndex).toBe(0);
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(320));
+    });
+
+    expect(result.current.activeListIndex).toBe(0);
+
+    await act(async () => {
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(syncCurrentIndex).toHaveBeenCalledWith(1);
+    expect(result.current.activeListIndex).toBe(1);
+  });
+
+  it('resets the active cell when the adjusted initial index changes', async () => {
+    const { rerender, result } = await renderHook<
+      UseGestureViewerPagingResult,
+      { adjustedInitialIndex: number }
+    >(({ adjustedInitialIndex }) => useGestureViewerPaging(createArgs({ adjustedInitialIndex })), {
+      initialProps: { adjustedInitialIndex: 0 },
+    });
+
+    expect(result.current.activeListIndex).toBe(0);
+
+    await rerender({ adjustedInitialIndex: 2 });
+
+    expect(result.current.activeListIndex).toBe(2);
+  });
+});

--- a/src/__tests__/useGestureViewerPaging.web.test.tsx
+++ b/src/__tests__/useGestureViewerPaging.web.test.tsx
@@ -84,6 +84,26 @@ describe('useGestureViewerPaging web active state', () => {
     expect(result.current.activeListIndex).toBe(1);
   });
 
+  it('keeps the settled cell when a layout change does not reschedule initial scrolling', async () => {
+    const { rerender, result } = await renderHook<UseGestureViewerPagingResult, { width: number }>(
+      ({ width }) => useGestureViewerPaging(createArgs({ width })),
+      {
+        initialProps: { width: 320 },
+      },
+    );
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(640));
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(result.current.activeListIndex).toBe(2);
+
+    await rerender({ width: 400 });
+
+    expect(result.current.activeListIndex).toBe(2);
+  });
+
   it('resets the active cell when the adjusted initial index changes', async () => {
     const { rerender, result } = await renderHook<
       UseGestureViewerPagingResult,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ export type {
   GestureViewerEventData,
   GestureViewerEventType,
   GestureViewerProps,
+  GestureViewerRenderItemInfo,
   GestureViewerState,
   GestureViewerSingleTapEvent,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,14 @@ export type GestureViewerSingleTapEvent<ItemT> = {
   item: ItemT;
 };
 
+export type GestureViewerRenderItemInfo = {
+  /**
+   * Whether the rendered item is currently active.
+   * @remarks The current item remains active during a page transition. When the transition finishes on another item, that item becomes active.
+   */
+  readonly isActive: boolean;
+};
+
 export type GestureViewerDismissDirection = 'down' | 'up' | 'both';
 
 export interface TriggerAnimationConfig extends WithTimingConfig {
@@ -128,8 +136,11 @@ export interface GestureViewerProps<ItemT, LC> {
   onDismissStart?: () => void;
   /**
    * A callback function that is called to render the item.
+   * @param item - The item to render.
+   * @param index - The list index of the rendered item.
+   * @param info - Render state for this list cell.
    */
-  renderItem: (item: ItemT, index: number) => React.ReactElement;
+  renderItem: (item: ItemT, index: number, info: GestureViewerRenderItemInfo) => React.ReactElement;
   /**
    * A callback function that is called when a single tap is confirmed on the viewer content.
    * @remarks

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -293,6 +293,7 @@ export const useGestureViewer = <ItemT, LC>({
 
   useEffect(() => {
     const hasDataLengthChanged = previousDataLengthRef.current !== dataLength;
+    const hasValidInitialIndex = initialIndex >= 0 && initialIndex < dataLength;
 
     previousDataLengthRef.current = dataLength;
     translateY.set(0);
@@ -302,7 +303,11 @@ export const useGestureViewer = <ItemT, LC>({
     startScale.set(1);
     rotation.set(0);
 
-    if ((!hasDataLengthChanged && adjustedInitialIndex <= 0) || !listRef.current) {
+    if (
+      !hasValidInitialIndex ||
+      (!hasDataLengthChanged && adjustedInitialIndex <= 0) ||
+      !listRef.current
+    ) {
       return;
     }
 
@@ -312,6 +317,7 @@ export const useGestureViewer = <ItemT, LC>({
   }, [
     adjustedInitialIndex,
     dataLength,
+    initialIndex,
     translateY,
     backdropOpacity,
     translateX,

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -102,6 +102,7 @@ export const useGestureViewer = <ItemT, LC>({
   const hasActiveFocal = useSharedValue(false);
 
   const dataLength = data?.length || 0;
+  const previousDataLengthRef = useRef(dataLength);
 
   const animationConfig = useMemo(
     () => ({
@@ -291,6 +292,9 @@ export const useGestureViewer = <ItemT, LC>({
   }, [manager]);
 
   useEffect(() => {
+    const hasDataLengthChanged = previousDataLengthRef.current !== dataLength;
+
+    previousDataLengthRef.current = dataLength;
     translateY.set(0);
     translateX.set(0);
     scale.set(1);
@@ -298,7 +302,7 @@ export const useGestureViewer = <ItemT, LC>({
     startScale.set(1);
     rotation.set(0);
 
-    if (adjustedInitialIndex <= 0 || !listRef.current) {
+    if ((!hasDataLengthChanged && adjustedInitialIndex <= 0) || !listRef.current) {
       return;
     }
 
@@ -307,6 +311,7 @@ export const useGestureViewer = <ItemT, LC>({
     });
   }, [
     adjustedInitialIndex,
+    dataLength,
     translateY,
     backdropOpacity,
     translateX,

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -811,32 +811,34 @@ export const useGestureViewer = <ItemT, LC>({
     return Gesture.Native().requireExternalGestureToFail(dismissGestureRef);
   }, []);
 
-  const { onMomentumScrollEnd, onScroll, onScrollBeginDrag, onWebClick } = useGestureViewerPaging({
-    adjustedInitialIndex,
-    autoPlay,
-    autoPlayInterval,
-    currentIndex,
-    dataLength,
-    enableDoubleTapZoom,
-    enableHorizontalSwipe,
-    enableLoop,
-    height,
-    isRotated,
-    isZoomed,
-    itemSpacing,
-    manager,
-    maxZoomScale,
-    onSingleTap: emitSingleTap,
-    scale,
-    scrollTo,
-    syncCurrentIndex,
-    syncPendingIndex,
-    translateX,
-    translateY,
-    width,
-  });
+  const { activeListIndex, onMomentumScrollEnd, onScroll, onScrollBeginDrag, onWebClick } =
+    useGestureViewerPaging({
+      adjustedInitialIndex,
+      autoPlay,
+      autoPlayInterval,
+      currentIndex,
+      dataLength,
+      enableDoubleTapZoom,
+      enableHorizontalSwipe,
+      enableLoop,
+      height,
+      isRotated,
+      isZoomed,
+      itemSpacing,
+      manager,
+      maxZoomScale,
+      onSingleTap: emitSingleTap,
+      scale,
+      scrollTo,
+      syncCurrentIndex,
+      syncPendingIndex,
+      translateX,
+      translateY,
+      width,
+    });
 
   return {
+    activeListIndex,
     animatedStyle,
     backdropStyle,
     dataLength,

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -91,6 +91,7 @@ export function useGestureViewerPaging({
       }
 
       if (isLoopHandled) {
+        syncCurrentIndex(realIndex);
         setActiveListIndex(jumpToIndex ?? scrollIndex);
         return;
       }

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -25,10 +25,12 @@ export function useGestureViewerPaging({
   width,
 }: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
   const [activeListIndex, setActiveListIndex] = useState(adjustedInitialIndex);
+  const activeResetItemSpacing = adjustedInitialIndex > 0 ? itemSpacing : 0;
+  const activeResetWidth = adjustedInitialIndex > 0 ? width : 0;
 
   useEffect(() => {
     setActiveListIndex(adjustedInitialIndex);
-  }, [adjustedInitialIndex]);
+  }, [adjustedInitialIndex, activeResetItemSpacing, activeResetWidth, dataLength]);
 
   useEffect(() => {
     if (
@@ -84,15 +86,12 @@ export function useGestureViewerPaging({
 
       const isLoopHandled = manager?.handleMomentumScrollEnd(scrollIndex);
 
-      if (isLoopHandled) {
-        if (needsJump && jumpToIndex !== undefined) {
-          setActiveListIndex(jumpToIndex);
-        }
-
+      if (realIndex < 0 || realIndex >= dataLength) {
         return;
       }
 
-      if (realIndex < 0 || realIndex >= dataLength) {
+      if (isLoopHandled) {
+        setActiveListIndex(jumpToIndex ?? scrollIndex);
         return;
       }
 

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
 import type {
@@ -8,6 +8,7 @@ import type {
 import { getLoopAdjustedIndex } from './utils';
 
 export function useGestureViewerPaging({
+  adjustedInitialIndex,
   autoPlay,
   autoPlayInterval,
   currentIndex,
@@ -23,6 +24,12 @@ export function useGestureViewerPaging({
   syncPendingIndex,
   width,
 }: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
+  const [activeListIndex, setActiveListIndex] = useState(adjustedInitialIndex);
+
+  useEffect(() => {
+    setActiveListIndex(adjustedInitialIndex);
+  }, [adjustedInitialIndex]);
+
   useEffect(() => {
     if (
       !autoPlay ||
@@ -69,24 +76,32 @@ export function useGestureViewerPaging({
 
       const { contentOffset } = event.nativeEvent;
       const scrollIndex = Math.round(contentOffset.x / (width + itemSpacing));
-
-      const isLoopHandled = manager?.handleMomentumScrollEnd(scrollIndex);
-
-      if (isLoopHandled) {
-        return;
-      }
-
       const { realIndex, needsJump, jumpToIndex } = getLoopAdjustedIndex(
         scrollIndex,
         dataLength,
         enableLoop,
       );
 
+      const isLoopHandled = manager?.handleMomentumScrollEnd(scrollIndex);
+
+      if (isLoopHandled) {
+        if (needsJump && jumpToIndex !== undefined) {
+          setActiveListIndex(jumpToIndex);
+        }
+
+        return;
+      }
+
+      if (realIndex < 0 || realIndex >= dataLength) {
+        return;
+      }
+
       if (needsJump && jumpToIndex !== undefined) {
         scrollTo(jumpToIndex, false);
       }
 
       syncCurrentIndex(realIndex);
+      setActiveListIndex(jumpToIndex ?? scrollIndex);
     },
     [
       dataLength,
@@ -120,6 +135,7 @@ export function useGestureViewerPaging({
   }, [manager]);
 
   return {
+    activeListIndex,
     onMomentumScrollEnd,
     onScroll,
     onScrollBeginDrag,

--- a/src/useGestureViewerPaging.types.ts
+++ b/src/useGestureViewerPaging.types.ts
@@ -34,6 +34,7 @@ export type WebClickTarget = {
 };
 
 export type UseGestureViewerPagingResult = {
+  activeListIndex: number;
   onMomentumScrollEnd?: ScrollViewProps['onMomentumScrollEnd'];
   onScroll?: ScrollViewProps['onScroll'];
   onScrollBeginDrag?: ScrollViewProps['onScrollBeginDrag'];

--- a/src/useGestureViewerPaging.web.ts
+++ b/src/useGestureViewerPaging.web.ts
@@ -51,6 +51,8 @@ export function useGestureViewerPaging({
   width,
 }: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
   const [activeListIndex, setActiveListIndex] = useState(adjustedInitialIndex);
+  const activeResetItemSpacing = adjustedInitialIndex > 0 ? itemSpacing : 0;
+  const activeResetWidth = adjustedInitialIndex > 0 ? width : 0;
   const webSingleTapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const webScrollRuntimeRef = useRef<WebScrollRuntime>({
@@ -229,21 +231,33 @@ export function useGestureViewerPaging({
     runtime.actor = 'idle';
     runtime.isAutoplayPausedByUser = false;
     runtime.lastSettledPhysicalIndex = adjustedInitialIndex;
-    runtime.latestOffsetX = adjustedInitialIndex * (width + itemSpacing);
+    runtime.latestOffsetX = adjustedInitialIndex * (activeResetWidth + activeResetItemSpacing);
     runtime.latestRawPhysicalIndex = adjustedInitialIndex;
     runtime.lastProgrammaticScrollVersion = manager?.getProgrammaticScrollVersion() ?? 0;
     setActiveListIndex(adjustedInitialIndex);
     clearWebSettleTimer();
     clearWebAutoplayResumeTimer();
   }, [
+    activeResetItemSpacing,
+    activeResetWidth,
     adjustedInitialIndex,
     clearWebAutoplayResumeTimer,
     clearWebSettleTimer,
     dataLength,
-    itemSpacing,
     manager,
-    width,
   ]);
+
+  useEffect(() => {
+    const runtime = webScrollRuntimeRef.current;
+
+    runtime.actor = 'idle';
+    runtime.isAutoplayPausedByUser = false;
+    runtime.latestOffsetX = runtime.lastSettledPhysicalIndex * (width + itemSpacing);
+    runtime.latestRawPhysicalIndex = runtime.lastSettledPhysicalIndex;
+    runtime.lastProgrammaticScrollVersion = manager?.getProgrammaticScrollVersion() ?? 0;
+    clearWebSettleTimer();
+    clearWebAutoplayResumeTimer();
+  }, [clearWebAutoplayResumeTimer, clearWebSettleTimer, itemSpacing, manager, width]);
 
   useEffect(() => {
     return () => {

--- a/src/useGestureViewerPaging.web.ts
+++ b/src/useGestureViewerPaging.web.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, type MouseEvent } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
 import type {
@@ -50,6 +50,7 @@ export function useGestureViewerPaging({
   translateY,
   width,
 }: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
+  const [activeListIndex, setActiveListIndex] = useState(adjustedInitialIndex);
   const webSingleTapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const webScrollRuntimeRef = useRef<WebScrollRuntime>({
@@ -187,6 +188,7 @@ export function useGestureViewerPaging({
       runtime.latestOffsetX = settledPhysicalIndex * (width + itemSpacing);
       runtime.actor = 'idle';
       manager?.cancelPendingLoopTransition();
+      setActiveListIndex(settledPhysicalIndex);
       syncCurrentIndex(logicalIndex);
 
       if (settledByActor === 'user') {
@@ -230,6 +232,7 @@ export function useGestureViewerPaging({
     runtime.latestOffsetX = adjustedInitialIndex * (width + itemSpacing);
     runtime.latestRawPhysicalIndex = adjustedInitialIndex;
     runtime.lastProgrammaticScrollVersion = manager?.getProgrammaticScrollVersion() ?? 0;
+    setActiveListIndex(adjustedInitialIndex);
     clearWebSettleTimer();
     clearWebAutoplayResumeTimer();
   }, [
@@ -426,6 +429,7 @@ export function useGestureViewerPaging({
   );
 
   return {
+    activeListIndex,
     onMomentumScrollEnd,
     onScroll,
     onScrollBeginDrag,

--- a/src/useGestureViewerPaging.web.ts
+++ b/src/useGestureViewerPaging.web.ts
@@ -239,6 +239,7 @@ export function useGestureViewerPaging({
     adjustedInitialIndex,
     clearWebAutoplayResumeTimer,
     clearWebSettleTimer,
+    dataLength,
     itemSpacing,
     manager,
     width,


### PR DESCRIPTION
## Summary

- expose `isActive` through the third `renderItem` argument
- keep the current cell active while paging and activate the target only after settlement
- handle native and web paging, including loop sentinel normalization
- preserve existing two-argument `renderItem` callbacks
- update the example and add a minor Changeset

## Why

Media content such as video needs a reliable lifecycle signal to pause inactive items. The existing logical `currentIndex` can change before a programmatic transition settles and cannot uniquely identify v2 loop sentinel cells, so this PR tracks the settled physical list cell separately.

## API

```tsx
<GestureViewer
  data={mediaItems}
  renderItem={(item, index, { isActive }) => (
    <MediaItem item={item} paused={!isActive} />
  )}
/>
```

Documentation is intentionally excluded because the published docs are maintained from the `next` branch.

## Validation

- `CI=true pnpm test --runInBand`: 9 suites, 42 tests passed
- `CI=true pnpm build`
- `CI=true pnpm typecheck`
- `CI=true pnpm lint`
- `CI=true pnpm format:check`
- pre-commit format, lint, and typecheck hooks

## Remaining validation

- physical iOS and Android devices
- a real installed FlashList integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `renderItem` now provides `info.isActive` so you can style the currently settled active list cell (including correct behavior during page transitions and looping).
  * Added/updated `GestureViewerRenderItemInfo` and re-exported it for typed render callbacks.
  * Existing two-argument `renderItem(item, index)` callbacks continue to work.
* **Bug Fixes**
  * Improved active-item tracking and synchronization across native/web scrolling, momentum settling, looping sentinels, and measurement rendering.
* **Tests**
  * Added/expanded coverage for initial render, scrolling, programmatic navigation, looping, measurement, and web behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->