### PR TITLE
fix: keep adjacent pages hidden during pinch takeover

### DIFF
--- a/.changeset/calm-images-stay.md
+++ b/.changeset/calm-images-stay.md
@@ -1,0 +1,7 @@
+---
+'react-native-gesture-image-viewer': patch
+---
+
+Prevent adjacent images from bleeding into the active page when pinch zoom takes over after horizontal paging.
+
+Page slots now clip their contents, and an interrupted horizontal swipe snaps back to the committed page before pinch zoom updates transforms.

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -171,6 +171,7 @@ const styles = StyleSheet.create({
   },
   slot: {
     left: 0,
+    overflow: 'hidden',
     position: 'absolute',
     top: 0,
   },

--- a/src/__tests__/GestureViewer.integration.test.tsx
+++ b/src/__tests__/GestureViewer.integration.test.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, render, waitFor } from '@testing-library/react-native';
-import { Text, type View } from 'react-native';
+import { StyleSheet, Text, type View } from 'react-native';
 
 import { GestureViewer } from '../GestureViewer';
 import { PAGE_TRANSITION_CONFIG } from '../gestureViewerAnimation';
@@ -172,6 +172,20 @@ describe('GestureViewer render-window integration', () => {
     expect(rendered.getByText('third')).toBeTruthy();
     expect(rendered.getByText('fourth')).toBeTruthy();
     expect(rendered.queryByText('first')).toBeNull();
+  });
+
+  it('clips every render-window slot so zoomed neighbors cannot bleed into the active page', async () => {
+    const rendered = await render(<Harness initialIndex={1} viewerId="slot-clip" />);
+
+    await expectState(rendered, 'slot-clip', '1/4');
+
+    [0, 1, 2].forEach((index) => {
+      const item = rendered.getByTestId(`slot-clip-item-${index}`);
+      const slotView = item.parent?.parent?.parent;
+
+      expect(slotView).not.toBeNull();
+      expect(StyleSheet.flatten(slotView?.props.style)?.overflow).toBe('hidden');
+    });
   });
 
   it('provides active state for the committed render-window slot', async () => {

--- a/src/__tests__/useGestureViewerPaging.test.ts
+++ b/src/__tests__/useGestureViewerPaging.test.ts
@@ -8,6 +8,7 @@ import { PAGE_TRANSITION_CONFIG } from '../gestureViewerAnimation';
 import { useGestureViewerPaging } from '../useGestureViewerPaging';
 
 const createPagingOptions = ({
+  centerVirtualIndex = 0,
   clearPendingWebSingleTap = jest.fn(),
   commitVirtualIndexOnly = jest.fn(),
   currentIndex = 0,
@@ -16,6 +17,7 @@ const createPagingOptions = ({
   horizontalSwipeVelocityThreshold = 800,
   initialPage = 0,
 }: {
+  centerVirtualIndex?: number;
   clearPendingWebSingleTap?: jest.Mock;
   commitVirtualIndexOnly?: jest.Mock;
   currentIndex?: number;
@@ -24,7 +26,7 @@ const createPagingOptions = ({
   horizontalSwipeVelocityThreshold?: number;
   initialPage?: number;
 } = {}) => ({
-  centerVirtualIndex: 0,
+  centerVirtualIndex,
   clearPendingWebSingleTap,
   commitVirtualIndexOnly,
   currentIndex,
@@ -295,6 +297,36 @@ describe('useGestureViewerPaging horizontal gesture thresholds', () => {
       gesture.handlers.onFinalize?.({} as never, false);
     });
 
+    expect(result.current.pageTransitionLocked.get()).toBe(false);
+  });
+
+  it('snaps visual page to the committed page when pinch takes over active paging', async () => {
+    const { result } = await renderHook(() =>
+      useGestureViewerPaging(
+        createPagingOptions({
+          centerVirtualIndex: 1,
+          currentIndex: 1,
+          initialPage: 1,
+        }),
+      ),
+    );
+    const gesture = result.current.horizontalPagingGesture;
+
+    await act(async () => {
+      gesture.handlers.onStart?.({} as never);
+      gesture.handlers.onUpdate?.({ translationX: -80 } as never);
+    });
+
+    expect(result.current.visualPage.get()).toBe(1.25);
+
+    const stateManager = { fail: jest.fn() };
+
+    await act(async () => {
+      gesture.handlers.onTouchesDown?.({ numberOfTouches: 2 } as never, stateManager as never);
+    });
+
+    expect(stateManager.fail).toHaveBeenCalledTimes(1);
+    expect(result.current.visualPage.get()).toBe(1);
     expect(result.current.pageTransitionLocked.get()).toBe(false);
   });
 

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -184,7 +184,7 @@ export function useGestureViewerPaging({
       pagingAnimationActive.set(false);
       pagingGestureActive.set(false);
       pageTransitionLocked.set(false);
-      visualPage.set(withSpring(centerVirtualIndex, PAGE_SPRING_CONFIG));
+      visualPage.set(centerVirtualIndex);
       scheduleOnRN(setPageTransitioning, false);
     };
 


### PR DESCRIPTION
## Summary

- snap interrupted horizontal paging back to the committed page before pinch updates begin
- clip each render-window slot so adjacent images cannot draw over the active page
- add regression coverage for slot containment and paging-to-pinch handoff
- include a patch changeset

## Why

In `3.0.0-beta.1`, pinch can take over after a one-finger horizontal drag while `visualPage` is still between pages. Because the paging lock is released before the spring finishes, the active image can start zooming while the neighboring page remains visible. Render-window slots also lacked individual clipping, allowing transformed content to cross page boundaries.

This addresses the follow-up report on [PR #185](https://github.com/saseungmin/react-native-gesture-image-viewer/pull/185#issuecomment-5232761338).

## Impact

Pinch takeover remains responsive. If a second finger joins an active horizontal drag, the pager now snaps to the committed page instead of continuing a spring. Each page is contained within its own viewport-sized slot.

## Validation

- `node_modules/.bin/jest --runInBand` — 127 tests passed
- `node_modules/.bin/tsc`
- `node_modules/.bin/oxlint`
- `node_modules/.bin/oxfmt --check`
- `node_modules/.bin/bob build`
- `node_modules/.bin/changeset status`
- pre-commit format, lint, and type hooks

## Not tested

- reproduction in the reporter's application and device environment