### PR TITLE
docs: improve API discovery across versioned guides

### DIFF
--- a/docs/docs/1.x/en/index.md
+++ b/docs/docs/1.x/en/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Quick Start
-      link: /1.x/guide/getting-started/installation.html
+      link: /1.x/guide/getting-started/quick-start.html
     - theme: alt
       text: GitHub
       link: https://github.com/saseungmin/react-native-gesture-image-viewer

--- a/docs/docs/1.x/ko/index.md
+++ b/docs/docs/1.x/ko/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: 빠른 시작
-      link: /1.x/ko/guide/getting-started/installation.html
+      link: /1.x/ko/guide/getting-started/quick-start.html
     - theme: alt
       text: GitHub
       link: https://github.com/saseungmin/react-native-gesture-image-viewer

--- a/docs/docs/2.x/en/guide/usage/custom-components.mdx
+++ b/docs/docs/2.x/en/guide/usage/custom-components.mdx
@@ -113,3 +113,30 @@ function App() {
   return <GestureViewer data={images} renderItem={renderImage} />;
 }
 ```
+
+<span id="renderitem-active-state" />
+
+### `renderItem` active state (`isActive`)
+
+For content such as video that should play or perform work only while it is visible, use `isActive` from the third `renderItem` argument. It is `true` only for the currently selected content. During a page transition, the previous content remains active; when the move finishes, the newly selected content becomes active. Use [`useGestureViewerState`](/guide/usage/gesture-viewer-state) instead when UI outside the item needs the global `currentIndex`.
+
+```tsx
+import type { GestureViewerRenderItemInfo } from 'react-native-gesture-image-viewer';
+
+const renderMedia = useCallback(
+  // [!code highlight:1]
+  (item: MediaItem, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
+    return (
+      <Video
+        source={{ uri: item.uri }}
+        style={{ width: '100%', height: '100%' }}
+        paused={!isActive}
+        resizeMode="contain"
+      />
+    );
+  },
+  [],
+);
+
+return <GestureViewer data={mediaItems} renderItem={renderMedia} />;
+```

--- a/docs/docs/2.x/en/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/2.x/en/guide/usage/gesture-viewer-props.mdx
@@ -1,5 +1,9 @@
 # GestureViewer Props
 
+### `renderItem`
+
+`renderItem` renders each item in `data` and receives `isActive` through its third argument: `renderItem(item, index, { isActive })`. Use it for work that should run only on the active item, such as video playback. See [`renderItem` active state (`isActive`)](/guide/usage/custom-components#renderitem-active-state) for behavior and examples.
+
 ### `enableLoop` (default: `false`)
 
 Enables loop mode. When `true`, navigating next from the last item goes to the first item, and navigating previous from the first item goes to the last item.
@@ -135,9 +139,17 @@ Controls the maximum zoom scale multiplier.
 
 ## `GestureViewerProps` interface
 
-[Go to source](https://github.com/saseungmin/react-native-gesture-image-viewer/blob/a7b58a5fc9aa396e5b72ec1e6fe6ae27d94ed044/src/types.ts#L88)
+[Go to source](https://github.com/saseungmin/react-native-gesture-image-viewer/blob/d7981fb/src/types.ts#L112)
 
 ````tsx title="GestureViewerProps"
+export type GestureViewerRenderItemInfo = {
+  /**
+   * Whether the rendered item is currently active.
+   * @remarks The current item remains active during a page transition. When the transition finishes on another item, that item becomes active.
+   */
+  readonly isActive: boolean;
+};
+
 export interface GestureViewerProps<ItemT, LC> {
   /**
    * When you want to efficiently manage multiple `GestureViewer` instances, you can use the `id` prop to use multiple `GestureViewer` components.
@@ -165,8 +177,11 @@ export interface GestureViewerProps<ItemT, LC> {
   onDismissStart?: () => void;
   /**
    * A callback function that is called to render the item.
+   * @param item - The item to render.
+   * @param index - The list index of the rendered item.
+   * @param info - Render state for this list cell.
    */
-  renderItem: (item: ItemT, index: number) => React.ReactElement;
+  renderItem: (item: ItemT, index: number, info: GestureViewerRenderItemInfo) => React.ReactElement;
   /**
    * A callback function that is called when a single tap is confirmed on the viewer content.
    * @remarks

--- a/docs/docs/2.x/en/index.md
+++ b/docs/docs/2.x/en/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Quick Start
-      link: /guide/getting-started/installation.html
+      link: /guide/getting-started/quick-start.html
     - theme: alt
       text: GitHub
       link: https://github.com/saseungmin/react-native-gesture-image-viewer

--- a/docs/docs/2.x/ko/guide/usage/custom-components.mdx
+++ b/docs/docs/2.x/ko/guide/usage/custom-components.mdx
@@ -113,3 +113,30 @@ function App() {
   return <GestureViewer data={images} renderItem={renderImage} />;
 }
 ```
