### PR TITLE
fix: allow pinch takeover from single-touch gestures

### DIFF
--- a/.changeset/pinch-gesture-handoff.md
+++ b/.changeset/pinch-gesture-handoff.md
@@ -2,4 +2,8 @@
 'react-native-gesture-image-viewer': patch
 ---
 
-Improve pinch recognition by allowing pinch to take ownership from one-finger dismiss, paging, and zoom-pan gestures without letting those gestures update transforms concurrently.
+Fix gesture conflicts between pinch zoom, one-finger drags, and single taps.
+
+When a second finger is added during swipe-to-dismiss, horizontal paging, or panning a zoomed image, pinch zoom now takes control. Any interrupted dismiss movement resets before zooming begins.
+
+Single-tap callbacks are no longer triggered after pinching, swiping, or dragging. Native taps now allow at most 10 points of movement to avoid treating an attempted drag as a tap.

--- a/.changeset/pinch-gesture-handoff.md
+++ b/.changeset/pinch-gesture-handoff.md
@@ -1,0 +1,5 @@
+---
+'react-native-gesture-image-viewer': patch
+---
+
+Improve pinch recognition by allowing pinch to take ownership from one-finger dismiss, paging, and zoom-pan gestures without letting those gestures update transforms concurrently.

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo } from 'react';
 import { StyleSheet, useWindowDimensions, View, type ViewStyle } from 'react-native';
-import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
+import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 import Animated, {
   type AnimatedStyle,
   type SharedValue,
   useAnimatedStyle,
 } from 'react-native-reanimated';
 
+import { composeGestureViewerGestures } from './gestureViewerGestures';
 import { registry } from './GestureViewerRegistry';
 import { getWebContentProps } from './getWebContentProps';
 import type { RenderWindowSlot } from './renderWindow';
