### PR TITLE
fix: prevent panning gestures from prematurely excluding pinch gestures

### DIFF
--- a/.changeset/twenty-dingos-brake.md
+++ b/.changeset/twenty-dingos-brake.md
@@ -1,0 +1,5 @@
+---
+'react-native-gesture-image-viewer': patch
+---
+
+fix: prevent panning gestures from prematurely excluding pinch gestures

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -134,7 +134,7 @@ export function GestureViewer<ItemT, LC>({
   );
 
   const gesture = useMemo(() => {
-    return Gesture.Race(dismissGesture, zoomGesture);
+    return Gesture.Simultaneous(dismissGesture, zoomGesture);
   }, [zoomGesture, dismissGesture]);
 
   useEffect(() => {

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -787,7 +787,7 @@ export const useGestureViewer = <ItemT, LC>({
   );
 
   const zoomGesture = useMemo(
-    () => Gesture.Race(zoomPinchGesture, Gesture.Exclusive(zoomPanGesture, tapGesture)),
+    () => Gesture.Simultaneous(zoomPinchGesture, Gesture.Exclusive(zoomPanGesture, tapGesture)),
     [zoomPinchGesture, zoomPanGesture, tapGesture],
   );
 


### PR DESCRIPTION
It is difficult to pinch to zoom for my users because ...
1. When the image is not zoomed, dismissGesture wins the Gesture.Race almost every time
2. When the image is zoomed, zoomPanGesture wins the Gesture.Race almost every time

A simple fix seems to be to change both Gesture.Race into Gesture.Simultaneous (2 line fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture handling so dismissal and zoom gestures can be recognized simultaneously.
  * Updated zoom interactions to support combined pinch, pan, and tap gestures more smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->