+
+<span id="renderitem-active-state" />
+
+### `renderItem` 활성 상태 (`isActive`)
+
+비디오처럼 현재 표시 중인 콘텐츠에서만 재생이나 작업을 수행해야 한다면 세 번째 `renderItem` 인자의 `isActive`를 사용할 수 있습니다. 이 값은 현재 선택된 콘텐츠에서만 `true`입니다. 페이지 전환 중에는 기존 콘텐츠가 활성 상태를 유지하고, 이동이 완료되면 새로 선택된 콘텐츠가 활성화됩니다. 아이템 외부 UI에서 전역 `currentIndex`가 필요할 때는 [`useGestureViewerState`](/guide/usage/gesture-viewer-state)를 사용하세요.
+
+```tsx
+import type { GestureViewerRenderItemInfo } from 'react-native-gesture-image-viewer';
+
+const renderMedia = useCallback(
+  // [!code highlight:1]
+  (item: MediaItem, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
+    return (
+      <Video
+        source={{ uri: item.uri }}
+        style={{ width: '100%', height: '100%' }}
+        paused={!isActive}
+        resizeMode="contain"
+      />
+    );
+  },
+  [],
+);
+
+return <GestureViewer data={mediaItems} renderItem={renderMedia} />;
+```

--- a/docs/docs/2.x/ko/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/2.x/ko/guide/usage/gesture-viewer-props.mdx
@@ -1,5 +1,9 @@
 # GestureViewer Props
 