@@ -90,6 +91,7 @@ export function GestureViewer<ItemT>({
     renderWindowSlots,
     visualPage,
     zoomGesture,
+    zoomPinchGesture,
   } = useGestureViewer({
     id,
     data,
@@ -103,8 +105,13 @@ export function GestureViewer<ItemT>({
   });
 
   const gesture = useMemo(() => {
-    return Gesture.Race(dismissGesture, horizontalPagingGesture, zoomGesture);
-  }, [dismissGesture, horizontalPagingGesture, zoomGesture]);
+    return composeGestureViewerGestures({
+      dismissGesture,
+      horizontalPagingGesture,
+      zoomGesture,
+      zoomPinchGesture,
+    });
+  }, [dismissGesture, horizontalPagingGesture, zoomGesture, zoomPinchGesture]);
 
   useEffect(() => {
     registry.createManager(id);

--- a/src/__tests__/gestureViewerGestures.test.ts
+++ b/src/__tests__/gestureViewerGestures.test.ts
@@ -1,0 +1,38 @@
+import { Gesture } from 'react-native-gesture-handler';
+
+import { composeGestureViewerGestures } from '../gestureViewerGestures';
+
+describe('composeGestureViewerGestures', () => {
+  it('keeps pinch observable while single-pointer gestures remain mutually exclusive', () => {
+    const dismissGesture = Gesture.Pan();
+    const horizontalPagingGesture = Gesture.Pan();
+    const zoomPinchGesture = Gesture.Pinch();
+    const zoomPanGesture = Gesture.Pan();
+    const tapGesture = Gesture.Tap();
+    const zoomGesture = Gesture.Exclusive(zoomPanGesture, tapGesture);
+
+    const gesture = composeGestureViewerGestures({
+      dismissGesture,
+      horizontalPagingGesture,
+      zoomGesture,
+      zoomPinchGesture,
+    });
+
+    gesture.prepare();
+
+    const singlePointerGestures = [
+      dismissGesture,
+      horizontalPagingGesture,
+      zoomPanGesture,
+      tapGesture,
+    ];
+
+    expect(zoomPinchGesture.config.simultaneousWith).toEqual(
+      expect.arrayContaining(singlePointerGestures),
+    );
+
+    singlePointerGestures.forEach((singlePointerGesture) => {
+      expect(singlePointerGesture.config.simultaneousWith).toEqual([zoomPinchGesture]);
+    });
+  });
+});

--- a/src/__tests__/useGestureViewer.test.tsx
+++ b/src/__tests__/useGestureViewer.test.tsx
@@ -395,4 +395,149 @@ describe('useGestureViewer horizontal swipe options', () => {
     expect(dismissStateManager.fail).toHaveBeenCalledTimes(1);
     expect(zoomPanStateManager.fail).toHaveBeenCalledTimes(1);
   });
+
+  it('suppresses a native single tap after a pinch and restores taps for the next touch', async () => {
+    const onSingleTap = jest.fn();
+    const { result } = await renderHook(() =>
+      useGestureViewer({
+        data: ['first'],
+        height: 240,
+        onSingleTap,
+        width: 320,
+      }),
+    );
+    const singleTapGesture = result.current.zoomGesture
+      .toGestureArray()
+      .find(
+        (gesture) =>
+          gesture.handlerName === 'TapGestureHandler' && gesture.config.numberOfTaps === 1,
+      );
+
+    expect(singleTapGesture).toBeDefined();
+
+    await act(async () => {
+      singleTapGesture?.handlers.onTouchesDown?.(
+        { numberOfTouches: 1 } as never,
+        { fail: jest.fn() } as never,
+      );
+      result.current.zoomPinchGesture.handlers.onTouchesDown?.(
+        { numberOfTouches: 2 } as never,
+        { fail: jest.fn() } as never,
+      );
+      singleTapGesture?.handlers.onEnd?.({ x: 100, y: 120 } as never, true);
+    });
+
+    expect(onSingleTap).not.toHaveBeenCalled();
+
+    await act(async () => {
+      singleTapGesture?.handlers.onTouchesDown?.(
+        { numberOfTouches: 1 } as never,
+        { fail: jest.fn() } as never,
+      );
+      singleTapGesture?.handlers.onEnd?.({ x: 120, y: 140 } as never, true);
+    });
+
+    expect(onSingleTap).toHaveBeenCalledTimes(1);
+    expect(onSingleTap).toHaveBeenCalledWith({ index: 0, item: 'first', x: 120, y: 140 });
+  });
+
+  it('does not emit a single tap when a horizontal swipe settles', async () => {
+    const onSingleTap = jest.fn();
+    const { result } = await renderHook(() =>
+      useGestureViewer({
+        data: ['first', 'second'],
+        height: 240,
+        onSingleTap,
+        width: 320,
+      }),
+    );
+    const singleTapGesture = result.current.zoomGesture
+      .toGestureArray()
+      .find(
+        (gesture) =>
+          gesture.handlerName === 'TapGestureHandler' && gesture.config.numberOfTaps === 1,
+      );
+
+    expect(singleTapGesture).toBeDefined();
+
+    await act(async () => {
+      singleTapGesture?.handlers.onTouchesDown?.(
+        { numberOfTouches: 1 } as never,
+        { fail: jest.fn() } as never,
+      );
+      result.current.horizontalPagingGesture.handlers.onStart?.({} as never);
+      result.current.horizontalPagingGesture.handlers.onUpdate?.({ translationX: -40 } as never);
+      result.current.horizontalPagingGesture.handlers.onEnd?.(
+        {
+          translationX: -40,
+          velocityX: 0,
+        } as never,
+        true,
+      );
+      singleTapGesture?.handlers.onEnd?.({ x: 100, y: 120 } as never, true);
+    });
+
+    expect(onSingleTap).not.toHaveBeenCalled();
+  });
+
+  it('limits tap travel when competing pan gestures fail to activate', async () => {
+    const { result } = await renderHook(() =>
+      useGestureViewer({
+        data: ['first', 'second'],
+        height: 240,
+        width: 320,
+      }),
+    );
+    const tapGestures = result.current.zoomGesture
+      .toGestureArray()
+      .filter((gesture) => gesture.handlerName === 'TapGestureHandler');
+
+    expect(tapGestures).toHaveLength(2);
+    expect(tapGestures.map((gesture) => gesture.config.maxDist)).toEqual([10, 10]);
+  });
+
+  it('resets an interrupted dismiss before pinch updates the image', async () => {
+    const onDismiss = jest.fn();
+    const { rerender, result } = await renderHook(() =>
+      useGestureViewer({
+        data: ['first'],
+        dismiss: { direction: 'both' },
+        height: 240,
+        onDismiss,
+        width: 320,
+      }),
+    );
+    const dismissStateManager = { fail: jest.fn() };
+
+    await act(async () => {
+      result.current.dismissGesture.handlers.onUpdate?.({ translationY: 160 } as never);
+      result.current.dismissGesture.handlers.onTouchesDown?.(
+        { numberOfTouches: 2 } as never,
+        dismissStateManager as never,
+      );
+      result.current.zoomPinchGesture.handlers.onStart?.({ focalX: 160, focalY: 120 } as never);
+      result.current.zoomPinchGesture.handlers.onUpdate?.({
+        focalX: 160,
+        focalY: 120,
+        scale: 1.5,
+      } as never);
+      result.current.dismissGesture.handlers.onEnd?.({ translationY: 160 } as never, false);
+      result.current.dismissGesture.handlers.onFinalize?.({} as never, false);
+    });
+
+    await rerender({});
+
+    const transform = (
+      result.current.animatedStyle as unknown as {
+        initial: {
+          updater: () => { transform: Array<Record<string, number | string>> };
+        };
+      }
+    ).initial.updater().transform;
+
+    expect(dismissStateManager.fail).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(transform[3]).toEqual({ translateY: 0 });
+    expect(transform[5]).toEqual({ scale: 1.5 });
+  });
 });

--- a/src/__tests__/useGestureViewer.test.tsx
+++ b/src/__tests__/useGestureViewer.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, waitFor } from '@testing-library/react-native';
+import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react-native';
 import { Text, View } from 'react-native';
 import {
   GestureDetector,
@@ -355,5 +355,44 @@ describe('useGestureViewer horizontal swipe options', () => {
     expect(manager.getState()).toEqual({ currentIndex: 0, totalCount: 4 });
 
     unsubscribe();
+  });
+
+  it('reserves multi-pointer input for pinch across every competing pan gesture', async () => {
+    const viewerId = 'single-pointer-pan-guards';
+
+    registry.createManager(viewerId);
+    createdManagerIds.add(viewerId);
+
+    const { result } = await renderHook(() =>
+      useGestureViewer({
+        data: ['first', 'second'],
+        height: 240,
+        id: viewerId,
+        width: 320,
+      }),
+    );
+
+    const zoomPanGesture = result.current.zoomGesture
+      .toGestureArray()
+      .find((gesture) => gesture.handlerName === 'PanGestureHandler');
+
+    expect(result.current.dismissGesture.config.maxPointers).toBe(1);
+    expect(result.current.horizontalPagingGesture.config.maxPointers).toBe(1);
+    expect(zoomPanGesture?.config.maxPointers).toBe(1);
+
+    const dismissStateManager = { fail: jest.fn() };
+    const zoomPanStateManager = { fail: jest.fn() };
+
+    result.current.dismissGesture.handlers.onTouchesDown?.(
+      { numberOfTouches: 2 } as never,
+      dismissStateManager as never,
+    );
+    zoomPanGesture?.handlers.onTouchesDown?.(
+      { numberOfTouches: 2 } as never,
+      zoomPanStateManager as never,
+    );
+
+    expect(dismissStateManager.fail).toHaveBeenCalledTimes(1);
+    expect(zoomPanStateManager.fail).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/useGestureViewerPaging.test.ts
+++ b/src/__tests__/useGestureViewerPaging.test.ts
@@ -39,6 +39,10 @@ const createPagingOptions = ({
   isTriggerOpening: false,
   isZoomed: false,
   pageStride: 320,
+  suppressNativeTap: {
+    get: () => false,
+    set: jest.fn(),
+  } as never,
   width: 320,
 });
 

--- a/src/__tests__/useGestureViewerPaging.test.ts
+++ b/src/__tests__/useGestureViewerPaging.test.ts
@@ -266,6 +266,34 @@ describe('useGestureViewerPaging horizontal gesture thresholds', () => {
     expect(commitVirtualIndexOnly).toHaveBeenCalledWith(-1);
   });
 
+  it('releases active paging immediately when a pinch adds a second pointer', async () => {
+    const { result } = await renderHook(() => useGestureViewerPaging(createPagingOptions()));
+    const gesture = result.current.horizontalPagingGesture;
+
+    await act(async () => {
+      gesture.handlers.onStart?.({} as never);
+      gesture.handlers.onUpdate?.({ translationX: -64 } as never);
+    });
+
+    expect(result.current.pageTransitionLocked.get()).toBe(true);
+    expect(result.current.visualPage.get()).toBe(0.2);
+
+    const stateManager = { fail: jest.fn() };
+
+    await act(async () => {
+      gesture.handlers.onTouchesDown?.({ numberOfTouches: 2 } as never, stateManager as never);
+    });
+
+    expect(stateManager.fail).toHaveBeenCalledTimes(1);
+    expect(result.current.pageTransitionLocked.get()).toBe(false);
+
+    await act(async () => {
+      gesture.handlers.onFinalize?.({} as never, false);
+    });
+
+    expect(result.current.pageTransitionLocked.get()).toBe(false);
+  });
+
   it('disables the pan gesture when horizontal swipe is disabled', async () => {
     const { result } = await renderHook(() =>
       useGestureViewerPaging(createPagingOptions({ horizontalSwipeEnabled: false })),

--- a/src/gestureViewerGestures.ts
+++ b/src/gestureViewerGestures.ts
@@ -1,0 +1,20 @@
+import { Gesture, type ComposedGesture, type GestureType } from 'react-native-gesture-handler';
+
+type GestureViewerGestures = {
+  dismissGesture: GestureType;
+  horizontalPagingGesture: GestureType;
+  zoomGesture: ComposedGesture;
+  zoomPinchGesture: GestureType;
+};
+
+export function composeGestureViewerGestures({
+  dismissGesture,
+  horizontalPagingGesture,
+  zoomGesture,
+  zoomPinchGesture,
+}: GestureViewerGestures): ComposedGesture {
+  return Gesture.Simultaneous(
+    zoomPinchGesture,
+    Gesture.Race(dismissGesture, horizontalPagingGesture, zoomGesture),
+  );
+}

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -966,13 +966,10 @@ export const useGestureViewer = <ItemT>({
             cancelAnimation(translateY);
             translateX.set(0);
             translateY.set(0);
-            initialTranslateX.set(0);
-            initialTranslateY.set(0);
-          } else {
-            initialTranslateX.set(translateX.get());
-            initialTranslateY.set(translateY.get());
           }
 
+          initialTranslateX.set(translateX.get());
+          initialTranslateY.set(translateY.get());
           startFocalX.set(event.focalX);
           startFocalY.set(event.focalY);
           lastFocalX.set(event.focalX);

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -43,6 +43,8 @@ import { getDismissDistance, shouldDismissByDirection } from './utils/dismiss';
 import { applyTapZoomAtPoint } from './utils/tapZoom';
 import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from './utils/zoom';
 
+const NATIVE_TAP_MAX_DISTANCE = 10;
+
 const isValidTriggerRect = (rect: TriggerRect | null): rect is TriggerRect => {
   return !!rect && rect.width > 0 && rect.height > 0;
 };
@@ -144,6 +146,8 @@ export const useGestureViewer = <ItemT>({
   const startFocalX = useSharedValue(0);
   const startFocalY = useSharedValue(0);
   const hasActiveFocal = useSharedValue(false);
+  const nativeInteractionHadMultipleTouches = useSharedValue(false);
+  const suppressNativeTap = useSharedValue(false);
   const { clearPendingWebSingleTap, scheduleWebSingleTap } = useWebSingleTapTimer();
 
   const animationConfig = useMemo(
@@ -266,6 +270,7 @@ export const useGestureViewer = <ItemT>({
     isTriggerOpening,
     isZoomed,
     pageStride,
+    suppressNativeTap,
     width,
   });
 
@@ -736,7 +741,12 @@ export const useGestureViewer = <ItemT>({
   }, [animateDismissToRect, dismissWithoutTrigger, id, isPageTransitioningRef, onDismissStart]);
 
   const dismissGesture = useMemo(() => {
-    const canDismiss = !isTriggerOpening && !isZoomed && dismissOptions.enabled;
+    const canDismiss = !isTriggerOpening && !isPinching && !isZoomed && dismissOptions.enabled;
+    const resetDismissTranslation = () => {
+      'worklet';
+      cancelAnimation(translateY);
+      translateY.set(0);
+    };
 
     return Gesture.Pan()
       .minDistance(10)
@@ -748,20 +758,36 @@ export const useGestureViewer = <ItemT>({
       .withRef(dismissGestureRef)
       .enabled(canDismiss)
       .onTouchesDown((event, stateManager) => {
+        if (event.numberOfTouches === 1) {
+          nativeInteractionHadMultipleTouches.set(false);
+          return;
+        }
+
         if (event.numberOfTouches > 1) {
+          nativeInteractionHadMultipleTouches.set(true);
+          suppressNativeTap.set(true);
+          resetDismissTranslation();
           stateManager.fail();
         }
       })
+      .onStart(() => {
+        suppressNativeTap.set(true);
+      })
       .onUpdate((event) => {
-        if (pageTransitionLocked.get()) {
+        if (nativeInteractionHadMultipleTouches.get() || pageTransitionLocked.get()) {
           return;
         }
 
         translateY.set(event.translationY / dismissOptions.resistance);
       })
       .onEnd((event) => {
+        if (nativeInteractionHadMultipleTouches.get()) {
+          resetDismissTranslation();
+          return;
+        }
+
         if (pageTransitionLocked.get()) {
-          translateY.set(withSpring(0, PAGE_SPRING_CONFIG));
+          resetDismissTranslation();
           return;
         }
 
@@ -778,8 +804,24 @@ export const useGestureViewer = <ItemT>({
         }
 
         translateY.set(withSpring(0, PAGE_SPRING_CONFIG));
+      })
+      .onFinalize((_event, success) => {
+        if ((!success || nativeInteractionHadMultipleTouches.get()) && scale.get() <= 1) {
+          resetDismissTranslation();
+        }
       });
-  }, [translateY, dismissOptions, handleDismiss, isTriggerOpening, isZoomed, pageTransitionLocked]);
+  }, [
+    dismissOptions,
+    handleDismiss,
+    isPinching,
+    isTriggerOpening,
+    isZoomed,
+    nativeInteractionHadMultipleTouches,
+    pageTransitionLocked,
+    scale,
+    suppressNativeTap,
+    translateY,
+  ]);
 
   const getCurrentTapTarget = useCallback((): { index: number; item: ItemT } | null => {
     const index = pendingIndexRef.current;
@@ -825,14 +867,26 @@ export const useGestureViewer = <ItemT>({
       Gesture.Tap()
         .enabled(enableNativeTapGestures)
         .numberOfTaps(1)
+        .maxDistance(NATIVE_TAP_MAX_DISTANCE)
+        .onTouchesDown((event, stateManager) => {
+          if (event.numberOfTouches === 1) {
+            nativeInteractionHadMultipleTouches.set(false);
+            suppressNativeTap.set(false);
+            return;
+          }
+
+          nativeInteractionHadMultipleTouches.set(true);
+          suppressNativeTap.set(true);
+          stateManager.fail();
+        })
         .onEnd((event, success) => {
-          if (!success || pageTransitionLocked.get()) {
+          if (!success || pageTransitionLocked.get() || suppressNativeTap.get()) {
             return;
           }
 
           scheduleOnRN(emitSingleTap, event.x, event.y);
         }),
-    [emitSingleTap, pageTransitionLocked],
+    [emitSingleTap, nativeInteractionHadMultipleTouches, pageTransitionLocked, suppressNativeTap],
   );
 
   const doubleTapGesture = useMemo(
@@ -840,8 +894,18 @@ export const useGestureViewer = <ItemT>({
       Gesture.Tap()
         .enabled(enableDoubleTapZoom && enableNativeTapGestures)
         .numberOfTaps(2)
+        .maxDistance(NATIVE_TAP_MAX_DISTANCE)
+        .onTouchesDown((event, stateManager) => {
+          if (event.numberOfTouches === 1) {
+            return;
+          }
+
+          nativeInteractionHadMultipleTouches.set(true);
+          suppressNativeTap.set(true);
+          stateManager.fail();
+        })
         .onEnd((event) => {
-          if (pageTransitionLocked.get()) {
+          if (pageTransitionLocked.get() || suppressNativeTap.get()) {
             return;
           }
 
@@ -860,8 +924,10 @@ export const useGestureViewer = <ItemT>({
       enableDoubleTapZoom,
       height,
       maxZoomScale,
+      nativeInteractionHadMultipleTouches,
       pageTransitionLocked,
       scale,
+      suppressNativeTap,
       translateX,
       translateY,
       width,
@@ -878,11 +944,9 @@ export const useGestureViewer = <ItemT>({
       Gesture.Pinch()
         .enabled(enablePinchZoom)
         .onTouchesDown((event) => {
-          if (pageTransitionLocked.get()) {
-            return;
-          }
-
           if (event.numberOfTouches === 2) {
+            nativeInteractionHadMultipleTouches.set(true);
+            suppressNativeTap.set(true);
             scheduleOnRN(setIsPinching, true);
           }
         })
@@ -891,9 +955,24 @@ export const useGestureViewer = <ItemT>({
             return;
           }
 
-          startScale.set(scale.get());
-          initialTranslateX.set(translateX.get());
-          initialTranslateY.set(translateY.get());
+          const currentScale = scale.get();
+
+          nativeInteractionHadMultipleTouches.set(true);
+          suppressNativeTap.set(true);
+          startScale.set(currentScale);
+
+          if (currentScale <= 1) {
+            cancelAnimation(translateX);
+            cancelAnimation(translateY);
+            translateX.set(0);
+            translateY.set(0);
+            initialTranslateX.set(0);
+            initialTranslateY.set(0);
+          } else {
+            initialTranslateX.set(translateX.get());
+            initialTranslateY.set(translateY.get());
+          }
+
           startFocalX.set(event.focalX);
           startFocalY.set(event.focalY);
           lastFocalX.set(event.focalX);
@@ -1042,32 +1121,44 @@ export const useGestureViewer = <ItemT>({
       startFocalX,
       startFocalY,
       hasActiveFocal,
+      nativeInteractionHadMultipleTouches,
       pageTransitionLocked,
+      suppressNativeTap,
     ],
   );
 
   const zoomPanGesture = useMemo(
     () =>
       Gesture.Pan()
-        .enabled(enablePanWhenZoomed && isZoomed)
+        .enabled(enablePanWhenZoomed && !isPinching && isZoomed)
         .maxPointers(1)
         .activeCursor('grabbing')
         .averageTouches(true)
         .onTouchesDown((event, stateManager) => {
+          if (event.numberOfTouches === 1) {
+            nativeInteractionHadMultipleTouches.set(false);
+            return;
+          }
+
           if (event.numberOfTouches > 1) {
+            nativeInteractionHadMultipleTouches.set(true);
+            suppressNativeTap.set(true);
             stateManager.fail();
           }
         })
         .onBegin(() => {
-          if (pageTransitionLocked.get()) {
+          if (nativeInteractionHadMultipleTouches.get() || pageTransitionLocked.get()) {
             return;
           }
 
           initialTranslateX.set(translateX.get());
           initialTranslateY.set(translateY.get());
         })
+        .onStart(() => {
+          suppressNativeTap.set(true);
+        })
         .onUpdate((event) => {
-          if (pageTransitionLocked.get()) {
+          if (nativeInteractionHadMultipleTouches.get() || pageTransitionLocked.get()) {
             return;
           }
 
@@ -1092,12 +1183,15 @@ export const useGestureViewer = <ItemT>({
       translateX,
       translateY,
       enablePanWhenZoomed,
+      isPinching,
       isZoomed,
       scale,
       initialTranslateX,
       initialTranslateY,
       constrainTranslation,
+      nativeInteractionHadMultipleTouches,
       pageTransitionLocked,
+      suppressNativeTap,
     ],
   );
 

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -740,12 +740,18 @@ export const useGestureViewer = <ItemT>({
 
     return Gesture.Pan()
       .minDistance(10)
+      .maxPointers(1)
       .averageTouches(true)
       .activeCursor('grabbing')
       .activeOffsetY([-10, 10])
       .failOffsetX([-10, 10])
       .withRef(dismissGestureRef)
       .enabled(canDismiss)
+      .onTouchesDown((event, stateManager) => {
+        if (event.numberOfTouches > 1) {
+          stateManager.fail();
+        }
+      })
       .onUpdate((event) => {
         if (pageTransitionLocked.get()) {
           return;
@@ -1044,8 +1050,14 @@ export const useGestureViewer = <ItemT>({
     () =>
       Gesture.Pan()
         .enabled(enablePanWhenZoomed && isZoomed)
+        .maxPointers(1)
         .activeCursor('grabbing')
         .averageTouches(true)
+        .onTouchesDown((event, stateManager) => {
+          if (event.numberOfTouches > 1) {
+            stateManager.fail();
+          }
+        })
         .onBegin(() => {
           if (pageTransitionLocked.get()) {
             return;
@@ -1090,8 +1102,8 @@ export const useGestureViewer = <ItemT>({
   );
 
   const zoomGesture = useMemo(
-    () => Gesture.Race(zoomPinchGesture, Gesture.Exclusive(zoomPanGesture, tapGesture)),
-    [zoomPinchGesture, zoomPanGesture, tapGesture],
+    () => Gesture.Exclusive(zoomPanGesture, tapGesture),
+    [zoomPanGesture, tapGesture],
   );
 
   const onWebClick = useWebClickHandler({
@@ -1153,5 +1165,6 @@ export const useGestureViewer = <ItemT>({
     renderWindowSlots,
     visualPage,
     zoomGesture,
+    zoomPinchGesture,
   };
 };

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -1,6 +1,12 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
-import { cancelAnimation, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
+import {
+  cancelAnimation,
+  type SharedValue,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 
 import {
@@ -30,6 +36,7 @@ type UseGestureViewerPagingOptions = {
   isTriggerOpening: boolean;
   isZoomed: boolean;
   pageStride: number;
+  suppressNativeTap: SharedValue<boolean>;
   width: number;
 };
 
@@ -52,6 +59,7 @@ export function useGestureViewerPaging({
   isTriggerOpening,
   isZoomed,
   pageStride,
+  suppressNativeTap,
   width,
 }: UseGestureViewerPagingOptions) {
   const visualPage = useSharedValue(initialPage);
@@ -190,6 +198,7 @@ export function useGestureViewerPaging({
       .enabled(canSwipe)
       .onTouchesDown((event, stateManager) => {
         if (event.numberOfTouches > 1) {
+          suppressNativeTap.set(true);
           releasePagingForPinch();
           stateManager.fail();
         }
@@ -204,6 +213,7 @@ export function useGestureViewerPaging({
         pagingAnimationActive.set(false);
         pagingGestureActive.set(true);
         pagingStartPage.set(visualPage.get());
+        suppressNativeTap.set(true);
         scheduleOnRN(setPageTransitioning, true);
       })
       .onUpdate((event) => {
@@ -311,6 +321,7 @@ export function useGestureViewerPaging({
     pagingGestureActive,
     pagingStartPage,
     setPageTransitioning,
+    suppressNativeTap,
     visualPage,
     width,
   ]);

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -166,14 +166,34 @@ export function useGestureViewerPaging({
         }),
       );
     };
+    const releasePagingForPinch = () => {
+      'worklet';
+      if (!pagingGestureActive.get()) {
+        return;
+      }
+
+      cancelAnimation(visualPage);
+      pagingAnimationActive.set(false);
+      pagingGestureActive.set(false);
+      pageTransitionLocked.set(false);
+      visualPage.set(withSpring(centerVirtualIndex, PAGE_SPRING_CONFIG));
+      scheduleOnRN(setPageTransitioning, false);
+    };
 
     return Gesture.Pan()
       .minDistance(10)
+      .maxPointers(1)
       .averageTouches(true)
       .activeCursor('grabbing')
       .activeOffsetX([-10, 10])
       .failOffsetY([-10, 10])
       .enabled(canSwipe)
+      .onTouchesDown((event, stateManager) => {
+        if (event.numberOfTouches > 1) {
+          releasePagingForPinch();
+          stateManager.fail();
+        }
+      })
       .onStart(() => {
         if (pageTransitionLocked.get()) {
           return;


### PR DESCRIPTION
## Summary

- Keep pinch zoom observable while one-finger dismiss, horizontal paging, zoom-pan, and tap gestures remain mutually exclusive.
- Release and reset an active one-finger gesture when a second pointer starts a pinch.
- Prevent pinch, swipe, and drag interactions from triggering `onSingleTap`.
- Limit native tap travel to 10 points to avoid treating an attempted drag as a tap.
- Add regression coverage and a patch changeset for the v3 release.

## Why

A one-finger gesture could win the gesture race before a second pointer was added, preventing pinch zoom from activating reliably. Replacing the entire gesture race with simultaneous recognition improves pinch responsiveness, but allows competing gestures to update the same transforms and can leave tap handling active during dismissal.

This change keeps pinch recognition independent while preserving exclusive ownership among the competing one-finger gestures. It also covers v3's internal horizontal paging gesture.

## Behavior

When a second pointer is added:

- swipe-to-dismiss stops and returns the image to the centered position;
- horizontal paging releases its transition lock and settles back;
- zoom-pan stops updating the image;
- pinch zoom takes control of the transform;
- pending native tap callbacks are suppressed.

There are no public API changes.

## Validation

- `pnpm exec jest --runInBand` (11 suites, 125 tests passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm changeset status`

## Related

- https://github.com/saseungmin/react-native-gesture-image-viewer/pull/185