+### `renderItem`
+
+`renderItem`은 `data`의 각 아이템을 렌더링하며, `renderItem(item, index, { isActive })` 형태로 세 번째 인자에서 활성 상태를 제공합니다. 비디오 재생처럼 활성 아이템에서만 필요한 작업을 제어할 때 사용할 수 있습니다. 동작 방식과 예시는 [`renderItem` 활성 상태 (`isActive`)](/guide/usage/custom-components#renderitem-active-state)를 참고하세요.
+
 ### `enableLoop` (기본값: `false`)
 
 루프 모드를 활성화합니다. `true`일 때 마지막 아이템에서 다음으로 가면 첫 번째로, 첫 번째에서 이전으로 가면 마지막으로 돌아갑니다.
@@ -135,9 +139,17 @@ function App() {
 
 ## `GestureViewerProps` interface
 
-[Go to source](https://github.com/saseungmin/react-native-gesture-image-viewer/blob/a7b58a5fc9aa396e5b72ec1e6fe6ae27d94ed044/src/types.ts#L88)
+[Go to source](https://github.com/saseungmin/react-native-gesture-image-viewer/blob/d7981fb/src/types.ts#L112)
 
 ````tsx title="GestureViewerProps"
+export type GestureViewerRenderItemInfo = {
+  /**
+   * 렌더링된 아이템이 현재 활성 상태인지 여부입니다.
+   * @remarks 페이지 전환 중에는 기존 아이템이 활성 상태를 유지합니다. 전환이 완료되어 다른 아이템으로 이동하면 해당 아이템이 활성화됩니다.
+   */
+  readonly isActive: boolean;
+};
+
 export interface GestureViewerProps<ItemT, LC> {
   /**
    * 여러 개의 `GestureViewer` 인스턴스를 효율적으로 관리하고 싶다면 `id` prop을 사용해 각각의 `GestureViewer`를 구분할 수 있습니다.
@@ -165,8 +177,11 @@ export interface GestureViewerProps<ItemT, LC> {
   onDismissStart?: () => void;
   /**
    * 아이템을 렌더링할 때 호출되는 콜백 함수입니다.
+   * @param item - 렌더링할 아이템입니다.
+   * @param index - 렌더링된 아이템의 리스트 인덱스입니다.
+   * @param info - 이 리스트 셀의 렌더링 상태입니다.
    */
-  renderItem: (item: ItemT, index: number) => React.ReactElement;
+  renderItem: (item: ItemT, index: number, info: GestureViewerRenderItemInfo) => React.ReactElement;
   /**
    * 뷰어 콘텐츠에서 싱글 탭이 확정되었을 때 호출되는 콜백 함수입니다.
    * @remarks

--- a/docs/docs/2.x/ko/index.md
+++ b/docs/docs/2.x/ko/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: 빠른 시작
-      link: /ko/guide/getting-started/installation.html
+      link: /ko/guide/getting-started/quick-start.html
     - theme: alt
       text: GitHub
       link: https://github.com/saseungmin/react-native-gesture-image-viewer

--- a/docs/docs/3.x-beta/en/guide/migration-from-2.x.mdx
+++ b/docs/docs/3.x-beta/en/guide/migration-from-2.x.mdx
@@ -25,7 +25,7 @@ Delete `ListComponent` and `listProps` from `GestureViewer`.
 
 ### Replace snap spacing with page spacing
 
-`enableSnapMode` and `itemSpacing` have been removed. Use `pageSpacing` when you need visible space between pages.
+`enableSnapMode` and `itemSpacing` have been removed. Use [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing) when you need visible space between pages.
 
 ```diff
 <GestureViewer
@@ -39,7 +39,7 @@ Delete `ListComponent` and `listProps` from `GestureViewer`.
 
 ### Tune the render window only when needed
 
-By default, v3 mounts three pages: previous, current, and next. Increase `windowSize` only when you need more adjacent content mounted.
+By default, v3 mounts three pages: previous, current, and next. Increase [`windowSize`](/guide/usage/gesture-viewer-props#windowsize) only when you need more adjacent content mounted.
 
 ```tsx
 <GestureViewer data={images} renderItem={renderImage} windowSize={5} />
@@ -47,7 +47,7 @@ By default, v3 mounts three pages: previous, current, and next. Increase `window
 
 ### Keep programmatic navigation
 
-`goToIndex`, `goToPrevious`, and `goToNext` still work. `horizontalSwipe={{ enabled: false }}` disables only user/mouse horizontal swipe gestures; controller navigation and autoplay remain available.
+The [`goToIndex`, `goToPrevious`, and `goToNext` controller methods](/guide/usage/programmatic-control) still work. [`horizontalSwipe`](/guide/usage/gesture-features#horizontalswipe) with `enabled: false` disables only user/mouse horizontal swipe gestures; controller navigation and autoplay remain available.
 
 ```diff
 <GestureViewer
@@ -69,29 +69,29 @@ goToIndex(2, { animated: false });
 
 ## Removed Props
 
-| 2.x prop         | 3.x replacement                                      |
-| ---------------- | ---------------------------------------------------- |
-| `ListComponent`  | Removed. Paging is internal.                         |
-| `listProps`      | Removed. Use `renderItem` for content customization. |
-| `enableSnapMode` | Removed. Internal paging is always gesture-driven.   |
-| `itemSpacing`    | `pageSpacing`                                        |
+| 2.x prop         | 3.x replacement                                                                        |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| `ListComponent`  | Removed. Paging is internal.                                                           |
+| `listProps`      | Removed. Use [`renderItem`](/guide/usage/custom-components) for content customization. |
+| `enableSnapMode` | Removed. Internal paging is always gesture-driven.                                     |
+| `itemSpacing`    | [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing)                         |
 
 ## Common `listProps` Migrations
 
 v3 no longer forwards props to `ScrollView`, `FlatList`, or `FlashList`. Move common `listProps` usage to the v3 viewer APIs instead:
 
-| 2.x `listProps` usage                                                                | v3 direction                                                                                                                              |
-| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `keyExtractor`                                                                       | Removed. The render window owns slot keys; keep stable item identity in `data` and render content through `renderItem`.                   |
-| `initialScrollIndex`                                                                 | Use `initialIndex`.                                                                                                                       |
-| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | Removed. Paging is gesture-owned. Use `horizontalSwipe={{ enabled: false }}` to lock user swipes and `pageSpacing` for visible page gaps. |
-| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | Removed. Use `useGestureViewerState` for `currentIndex`/`totalCount`; use viewer events for supported viewer interactions.                |
-| `ref.current.scrollToIndex(...)`                                                     | Use `useGestureViewerController().goToIndex(...)`, `goToNext()`, or `goToPrevious()`.                                                     |
-| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | Replace list virtualization tuning with `windowSize`. The default mounts previous/current/next only.                                      |
-| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | Removed. Compose visual content inside `renderItem` or use `pageSpacing` for inter-page gaps.                                             |
+| 2.x `listProps` usage                                                                | v3 direction                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyExtractor`                                                                       | Removed. The render window owns slot keys; keep stable item identity in `data` and render content through `renderItem`.                                                                                                                      |
+| `initialScrollIndex`                                                                 | Use [`initialIndex`](/guide/usage/gesture-viewer-props#initialindex).                                                                                                                                                                        |
+| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | Removed. Paging is gesture-owned. Use [`horizontalSwipe`](/guide/usage/gesture-features#horizontalswipe) with `enabled: false` to lock user swipes and [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing) for visible page gaps. |
+| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | Removed. Use [`useGestureViewerState`](/guide/usage/gesture-viewer-state) for `currentIndex`/`totalCount`; use [viewer events](/guide/usage/handling-viewer-events) for supported viewer interactions.                                       |
+| `ref.current.scrollToIndex(...)`                                                     | Use [`useGestureViewerController().goToIndex(...)`, `goToNext()`, or `goToPrevious()`](/guide/usage/programmatic-control).                                                                                                                   |
+| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | Replace list virtualization tuning with [`windowSize`](/guide/usage/gesture-viewer-props#windowsize). The default mounts previous/current/next only.                                                                                         |
+| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | Removed. Compose visual content inside [`renderItem`](/guide/usage/custom-components) or use [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing) for inter-page gaps.                                                             |
 
 ## Notes
 
-- `renderItem` remains the customization point for images, videos, and custom content.
-- `useGestureViewerState` continues to expose `currentIndex` and `totalCount`.
-- `useGestureViewerController` remains the programmatic control surface.
+- [`renderItem`](/guide/usage/custom-components) remains the customization point for images, videos, and custom content.
+- [`useGestureViewerState`](/guide/usage/gesture-viewer-state) continues to expose `currentIndex` and `totalCount`.
+- [`useGestureViewerController`](/guide/usage/programmatic-control) remains the programmatic control surface.

--- a/docs/docs/3.x-beta/en/guide/usage/custom-components.mdx
+++ b/docs/docs/3.x-beta/en/guide/usage/custom-components.mdx
@@ -99,12 +99,17 @@ function App() {
 }
 ```
 
+<span id="renderitem-active-state" />
+
+### `renderItem` active state (`isActive`)
+
 For content such as video that should play or perform work only while it is visible, use `isActive` from the third `renderItem` argument. It is `true` only for the currently selected content. During a page transition, the previous content remains active; when the move finishes, the newly selected content becomes active. Use [`useGestureViewerState`](/guide/usage/gesture-viewer-state) instead when UI outside the item needs the global `currentIndex`.
 
 ```tsx
 import type { GestureViewerRenderItemInfo } from 'react-native-gesture-image-viewer';
 
 const renderMedia = useCallback(
+  // [!code highlight:1]
   (item: MediaItem, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
     return (
       <Video

--- a/docs/docs/3.x-beta/en/guide/usage/gesture-features.mdx
+++ b/docs/docs/3.x-beta/en/guide/usage/gesture-features.mdx
@@ -46,41 +46,72 @@ Dismiss gesture options. Controls which vertical swipe direction can trigger `on
 
 ### `horizontalSwipe`
 
-Horizontal swipe gesture options. Controls user-driven left/right page swipe gestures. Controller navigation and autoplay remain available when disabled.
+Controls user-driven left/right page swipe gestures. Controller navigation and autoplay remain available when disabled.
 
-| Property                 | Description                                                                                                                                                                      | Type      | Default |
-| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------- | :-----: |
-| `enabled`                | When `false`, user-driven horizontal page swipe gestures are disabled.                                                                                                           | `boolean` | `true`  |
-| `distanceThresholdRatio` | Distance threshold as a ratio of viewer width. A page commits when absolute translation is strictly greater than `width * distanceThresholdRatio`, or velocity passes threshold. | `number`  | `0.25`  |
-| `velocityThreshold`      | Horizontal velocity threshold in points per second. A page commits when absolute velocity is strictly greater than this value, or distance passes threshold.                     | `number`  |  `800`  |
+Defaults:
 
-Distance and velocity use strict `>` OR semantics. Zero and every finite non-negative value are accepted, including `distanceThresholdRatio` values greater than `1`; negative and non-finite values fall back to defaults.
+- `enabled`: `true`
+- `distanceThresholdRatio`: `0.25` of viewer width
+- `velocityThreshold`: `800` points/sec
+
+A page commits when absolute horizontal distance is strictly greater than `width * distanceThresholdRatio`, or absolute horizontal velocity is strictly greater than `velocityThreshold`. Distance and velocity use strict `>` OR semantics. Zero and every finite non-negative value are accepted, including distance ratios greater than `1`; negative and non-finite values fall back to defaults.
 
 ```tsx
-<GestureViewer data={images} renderItem={renderImage} horizontalSwipe={{ enabled: false }} />
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      data={data}
+      renderItem={renderItem}
+      // [!code highlight:5]
+      horizontalSwipe={{
+        enabled: true,
+        distanceThresholdRatio: 0.25,
+        velocityThreshold: 800,
+      }}
+    />
+  );
+}
 ```
+
+Disable only user/mouse horizontal gestures:
 
 ```tsx
 <GestureViewer
-  data={images}
-  renderItem={renderImage}
-  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }}
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight]
 />
 ```
 
-```tsx
-<GestureViewer
-  data={images}
-  renderItem={renderImage}
-  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }}
-/>
-```
+Use a distance-focused configuration:
 
 ```tsx
 <GestureViewer
-  data={images}
-  renderItem={renderImage}
-  horizontalSwipe={{ enabled: false }}
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }} // [!code highlight]
+/>
+```
+
+Use a velocity-focused configuration:
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }} // [!code highlight]
+/>
+```
+
+Disable user gestures while autoplay continues:
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight:3]
   autoPlay={true}
   autoPlayInterval={1000}
 />

--- a/docs/docs/3.x-beta/en/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/3.x-beta/en/guide/usage/gesture-viewer-props.mdx
@@ -1,5 +1,9 @@
 # GestureViewer Props
 
+### `renderItem`
+
+`renderItem` renders each item in `data` and receives `isActive` through its third argument: `renderItem(item, index, { isActive })`. Use it for work that should run only on the active item, such as video playback. See [`renderItem` active state (`isActive`)](/guide/usage/custom-components#renderitem-active-state) for behavior and examples.
+
 ### `enableLoop` (default: `false`)
 
 Enables loop mode. When `true`, navigating next from the last item goes to the first item, and navigating previous from the first item goes to the last item.
@@ -17,6 +21,8 @@ function App() {
   );
 }
 ```
+
+<span id="windowsize" />
 
 ### `windowSize` (default: `3`)
 
@@ -38,6 +44,8 @@ function App() {
 }
 ```
 
+<span id="pagespacing" />
+
 ### `pageSpacing` (default: `0`)
 
 Sets horizontal visual space between pages. The page stride is `width + pageSpacing`, while zoom bounds still use `width` and `height`.
@@ -54,78 +62,6 @@ function App() {
     />
   );
 }
-```
-
-### `horizontalSwipe`
-
-Controls user-driven left/right page swipe gestures. Controller navigation and autoplay remain available when disabled.
-
-Defaults:
-
-- `enabled`: `true`
-- `distanceThresholdRatio`: `0.25` of viewer width
-- `velocityThreshold`: `800` points/sec
-
-A page commits when absolute horizontal distance is strictly greater than `width * distanceThresholdRatio`, or absolute horizontal velocity is strictly greater than `velocityThreshold`. Distance and velocity use strict `>` OR semantics. Zero and every finite non-negative value are accepted, including distance ratios greater than `1`; negative and non-finite values fall back to defaults.
-
-```tsx
-import { GestureViewer } from 'react-native-gesture-image-viewer';
-
-function App() {
-  return (
-    <GestureViewer
-      data={data}
-      renderItem={renderItem}
-      horizontalSwipe={{
-        enabled: true,
-        distanceThresholdRatio: 0.25,
-        velocityThreshold: 800,
-      }} // [!code highlight:5]
-    />
-  );
-}
-```
-
-Disable only user/mouse horizontal gestures:
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ enabled: false }} // [!code highlight]
-/>
-```
-
-Use a distance-focused configuration:
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }} // [!code highlight]
-/>
-```
-
-Use a velocity-focused configuration:
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }} // [!code highlight]
-/>
-```
-
-Disable user gestures while autoplay continues:
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ enabled: false }} // [!code highlight:3]
-  autoPlay={true}
-  autoPlayInterval={1000}
-/>
 ```
 
 ### `autoPlay` (default: `false`)
@@ -196,6 +132,8 @@ function App() {
   );
 }
 ```
+
+<span id="initialindex" />
 
 ### `initialIndex` (default: `0`)
 

--- a/docs/docs/3.x-beta/en/index.md
+++ b/docs/docs/3.x-beta/en/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Quick Start
-      link: /3.x-beta/guide/getting-started/installation.html
+      link: /3.x-beta/guide/getting-started/quick-start.html
     - theme: alt
       text: GitHub
       link: https://github.com/saseungmin/react-native-gesture-image-viewer

--- a/docs/docs/3.x-beta/ko/guide/migration-from-2.x.mdx
+++ b/docs/docs/3.x-beta/ko/guide/migration-from-2.x.mdx
@@ -25,7 +25,7 @@ import { Steps } from '@rspress/core/theme';
 
 ### snap 간격을 pageSpacing으로 교체
 
-`enableSnapMode`와 `itemSpacing`은 제거되었습니다. 페이지 사이에 보이는 간격이 필요하다면 `pageSpacing`을 사용하세요.
+`enableSnapMode`와 `itemSpacing`은 제거되었습니다. 페이지 사이에 보이는 간격이 필요하다면 [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing)을 사용하세요.
 
 ```diff
 <GestureViewer
@@ -39,7 +39,7 @@ import { Steps } from '@rspress/core/theme';
 
 ### 필요한 경우에만 render window 조정
 
-3.x의 기본값은 이전, 현재, 다음 총 세 페이지를 마운트합니다. 인접한 콘텐츠를 더 많이 마운트해야 할 때만 `windowSize`를 늘리세요.
+3.x의 기본값은 이전, 현재, 다음 총 세 페이지를 마운트합니다. 인접한 콘텐츠를 더 많이 마운트해야 할 때만 [`windowSize`](/guide/usage/gesture-viewer-props#windowsize)를 늘리세요.
 
 ```tsx
 <GestureViewer data={images} renderItem={renderImage} windowSize={5} />
@@ -47,7 +47,7 @@ import { Steps } from '@rspress/core/theme';
 
 ### 프로그래밍 방식 이동 유지
 
-`goToIndex`, `goToPrevious`, `goToNext`는 계속 동작합니다. `horizontalSwipe={{ enabled: false }}`는 사용자/마우스 가로 스와이프 제스처만 비활성화하며, controller 이동과 autoplay는 계속 사용할 수 있습니다.
+[`goToIndex`, `goToPrevious`, `goToNext` controller 메서드](/guide/usage/programmatic-control)는 계속 동작합니다. [`horizontalSwipe`](/guide/usage/gesture-features#horizontalswipe)에서 `enabled: false`를 설정하면 사용자/마우스 가로 스와이프 제스처만 비활성화되며, controller 이동과 autoplay는 계속 사용할 수 있습니다.
 
 ```diff
 <GestureViewer
@@ -69,29 +69,29 @@ goToIndex(2, { animated: false });
 
 ## 제거된 Props
 
-| 2.x prop         | 3.x 대체 방식                                            |
-| ---------------- | -------------------------------------------------------- |
-| `ListComponent`  | 제거됨. 페이징은 내부에서 처리됩니다.                    |
-| `listProps`      | 제거됨. 콘텐츠 커스터마이징은 `renderItem`을 사용하세요. |
-| `enableSnapMode` | 제거됨. 내부 페이징은 항상 제스처 기반입니다.            |
-| `itemSpacing`    | `pageSpacing`                                            |
+| 2.x prop         | 3.x 대체 방식                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| `ListComponent`  | 제거됨. 페이징은 내부에서 처리됩니다.                                                      |
+| `listProps`      | 제거됨. 콘텐츠 커스터마이징은 [`renderItem`](/guide/usage/custom-components)을 사용하세요. |
+| `enableSnapMode` | 제거됨. 내부 페이징은 항상 제스처 기반입니다.                                              |
+| `itemSpacing`    | [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing)                             |
 
 ## 자주 쓰던 `listProps` 마이그레이션
 
 3.x는 더 이상 `ScrollView`, `FlatList`, `FlashList`로 props를 전달하지 않습니다. 자주 쓰던 `listProps` 설정은 아래 v3 API로 옮기세요.
 
-| 2.x `listProps` 사용                                                                 | 3.x 방향                                                                                                                                                      |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keyExtractor`                                                                       | 제거됨. render window가 slot key를 직접 관리합니다. 아이템 식별성은 `data`에서 안정적으로 유지하고, 콘텐츠는 `renderItem`에서 렌더링하세요.                   |
-| `initialScrollIndex`                                                                 | `initialIndex`를 사용하세요.                                                                                                                                  |
-| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | 제거됨. 페이징은 내부 제스처가 소유합니다. 사용자 스와이프를 잠글 때는 `horizontalSwipe={{ enabled: false }}`, 페이지 사이 간격은 `pageSpacing`을 사용하세요. |
-| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | 제거됨. `currentIndex`/`totalCount`는 `useGestureViewerState`를 사용하고, 지원되는 뷰어 인터랙션은 viewer event를 사용하세요.                                 |
-| `ref.current.scrollToIndex(...)`                                                     | `useGestureViewerController().goToIndex(...)`, `goToNext()`, `goToPrevious()`를 사용하세요.                                                                   |
-| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | 리스트 virtualization 튜닝 대신 `windowSize`를 사용하세요. 기본값은 이전/현재/다음만 마운트합니다.                                                            |
-| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | 제거됨. 시각적 구성은 `renderItem` 내부에서 조합하거나, 페이지 사이 간격은 `pageSpacing`을 사용하세요.                                                        |
+| 2.x `listProps` 사용                                                                 | 3.x 방향                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyExtractor`                                                                       | 제거됨. render window가 slot key를 직접 관리합니다. 아이템 식별성은 `data`에서 안정적으로 유지하고, 콘텐츠는 `renderItem`에서 렌더링하세요.                                                                                                                                |
+| `initialScrollIndex`                                                                 | [`initialIndex`](/guide/usage/gesture-viewer-props#initialindex)를 사용하세요.                                                                                                                                                                                             |
+| `scrollEnabled`, `pagingEnabled`, `horizontal`, `snapToInterval`, `decelerationRate` | 제거됨. 페이징은 내부 제스처가 소유합니다. 사용자 스와이프를 잠글 때는 [`horizontalSwipe`](/guide/usage/gesture-features#horizontalswipe)에서 `enabled: false`를 설정하고, 페이지 사이 간격은 [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing)을 사용하세요. |
+| `onScroll`, `onMomentumScrollEnd`, `onViewableItemsChanged`                          | 제거됨. `currentIndex`/`totalCount`는 [`useGestureViewerState`](/guide/usage/gesture-viewer-state)를 사용하고, 지원되는 뷰어 인터랙션은 [viewer event](/guide/usage/handling-viewer-events)를 사용하세요.                                                                  |
+| `ref.current.scrollToIndex(...)`                                                     | [`useGestureViewerController().goToIndex(...)`, `goToNext()`, `goToPrevious()`](/guide/usage/programmatic-control)를 사용하세요.                                                                                                                                           |
+| `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `estimatedItemSize`    | 리스트 virtualization 튜닝 대신 [`windowSize`](/guide/usage/gesture-viewer-props#windowsize)를 사용하세요. 기본값은 이전/현재/다음만 마운트합니다.                                                                                                                         |
+| `showsHorizontalScrollIndicator`, `contentContainerStyle`, list separators           | 제거됨. 시각적 구성은 [`renderItem`](/guide/usage/custom-components) 내부에서 조합하거나, 페이지 사이 간격은 [`pageSpacing`](/guide/usage/gesture-viewer-props#pagespacing)을 사용하세요.                                                                                  |
 
 ## 참고
 
-- `renderItem`은 이미지, 비디오, 커스텀 콘텐츠를 렌더링하는 커스터마이징 지점으로 유지됩니다.
-- `useGestureViewerState`는 계속 `currentIndex`와 `totalCount`를 제공합니다.
-- `useGestureViewerController`는 계속 프로그래밍 방식 제어 surface로 사용합니다.
+- [`renderItem`](/guide/usage/custom-components)은 이미지, 비디오, 커스텀 콘텐츠를 렌더링하는 커스터마이징 지점으로 유지됩니다.
+- [`useGestureViewerState`](/guide/usage/gesture-viewer-state)는 계속 `currentIndex`와 `totalCount`를 제공합니다.
+- [`useGestureViewerController`](/guide/usage/programmatic-control)는 계속 프로그래밍 방식 제어 surface로 사용합니다.

--- a/docs/docs/3.x-beta/ko/guide/usage/custom-components.mdx
+++ b/docs/docs/3.x-beta/ko/guide/usage/custom-components.mdx
@@ -99,12 +99,17 @@ function App() {
 }
 ```
 
+<span id="renderitem-active-state" />
+
+### `renderItem` 활성 상태 (`isActive`)
+
 비디오처럼 현재 표시 중인 콘텐츠에서만 재생이나 작업을 수행해야 한다면 세 번째 `renderItem` 인자의 `isActive`를 사용할 수 있습니다. 이 값은 현재 선택된 콘텐츠에서만 `true`입니다. 페이지 전환 중에는 기존 콘텐츠가 활성 상태를 유지하고, 이동이 완료되면 새로 선택된 콘텐츠가 활성화됩니다. 아이템 외부 UI에서 전역 `currentIndex`가 필요할 때는 [`useGestureViewerState`](/guide/usage/gesture-viewer-state)를 사용하세요.
 
 ```tsx
 import type { GestureViewerRenderItemInfo } from 'react-native-gesture-image-viewer';
 
 const renderMedia = useCallback(
+  // [!code highlight:1]
   (item: MediaItem, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
     return (
       <Video

--- a/docs/docs/3.x-beta/ko/guide/usage/gesture-features.mdx
+++ b/docs/docs/3.x-beta/ko/guide/usage/gesture-features.mdx
@@ -46,41 +46,72 @@ function App() {
 
 ### `horizontalSwipe`
 
-가로 스와이프 제스처 옵션입니다. 사용자가 직접 수행하는 좌우 페이지 스와이프 제스처를 제어합니다. 비활성화해도 controller 이동과 autoplay는 계속 사용할 수 있습니다.
+사용자가 직접 수행하는 좌우 페이지 스와이프 제스처를 제어합니다. 비활성화해도 controller 이동과 autoplay는 계속 사용할 수 있습니다.
 
-| 속성                     | 설명                                                                                                                                                  | 타입      | 기본값 |
-| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- | :-------- | :----: |
-| `enabled`                | `false`이면 사용자가 직접 수행하는 가로 페이지 스와이프 제스처가 비활성화됩니다.                                                                      | `boolean` | `true` |
-| `distanceThresholdRatio` | 뷰어 너비에 대한 거리 임계값 비율입니다. 절대 이동 거리가 `width * distanceThresholdRatio`보다 엄격히 클 때, 또는 속도가 임계값을 넘을 때 전환됩니다. | `number`  | `0.25` |
-| `velocityThreshold`      | 초당 points 단위의 가로 속도 임계값입니다. 절대 속도가 이 값보다 엄격히 클 때, 또는 거리가 임계값을 넘을 때 전환됩니다.                               | `number`  | `800`  |
+기본값:
 
-거리와 속도는 엄격한 `>` OR 조건으로 동작합니다. `0`과 모든 유한한 0 이상의 값은 허용되며, `1`보다 큰 `distanceThresholdRatio` 값도 허용됩니다. 음수와 유한하지 않은 값은 기본값으로 대체됩니다.
+- `enabled`: `true`
+- `distanceThresholdRatio`: 뷰어 너비의 `0.25`
+- `velocityThreshold`: 초당 `800` points
+
+절대 가로 이동 거리가 `width * distanceThresholdRatio`보다 엄격히 클 때, 또는 절대 가로 속도가 `velocityThreshold`보다 엄격히 클 때 페이지가 전환됩니다. 거리와 속도는 엄격한 `>` OR 조건으로 동작합니다. `0`과 모든 유한한 0 이상의 값은 허용되며, `1`보다 큰 거리 비율도 허용됩니다. 음수와 유한하지 않은 값은 기본값으로 대체됩니다.
 
 ```tsx
-<GestureViewer data={images} renderItem={renderImage} horizontalSwipe={{ enabled: false }} />
+import { GestureViewer } from 'react-native-gesture-image-viewer';
+
+function App() {
+  return (
+    <GestureViewer
+      data={data}
+      renderItem={renderItem}
+      // [!code highlight:5]
+      horizontalSwipe={{
+        enabled: true,
+        distanceThresholdRatio: 0.25,
+        velocityThreshold: 800,
+      }}
+    />
+  );
+}
 ```
+
+사용자/마우스 가로 제스처만 비활성화합니다.
 
 ```tsx
 <GestureViewer
-  data={images}
-  renderItem={renderImage}
-  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }}
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight]
 />
 ```
 
-```tsx
-<GestureViewer
-  data={images}
-  renderItem={renderImage}
-  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }}
-/>
-```
+거리 중심 설정을 사용합니다.
 
 ```tsx
 <GestureViewer
-  data={images}
-  renderItem={renderImage}
-  horizontalSwipe={{ enabled: false }}
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }} // [!code highlight]
+/>
+```
+
+속도 중심 설정을 사용합니다.
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }} // [!code highlight]
+/>
+```
+
+사용자 제스처를 비활성화해도 autoplay는 계속 동작합니다.
+
+```tsx
+<GestureViewer
+  data={data}
+  renderItem={renderItem}
+  horizontalSwipe={{ enabled: false }} // [!code highlight:3]
   autoPlay={true}
   autoPlayInterval={1000}
 />

--- a/docs/docs/3.x-beta/ko/guide/usage/gesture-viewer-props.mdx
+++ b/docs/docs/3.x-beta/ko/guide/usage/gesture-viewer-props.mdx
@@ -1,5 +1,9 @@
 # GestureViewer Props
 
+### `renderItem`
+
+`renderItem`은 `data`의 각 아이템을 렌더링하며, `renderItem(item, index, { isActive })` 형태로 세 번째 인자에서 활성 상태를 제공합니다. 비디오 재생처럼 활성 아이템에서만 필요한 작업을 제어할 때 사용할 수 있습니다. 동작 방식과 예시는 [`renderItem` 활성 상태 (`isActive`)](/guide/usage/custom-components#renderitem-active-state)를 참고하세요.
+
 ### `enableLoop` (기본값: `false`)
 
 루프 모드를 활성화합니다. `true`일 때 마지막 아이템에서 다음으로 가면 첫 번째로, 첫 번째에서 이전으로 가면 마지막으로 돌아갑니다.
@@ -17,6 +21,8 @@ function App() {
   );
 }
 ```
+
+<span id="windowsize" />
 
 ### `windowSize` (기본값: `3`)
 
@@ -38,6 +44,8 @@ function App() {
 }
 ```
 
+<span id="pagespacing" />
+
 ### `pageSpacing` (기본값: `0`)
 
 페이지 사이의 가로 시각 간격을 설정합니다. 페이지 stride는 `width + pageSpacing`이며, zoom bounds는 계속 `width`와 `height`를 사용합니다.
@@ -54,78 +62,6 @@ function App() {
     />
   );
 }
-```
-
-### `horizontalSwipe`
-
-사용자가 직접 수행하는 좌우 페이지 스와이프 제스처를 제어합니다. 비활성화해도 controller 이동과 autoplay는 계속 사용할 수 있습니다.
-
-기본값:
-
-- `enabled`: `true`
-- `distanceThresholdRatio`: 뷰어 너비의 `0.25`
-- `velocityThreshold`: 초당 `800` points
-
-절대 가로 이동 거리가 `width * distanceThresholdRatio`보다 엄격히 클 때, 또는 절대 가로 속도가 `velocityThreshold`보다 엄격히 클 때 페이지가 전환됩니다. 거리와 속도는 엄격한 `>` OR 조건으로 동작합니다. `0`과 모든 유한한 0 이상의 값은 허용되며, `1`보다 큰 거리 비율도 허용됩니다. 음수와 유한하지 않은 값은 기본값으로 대체됩니다.
-
-```tsx
-import { GestureViewer } from 'react-native-gesture-image-viewer';
-
-function App() {
-  return (
-    <GestureViewer
-      data={data}
-      renderItem={renderItem}
-      horizontalSwipe={{
-        enabled: true,
-        distanceThresholdRatio: 0.25,
-        velocityThreshold: 800,
-      }} // [!code highlight:5]
-    />
-  );
-}
-```
-
-사용자/마우스 가로 제스처만 비활성화합니다.
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ enabled: false }} // [!code highlight]
-/>
-```
-
-거리 중심 설정을 사용합니다.
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ distanceThresholdRatio: 0.5, velocityThreshold: 100_000 }} // [!code highlight]
-/>
-```
-
-속도 중심 설정을 사용합니다.
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ distanceThresholdRatio: 10, velocityThreshold: 100 }} // [!code highlight]
-/>
-```
-
-사용자 제스처를 비활성화해도 autoplay는 계속 동작합니다.
-
-```tsx
-<GestureViewer
-  data={data}
-  renderItem={renderItem}
-  horizontalSwipe={{ enabled: false }} // [!code highlight:3]
-  autoPlay={true}
-  autoPlayInterval={1000}
-/>
 ```
 
 ### `autoPlay` (기본값: `false`)
@@ -196,6 +132,8 @@ function App() {
   );
 }
 ```
+
+<span id="initialindex" />
 
 ### `initialIndex` (기본값: `0`)
 

--- a/docs/docs/3.x-beta/ko/index.md
+++ b/docs/docs/3.x-beta/ko/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: 빠른 시작
-      link: /3.x-beta/ko/guide/getting-started/installation.html
+      link: /3.x-beta/ko/guide/getting-started/quick-start.html
     - theme: alt
       text: GitHub
       link: https://github.com/saseungmin/react-native-gesture-image-viewer


### PR DESCRIPTION
## Summary

- Point the 1.x, 2.x, and 3.x-beta landing-page Quick Start actions to their quick-start guides in English and Korean.
- Document the v2 `renderItem` third argument and `isActive` behavior with an active-media example and direct links.
- Move detailed v3 `horizontalSwipe` guidance into the gesture features guide.
- Add stable anchors and cross-links for v3 migration replacements, controller APIs, viewer state, and active render items.

## Why

The relevant APIs were documented, but important behavior was split across pages or buried below general examples. This makes active-item rendering, horizontal swipe tuning, and v3 migration guidance easier to discover without duplicating detailed content.

## Validation

- `oxfmt --check` for all changed guides
- `tsc -p docs/tsconfig.json --noEmit`
- `rspress build`
