### PR TITLE
fix: clamp pan bounds to rendered content

### DIFF
--- a/.changeset/issue-191-pan-bounds.md
+++ b/.changeset/issue-191-pan-bounds.md
@@ -53,6 +53,29 @@ Runtime dimensions reported with `setItemDimensions` take precedence over
 `getItemDimensions`. Invalid or unavailable dimensions keep the existing viewer-cell fallback, so
 both APIs are optional and existing arbitrary-content renderers remain compatible.
 
+If object items are recreated at the same index while their content remains the same, provide
+`getItemKey` to retain their loaded dimensions safely. The key must be unique, must change when the
+rendered source or its natural dimensions can change, and must not be the index alone:
+
+```tsx
+<GestureViewer
+  data={images}
+  getItemKey={(item) => item.uri}
+  renderItem={(item, _index, { setItemDimensions }) => (
+    <Image
+      source={{ uri: item.uri }}
+      onLoad={({ nativeEvent: { source } }) => {
+        setItemDimensions({ width: source.width, height: source.height });
+      }}
+    />
+  )}
+/>
+```
+
+Without `getItemKey`, loaded dimensions are reused only while the exact item instance remains at
+that index. Replaced or reordered items use the viewer-cell fallback until their current dimensions
+become available, preventing stale bounds from a previous item.
+
 On each axis, scaled content stays centered while it is smaller than the viewport and stops when
 its rendered edge reaches the viewport edge once it becomes larger. The same bounds apply to
 pinch, pan, double-tap, web, and controller zoom paths.

--- a/.changeset/issue-191-pan-bounds.md
+++ b/.changeset/issue-191-pan-bounds.md
@@ -1,0 +1,60 @@
+---
+'react-native-gesture-image-viewer': minor
+---
+
+Clamp zoom and pan bounds to the rendered content rect for `contain`-fitted items.
+
+When natural dimensions are already available in each item, provide a stable
+`getItemDimensions` resolver:
+
+```tsx
+type ImageItem = {
+  uri: string;
+  width: number;
+  height: number;
+};
+
+const getImageDimensions = (item: ImageItem) => ({
+  width: item.width,
+  height: item.height,
+});
+
+<GestureViewer
+  data={images}
+  ListComponent={FlatList}
+  getItemDimensions={getImageDimensions}
+  renderItem={(item) => (
+    <Image source={{ uri: item.uri }} style={styles.image} resizeMode="contain" />
+  )}
+/>;
+```
+
+When dimensions are only known after loading, report them through the third `renderItem`
+argument:
+
+```tsx
+<GestureViewer
+  data={images}
+  ListComponent={FlatList}
+  renderItem={(item, _index, { setItemDimensions }) => (
+    <Image
+      source={{ uri: item.uri }}
+      style={styles.image}
+      resizeMode="contain"
+      onLoad={({ nativeEvent: { source } }) => {
+        setItemDimensions({ width: source.width, height: source.height });
+      }}
+    />
+  )}
+/>
+```
+
+Runtime dimensions reported with `setItemDimensions` take precedence over
+`getItemDimensions`. Invalid or unavailable dimensions keep the existing viewer-cell fallback, so
+both APIs are optional and existing arbitrary-content renderers remain compatible.
+
+On each axis, scaled content stays centered while it is smaller than the viewport and stops when
+its rendered edge reaches the viewport edge once it becomes larger. The same bounds apply to
+pinch, pan, double-tap, web, and controller zoom paths.
+
+Fixes [#191](https://github.com/saseungmin/react-native-gesture-image-viewer/issues/191).

--- a/.changeset/issue-191-pan-bounds.md
+++ b/.changeset/issue-191-pan-bounds.md
@@ -2,10 +2,11 @@
 'react-native-gesture-image-viewer': minor
 ---
 
-Clamp zoom and pan bounds to the rendered content rect for `contain`-fitted items.
+Clamp zoom and pan bounds to the rendered content rect for `contain`-fitted items. Content
+smaller than the viewport stays centered, while larger content stops when its edge reaches the
+viewport edge.
 
-When natural dimensions are already available in each item, provide a stable
-`getItemDimensions` resolver:
+When natural dimensions are already available, provide them through `getItemDimensions`:
 
 ```tsx
 type ImageItem = {
@@ -29,8 +30,8 @@ const getImageDimensions = (item: ImageItem) => ({
 />;
 ```
 
-When dimensions are only known after loading, report them through the third `renderItem`
-argument:
+When dimensions are only known after loading, report them through `setItemDimensions` in the third
+`renderItem` argument:
 
 ```tsx
 <GestureViewer
@@ -53,38 +54,13 @@ Runtime dimensions reported with `setItemDimensions` take precedence over
 `getItemDimensions`. Invalid or unavailable dimensions keep the existing viewer-cell fallback, so
 both APIs are optional and existing arbitrary-content renderers remain compatible.
 
-If object items are recreated at the same index while their content remains the same, provide
-`getItemKey` to retain their loaded dimensions safely. The key must be unique, must change when the
-rendered source or its natural dimensions can change, and must not be the index alone:
+If equivalent object items are recreated, provide a stable content key to retain their loaded
+dimensions:
 
 ```tsx
-<GestureViewer
-  data={images}
-  ListComponent={FlatList}
-  getItemKey={(item) => item.uri}
-  renderItem={(item, _index, { setItemDimensions }) => (
-    <Image
-      source={{ uri: item.uri }}
-      onLoad={({ nativeEvent: { source } }) => {
-        setItemDimensions({ width: source.width, height: source.height });
-      }}
-    />
-  )}
-/>
+getItemKey={(item) => item.uri}
 ```
 
-Without `getItemKey`, loaded dimensions are reused only while the exact item instance remains at
-that index. Replaced or reordered items use the viewer-cell fallback until their current dimensions
-become available, preventing stale bounds from a previous item.
-
-Viewer position reconciliation now derives logical manager state and physical list offsets from the
-same normalized target. Changing `initialIndex`, data length, loop layout, viewport width, or item
-spacing can no longer leave the visible page and controller state on different items. Non-finite or
-negative initial indexes resolve to `0`, values above the data range resolve to the last item, and
-empty data reports index `0` without scrolling.
-
-On each axis, scaled content stays centered while it is smaller than the viewport and stops when
-its rendered edge reaches the viewport edge once it becomes larger. The same bounds apply to
-pinch, pan, double-tap, web, and controller zoom paths.
+The same bounds apply to pinch, pan, double-tap, web, and controller zoom paths.
 
 Fixes [#191](https://github.com/saseungmin/react-native-gesture-image-viewer/issues/191).

--- a/.changeset/issue-191-pan-bounds.md
+++ b/.changeset/issue-191-pan-bounds.md
@@ -76,6 +76,12 @@ Without `getItemKey`, loaded dimensions are reused only while the exact item ins
 that index. Replaced or reordered items use the viewer-cell fallback until their current dimensions
 become available, preventing stale bounds from a previous item.
 
+Viewer position reconciliation now derives logical manager state and physical list offsets from the
+same normalized target. Changing `initialIndex`, data length, loop layout, viewport width, or item
+spacing can no longer leave the visible page and controller state on different items. Non-finite or
+negative initial indexes resolve to `0`, values above the data range resolve to the last item, and
+empty data reports index `0` without scrolling.
+
 On each axis, scaled content stays centered while it is smaller than the viewport and stops when
 its rendered edge reaches the viewport edge once it becomes larger. The same bounds apply to
 pinch, pan, double-tap, web, and controller zoom paths.

--- a/.changeset/issue-191-pan-bounds.md
+++ b/.changeset/issue-191-pan-bounds.md
@@ -60,6 +60,7 @@ rendered source or its natural dimensions can change, and must not be the index 
 ```tsx
 <GestureViewer
   data={images}
+  ListComponent={FlatList}
   getItemKey={(item) => item.uri}
   renderItem={(item, _index, { setItemDimensions }) => (
     <Image

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -59,8 +59,16 @@ import {
   useGestureViewerState,
 } from 'react-native-gesture-image-viewer';
 
+const images = [
+  { uri: 'https://picsum.photos/400/200', width: 400, height: 200 },
+  { uri: 'https://picsum.photos/200/400', width: 200, height: 400 },
+];
+
+function getImageDimensions(image: (typeof images)[number]) {
+  return { width: image.width, height: image.height };
+}
+
 function App() {
-  const images = [...];
   const [visible, setVisible] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -73,8 +81,14 @@ function App() {
     setVisible(true);
   };
 
-  const renderImage = useCallback((imageUrl: string) => {
-    return <Image source={{ uri: imageUrl }} style={{ width: '100%', height: '100%' }} resizeMode="contain" />;
+  const renderImage = useCallback((image: (typeof images)[number]) => {
+    return (
+      <Image
+        source={{ uri: image.uri }}
+        style={{ width: '100%', height: '100%' }}
+        resizeMode="contain"
+      />
+    );
   }, []);
 
   useGestureViewerEvent('zoomChange', (data) => {
@@ -83,10 +97,10 @@ function App() {
 
   return (
     <View>
-      {images.map((uri, index) => (
-        <GestureTrigger key={uri} onPress={() => openModal(index)}>
+      {images.map((image, index) => (
+        <GestureTrigger key={image.uri} onPress={() => openModal(index)}>
           <Pressable>
-            <Image source={{ uri }} />
+            <Image source={{ uri: image.uri }} />
           </Pressable>
         </GestureTrigger>
       ))}
@@ -95,6 +109,7 @@ function App() {
           data={images}
           initialIndex={selectedIndex}
           renderItem={renderImage}
+          getItemDimensions={getImageDimensions}
           ListComponent={ScrollView}
           onDismiss={() => setVisible(false)}
         />

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -126,6 +126,11 @@ function App() {
 }
 ```
 
+이미지 load callback에서 치수를 얻고 객체 item이 다시 생성될 수 있다면
+`getItemKey={(item) => item.uri}`처럼 안정적이고 고유한 key를 제공하세요. 같은 index에서
+동일한 논리적 item이 재생성될 때는 치수를 유지하고, 교체되거나 재정렬된 item에는 이전
+치수가 적용되지 않습니다.
+
 ## 기여하기
 
 프로젝트 기여 방법과 개발 환경 설정에 대한 자세한 내용은 [기여 가이드](CONTRIBUTING.md)를 참고해 주세요.

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -60,14 +60,10 @@ import {
 } from 'react-native-gesture-image-viewer';
 
 const images = [
-  { uri: 'https://picsum.photos/400/200', width: 400, height: 200 },
-  { uri: 'https://picsum.photos/200/400', width: 200, height: 400 },
-  { uri: 'https://picsum.photos/300/300', width: 300, height: 300 },
+  'https://picsum.photos/400/200',
+  'https://picsum.photos/200/400',
+  'https://picsum.photos/300/300',
 ];
-
-function getImageDimensions(image: (typeof images)[number]) {
-  return { width: image.width, height: image.height };
-}
 
 function App() {
   const [visible, setVisible] = useState(false);
@@ -82,10 +78,10 @@ function App() {
     setVisible(true);
   };
 
-  const renderImage = useCallback((image: (typeof images)[number]) => {
+  const renderImage = useCallback((imageUrl: string) => {
     return (
       <Image
-        source={{ uri: image.uri }}
+        source={{ uri: imageUrl }}
         style={{ width: '100%', height: '100%' }}
         resizeMode="contain"
       />
@@ -98,10 +94,10 @@ function App() {
 
   return (
     <View>
-      {images.map((image, index) => (
-        <GestureTrigger key={image.uri} onPress={() => openModal(index)}>
+      {images.map((imageUrl, index) => (
+        <GestureTrigger key={imageUrl} onPress={() => openModal(index)}>
           <Pressable>
-            <Image source={{ uri: image.uri }} />
+            <Image source={{ uri: imageUrl }} />
           </Pressable>
         </GestureTrigger>
       ))}
@@ -110,7 +106,6 @@ function App() {
           data={images}
           initialIndex={selectedIndex}
           renderItem={renderImage}
-          getItemDimensions={getImageDimensions}
           ListComponent={ScrollView}
           onDismiss={() => setVisible(false)}
         />
@@ -126,10 +121,8 @@ function App() {
 }
 ```
 
-이미지 load callback에서 치수를 얻고 객체 item이 다시 생성될 수 있다면
-`getItemKey={(item) => item.uri}`처럼 안정적이고 고유한 key를 제공하세요. 같은 index에서
-동일한 논리적 item이 재생성될 때는 치수를 유지하고, 교체되거나 재정렬된 item에는 이전
-치수가 적용되지 않습니다.
+`contain` 콘텐츠의 정확한 pan 범위가 필요하다면
+[콘텐츠 치수 가이드](https://react-native-gesture-image-viewer.pages.dev/ko/guide/usage/custom-components#콘텐츠-치수)를 참고하세요.
 
 ## 기여하기
 

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -62,6 +62,7 @@ import {
 const images = [
   { uri: 'https://picsum.photos/400/200', width: 400, height: 200 },
   { uri: 'https://picsum.photos/200/400', width: 200, height: 400 },
+  { uri: 'https://picsum.photos/300/300', width: 300, height: 300 },
 ];
 
 function getImageDimensions(image: (typeof images)[number]) {

--- a/README.md
+++ b/README.md
@@ -60,14 +60,10 @@ import {
 } from 'react-native-gesture-image-viewer';
 
 const images = [
-  { uri: 'https://picsum.photos/400/200', width: 400, height: 200 },
-  { uri: 'https://picsum.photos/200/400', width: 200, height: 400 },
-  { uri: 'https://picsum.photos/300/300', width: 300, height: 300 },
+  'https://picsum.photos/400/200',
+  'https://picsum.photos/200/400',
+  'https://picsum.photos/300/300',
 ];
-
-function getImageDimensions(image: (typeof images)[number]) {
-  return { width: image.width, height: image.height };
-}
 
 function App() {
   const [visible, setVisible] = useState(false);
@@ -82,10 +78,10 @@ function App() {
     setVisible(true);
   };
 
-  const renderImage = useCallback((image: (typeof images)[number]) => {
+  const renderImage = useCallback((imageUrl: string) => {
     return (
       <Image
-        source={{ uri: image.uri }}
+        source={{ uri: imageUrl }}
         style={{ width: '100%', height: '100%' }}
         resizeMode="contain"
       />
@@ -98,10 +94,10 @@ function App() {
 
   return (
     <View>
-      {images.map((image, index) => (
-        <GestureTrigger key={image.uri} onPress={() => openModal(index)}>
+      {images.map((imageUrl, index) => (
+        <GestureTrigger key={imageUrl} onPress={() => openModal(index)}>
           <Pressable>
-            <Image source={{ uri: image.uri }} />
+            <Image source={{ uri: imageUrl }} />
           </Pressable>
         </GestureTrigger>
       ))}
@@ -110,7 +106,6 @@ function App() {
           data={images}
           initialIndex={selectedIndex}
           renderItem={renderImage}
-          getItemDimensions={getImageDimensions}
           ListComponent={ScrollView}
           onDismiss={() => setVisible(false)}
         />
@@ -126,9 +121,8 @@ function App() {
 }
 ```
 
-When dimensions are learned from an image load callback and object items may be recreated, provide
-`getItemKey={(item) => item.uri}` (or another stable unique key). This preserves dimensions when the
-same logical item is recreated at the same index without reusing them after replacement or reorder.
+For accurate pan bounds with `contain`-fitted content, see the
+[Content Dimensions guide](https://react-native-gesture-image-viewer.pages.dev/guide/usage/custom-components#content-dimensions).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,16 @@ import {
   useGestureViewerState,
 } from 'react-native-gesture-image-viewer';
 
+const images = [
+  { uri: 'https://picsum.photos/400/200', width: 400, height: 200 },
+  { uri: 'https://picsum.photos/200/400', width: 200, height: 400 },
+];
+
+function getImageDimensions(image: (typeof images)[number]) {
+  return { width: image.width, height: image.height };
+}
+
 function App() {
-  const images = [...];
   const [visible, setVisible] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -73,8 +81,14 @@ function App() {
     setVisible(true);
   };
 
-  const renderImage = useCallback((imageUrl: string) => {
-    return <Image source={{ uri: imageUrl }} style={{ width: '100%', height: '100%' }} resizeMode="contain" />;
+  const renderImage = useCallback((image: (typeof images)[number]) => {
+    return (
+      <Image
+        source={{ uri: image.uri }}
+        style={{ width: '100%', height: '100%' }}
+        resizeMode="contain"
+      />
+    );
   }, []);
 
   useGestureViewerEvent('zoomChange', (data) => {
@@ -83,10 +97,10 @@ function App() {
 
   return (
     <View>
-      {images.map((uri, index) => (
-        <GestureTrigger key={uri} onPress={() => openModal(index)}>
+      {images.map((image, index) => (
+        <GestureTrigger key={image.uri} onPress={() => openModal(index)}>
           <Pressable>
-            <Image source={{ uri }} />
+            <Image source={{ uri: image.uri }} />
           </Pressable>
         </GestureTrigger>
       ))}
@@ -95,6 +109,7 @@ function App() {
           data={images}
           initialIndex={selectedIndex}
           renderItem={renderImage}
+          getItemDimensions={getImageDimensions}
           ListComponent={ScrollView}
           onDismiss={() => setVisible(false)}
         />

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ import {
 const images = [
   { uri: 'https://picsum.photos/400/200', width: 400, height: 200 },
   { uri: 'https://picsum.photos/200/400', width: 200, height: 400 },
+  { uri: 'https://picsum.photos/300/300', width: 300, height: 300 },
 ];
 
 function getImageDimensions(image: (typeof images)[number]) {

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ function App() {
 }
 ```
 
+When dimensions are learned from an image load callback and object items may be recreated, provide
+`getItemKey={(item) => item.uri}` (or another stable unique key). This preserves dimensions when the
+same logical item is recreated at the same index without reusing them after replacement or reorder.
+
 ## Contributing
 
 For details on how to contribute to the project and set up the development environment, please refer to the [Contributing Guide](CONTRIBUTING.md).

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -13,28 +13,49 @@ import {
 } from 'react-native-gesture-image-viewer';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const photos = [
+type Photo = {
+  uri: string;
+  width: number;
+  height: number;
+  note: string;
+};
+
+const photos: Photo[] = [
   {
     uri: 'https://picsum.photos/400/200',
+    width: 400,
+    height: 200,
     note: 'Single tap anywhere to hide or show the viewer controls.',
   },
   {
     uri: 'https://picsum.photos/300/200',
+    width: 300,
+    height: 200,
     note: 'Pinch to zoom and swipe left or right to move between items.',
   },
   {
     uri: 'https://picsum.photos/200/200',
+    width: 200,
+    height: 200,
     note: 'Use the toolbar buttons for zoom, rotate, and reset actions.',
   },
   {
     uri: 'https://picsum.photos/200/300',
+    width: 200,
+    height: 300,
     note: 'Swipe down to dismiss the viewer at any time.',
   },
   {
     uri: 'https://picsum.photos/200/400',
+    width: 200,
+    height: 400,
     note: 'Loop mode lets you keep paging without stopping at the end.',
   },
-] as const;
+];
+
+function getPhotoDimensions(photo: Photo) {
+  return { width: photo.width, height: photo.height };
+}
 
 function Example() {
   const [visible, setVisible] = useState(false);
@@ -70,10 +91,10 @@ function Example() {
   });
 
   const renderImage = useCallback(
-    (imageUrl: string, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
+    (photo: Photo, _index: number, { isActive }: GestureViewerRenderItemInfo) => {
       return (
         <Image
-          source={{ uri: imageUrl }}
+          source={{ uri: photo.uri }}
           style={{ width: '100%', height: '100%', opacity: isActive ? 1 : 0.5 }}
           pointerEvents="none"
           contentFit="contain"
@@ -109,13 +130,14 @@ function Example() {
       >
         <View style={{ flex: 1 }}>
           <GestureViewer
-            data={photos.map(({ uri }) => uri)}
+            data={photos}
             initialIndex={selectedIndex}
             onDismiss={() => setVisible(false)}
             onDismissStart={() => setShowExternalUI(false)}
             enableLoop={enableLoop}
             ListComponent={FlashList}
             renderItem={renderImage}
+            getItemDimensions={getPhotoDimensions}
             dismiss={{
               direction: 'down',
             }}

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -42,12 +42,9 @@ function GestureViewerItemCell<ItemT>({
   renderItem,
   setItemDimensions,
 }: GestureViewerItemCellProps<ItemT>) {
-  const registerItemDimensions = useCallback(
-    (dimensions: GestureViewerItemDimensions) => {
-      setItemDimensions(index, item, dimensions);
-    },
-    [index, item, setItemDimensions],
-  );
+  const registerItemDimensions = (dimensions: GestureViewerItemDimensions) => {
+    setItemDimensions(index, item, dimensions);
+  };
 
   return renderItem(item, index, {
     isActive,

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, type ReactElement } from 'react';
 import {
   Platform,
   type ScrollViewProps,
@@ -72,14 +72,12 @@ export function GestureViewer<ItemT, LC>({
 }: GestureViewerProps<ItemT, LC>) {
   const Component = ListComponent as React.ComponentType<any>;
 
-  const dataRef = useRef(data);
-
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
   const width = customWidth || screenWidth;
   const height = customHeight || screenHeight;
 
-  const loopData = useMemo(() => createLoopData(dataRef, enableLoop), [enableLoop]);
+  const loopData = useMemo(() => createLoopData(data, enableLoop), [data, enableLoop]);
 
   const isScrollView = isScrollViewLike(Component);
   const isFlashList = isFlashListLike(Component);
@@ -174,10 +172,6 @@ export function GestureViewer<ItemT, LC>({
   const gesture = useMemo(() => {
     return Gesture.Race(dismissGesture, zoomGesture);
   }, [zoomGesture, dismissGesture]);
-
-  useEffect(() => {
-    dataRef.current = data;
-  }, [data]);
 
   useEffect(() => {
     registry.createManager(id);

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type ReactElement } from 'react';
 import {
   Platform,
   type ScrollViewProps,
@@ -10,7 +10,11 @@ import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-g
 import Animated from 'react-native-reanimated';
 
 import { registry } from './GestureViewerRegistry';
-import type { GestureViewerProps } from './types';
+import type {
+  GestureViewerItemDimensions,
+  GestureViewerProps,
+  GestureViewerRenderItemInfo,
+} from './types';
 import { useGestureViewer } from './useGestureViewer';
 import {
   createLoopData,
@@ -20,6 +24,34 @@ import {
   shouldUseNativeScrollGesture,
 } from './utils';
 import WebPagingFixStyle from './WebPagingFixStyle';
+
+type GestureViewerItemCellProps<ItemT> = {
+  item: ItemT;
+  index: number;
+  isActive: boolean;
+  renderItem: (item: ItemT, index: number, info: GestureViewerRenderItemInfo) => ReactElement;
+  setItemDimensions: (index: number, item: ItemT, dimensions: GestureViewerItemDimensions) => void;
+};
+
+function GestureViewerItemCell<ItemT>({
+  item,
+  index,
+  isActive,
+  renderItem,
+  setItemDimensions,
+}: GestureViewerItemCellProps<ItemT>) {
+  const registerItemDimensions = useCallback(
+    (dimensions: GestureViewerItemDimensions) => {
+      setItemDimensions(index, item, dimensions);
+    },
+    [index, item, setItemDimensions],
+  );
+
+  return renderItem(item, index, {
+    isActive,
+    setItemDimensions: registerItemDimensions,
+  });
+}
 
 export function GestureViewer<ItemT, LC>({
   id = 'default',
@@ -68,6 +100,7 @@ export function GestureViewer<ItemT, LC>({
     animatedStyle,
     backdropStyle,
     handleDismiss,
+    setItemDimensions,
   } = useGestureViewer({
     id,
     data,
@@ -106,9 +139,13 @@ export function GestureViewer<ItemT, LC>({
             styles.item,
           ]}
         >
-          {renderItemProp(item, index, {
-            isActive: index === activeListIndex && isFlashListCell,
-          })}
+          <GestureViewerItemCell
+            index={index}
+            isActive={index === activeListIndex && isFlashListCell}
+            item={item}
+            renderItem={renderItemProp}
+            setItemDimensions={setItemDimensions}
+          />
         </View>
       );
     },
@@ -121,6 +158,7 @@ export function GestureViewer<ItemT, LC>({
       isScrollView,
       isFlashList,
       height,
+      setItemDimensions,
     ],
   );
 

--- a/src/GestureViewer.tsx
+++ b/src/GestureViewer.tsx
@@ -17,7 +17,9 @@ import type {
 } from './types';
 import { useGestureViewer } from './useGestureViewer';
 import {
+  clampIndex,
   createLoopData,
+  getLoopPhysicalIndex,
   isFlashListLike,
   isFlatListLike,
   isScrollViewLike,
@@ -76,6 +78,8 @@ export function GestureViewer<ItemT, LC>({
 
   const width = customWidth || screenWidth;
   const height = customHeight || screenHeight;
+  const normalizedInitialIndex = clampIndex(initialIndex, data.length);
+  const initialListIndex = getLoopPhysicalIndex(normalizedInitialIndex, data.length, enableLoop);
 
   const loopData = useMemo(() => createLoopData(data, enableLoop), [data, enableLoop]);
 
@@ -104,7 +108,7 @@ export function GestureViewer<ItemT, LC>({
     data,
     width,
     height,
-    initialIndex,
+    initialIndex: normalizedInitialIndex,
     itemSpacing,
     enableLoop,
     ...props,
@@ -257,9 +261,7 @@ export function GestureViewer<ItemT, LC>({
                     {...commonProps}
                     data={loopData}
                     renderItem={renderItem}
-                    initialScrollIndex={
-                      enableLoop && data.length > 1 ? initialIndex + 1 : initialIndex
-                    }
+                    initialScrollIndex={initialListIndex}
                     keyExtractor={keyExtractor}
                     {...(isFlashList
                       ? // NOTE - Deprecated estimatedItemSize for FlashList V2 (https://shopify.github.io/flash-list/docs/v2-changes#deprecated)

--- a/src/GestureViewerManager.ts
+++ b/src/GestureViewerManager.ts
@@ -6,12 +6,22 @@ import type {
   GestureViewerEventType,
   GestureViewerState,
 } from './types';
-import { createBoundsConstraint, createScrollAction } from './utils';
+import { clampTranslationToBounds, createScrollAction } from './utils';
+
+type ZoomSharedValuesOptions = {
+  scale: SharedValue<number>;
+  translateX: SharedValue<number>;
+  translateY: SharedValue<number>;
+  maxZoomScale: number;
+  contentWidth?: SharedValue<number>;
+  contentHeight?: SharedValue<number>;
+};
 
 class GestureViewerManager {
   private currentIndex = 0;
   private dataLength = 0;
-  private width = 0;
+  private pagingStride = 0;
+  private viewportWidth = 0;
   private height = 0;
   private maxZoomScale = 2;
   private enableHorizontalSwipe = true;
@@ -22,6 +32,8 @@ class GestureViewerManager {
   private rotation: SharedValue<number> | null = null;
   private translateX: SharedValue<number> | null = null;
   private translateY: SharedValue<number> | null = null;
+  private contentWidth: SharedValue<number> | null = null;
+  private contentHeight: SharedValue<number> | null = null;
   private resetTransformCallback: (() => void) | null = null;
 
   private loopCallback: (() => void) | null = null;
@@ -105,8 +117,12 @@ class GestureViewerManager {
     this.enableLoop = enabled;
   }
 
-  setWidth(width: number) {
-    this.width = width;
+  setPagingStride(pagingStride: number) {
+    this.pagingStride = pagingStride;
+  }
+
+  setViewportWidth(width: number) {
+    this.viewportWidth = width;
   }
 
   setHeight(height: number) {
@@ -131,16 +147,20 @@ class GestureViewerManager {
     }
   }
 
-  setZoomSharedValues(
-    scale: SharedValue<number>,
-    translateX: SharedValue<number>,
-    translateY: SharedValue<number>,
-    maxZoomScale: number,
-  ) {
+  setZoomSharedValues({
+    scale,
+    translateX,
+    translateY,
+    maxZoomScale,
+    contentWidth,
+    contentHeight,
+  }: ZoomSharedValuesOptions) {
     this.scale = scale;
     this.translateX = translateX;
     this.translateY = translateY;
     this.maxZoomScale = maxZoomScale;
+    this.contentWidth = contentWidth ?? null;
+    this.contentHeight = contentHeight ?? null;
   }
 
   setResetTransformCallback(callback: (() => void) | null) {
@@ -203,10 +223,7 @@ class GestureViewerManager {
 
     this.scale.set(withTiming(nextScale));
 
-    const { translateX, translateY } = createBoundsConstraint({
-      width: this.width,
-      height: this.height,
-    })({
+    const { translateX, translateY } = this.constrainZoomTranslation({
       translateX: this.translateX.get(),
       translateY: this.translateY.get(),
       scale: nextScale,
@@ -237,10 +254,7 @@ class GestureViewerManager {
       return;
     }
 
-    const { translateX, translateY } = createBoundsConstraint({
-      width: this.width,
-      height: this.height,
-    })({
+    const { translateX, translateY } = this.constrainZoomTranslation({
       translateX: this.translateX.get(),
       translateY: this.translateY.get(),
       scale: nextScale,
@@ -273,7 +287,7 @@ class GestureViewerManager {
 
     this.cancelPendingLoopTransition();
 
-    const { scrollTo } = createScrollAction(this.listRef, this.width);
+    const { scrollTo } = createScrollAction(this.listRef, this.pagingStride || this.viewportWidth);
 
     if (this.enableLoop && this.dataLength > 1) {
       if (index < 0) {
@@ -358,9 +372,14 @@ class GestureViewerManager {
     this.currentIndex = 0;
     this.dataLength = 0;
     this.maxZoomScale = 2;
+    this.pagingStride = 0;
+    this.viewportWidth = 0;
+    this.height = 0;
     this.scale = null;
     this.translateX = null;
     this.translateY = null;
+    this.contentWidth = null;
+    this.contentHeight = null;
     this.rotation = null;
     this.resetTransformCallback = null;
     this.eventListeners.clear();
@@ -369,6 +388,26 @@ class GestureViewerManager {
   private updateCurrentIndex = (targetIndex: number) => {
     this.currentIndex = targetIndex;
     this.notifyListeners();
+  };
+
+  private constrainZoomTranslation = ({
+    scale,
+    translateX,
+    translateY,
+  }: {
+    scale: number;
+    translateX: number;
+    translateY: number;
+  }) => {
+    return clampTranslationToBounds({
+      contentHeight: this.contentHeight?.get(),
+      contentWidth: this.contentWidth?.get(),
+      height: this.height,
+      scale,
+      translateX,
+      translateY,
+      width: this.viewportWidth || this.pagingStride,
+    });
   };
 }
 

--- a/src/__tests__/itemDimensions.test.ts
+++ b/src/__tests__/itemDimensions.test.ts
@@ -41,7 +41,7 @@ describe('item dimensions registry', () => {
     expect(getItemDimensions).toHaveBeenLastCalledWith(second, 1);
   });
 
-  it('prefers valid runtime registration, ignores invalid input, and dedupes equal values', () => {
+  it('prefers same-item runtime registration, ignores invalid input, and dedupes equal values', () => {
     const item = { id: 'active' };
     const data = [item];
     const registry: ItemDimensionsRegistry<Item> = new Map();
@@ -137,41 +137,124 @@ describe('item dimensions registry', () => {
     ).toEqual(dimensions(100, 300));
   });
 
-  it('prunes replaced or removed entries while rejecting late stale callbacks', () => {
+  it('prefers current getter dimensions over a stale slot cache', () => {
     const replaced = { id: 'replaced' };
-    const retained = { id: 'retained' };
     const next = { id: 'next' };
     const registry: ItemDimensionsRegistry<Item> = new Map();
+    const getItemDimensions = jest.fn(() => dimensions(300, 400));
 
     registerItemDimensions({
-      data: [replaced, retained],
+      data: [replaced],
       dimensions: dimensions(100, 200),
       index: 0,
       item: replaced,
       registry,
     });
-    registerItemDimensions({
-      data: [replaced, retained],
-      dimensions: dimensions(200, 100),
-      index: 1,
-      item: retained,
-      registry,
-    });
 
-    pruneItemDimensionsRegistry(registry, [next, retained]);
+    pruneItemDimensionsRegistry(registry, 1);
 
     expect(registry.size).toBe(1);
-    expect(registry.get(1)?.item).toBe(retained);
+    expect(resolveItemDimensions({ data: [next], getItemDimensions, index: 0, registry })).toEqual(
+      dimensions(300, 400),
+    );
+    expect(getItemDimensions).toHaveBeenCalledWith(next, 0);
     expect(
       registerItemDimensions({
-        data: [next, retained],
+        data: [next],
         dimensions: dimensions(100, 200),
         index: 0,
         item: replaced,
         registry,
       }),
     ).toBe(false);
-    expect(registry.size).toBe(1);
+    expect(registry.get(0)?.dimensions).toEqual(dimensions(100, 200));
+    expect(
+      registerItemDimensions({
+        data: [next],
+        dimensions: dimensions(300, 400),
+        index: 0,
+        item: next,
+        registry,
+      }),
+    ).toBe(true);
+    expect(resolveItemDimensions({ data: [next], getItemDimensions, index: 0, registry })).toEqual(
+      dimensions(300, 400),
+    );
+  });
+
+  it('uses the last-known slot cache for a recreated item when the getter is missing', () => {
+    const item = { id: 'item' };
+    const recreatedItem = { id: 'item' };
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+    const getItemDimensions = jest.fn(() => undefined);
+
+    registerItemDimensions({
+      data: [item],
+      dimensions: dimensions(100, 200),
+      index: 0,
+      item,
+      registry,
+    });
+
+    pruneItemDimensionsRegistry(registry, 1);
+
+    expect(registry.has(0)).toBe(true);
+    expect(
+      resolveItemDimensions({ data: [recreatedItem], getItemDimensions, index: 0, registry }),
+    ).toEqual(dimensions(100, 200));
+    expect(getItemDimensions).toHaveBeenCalledWith(recreatedItem, 0);
+  });
+
+  it('prunes only out-of-range cached indexes', () => {
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+    const third = { id: 'third' };
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+
+    registerItemDimensions({
+      data: [first, second, third],
+      dimensions: dimensions(100, 200),
+      index: 0,
+      item: first,
+      registry,
+    });
+    registerItemDimensions({
+      data: [first, second, third],
+      dimensions: dimensions(200, 100),
+      index: 2,
+      item: third,
+      registry,
+    });
+
+    pruneItemDimensionsRegistry(registry, 2);
+
+    expect(registry.has(0)).toBe(true);
+    expect(registry.has(2)).toBe(false);
+  });
+
+  it('treats null resolver values and null runtime reports as missing dimensions', () => {
+    const item = { id: 'active' };
+    const data = [item];
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+
+    expect(
+      resolveItemDimensions({
+        data,
+        getItemDimensions: () => null as never,
+        index: 0,
+        registry,
+      }),
+    ).toBeUndefined();
+    expect(
+      registerItemDimensions({
+        data,
+        dimensions: null as never,
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(false);
+    expect(registry.size).toBe(0);
   });
 
   it('maps loop sentinels to their canonical logical items', () => {

--- a/src/__tests__/itemDimensions.test.ts
+++ b/src/__tests__/itemDimensions.test.ts
@@ -182,7 +182,7 @@ describe('item dimensions registry', () => {
     );
   });
 
-  it('uses the last-known slot cache for a recreated item when the getter is missing', () => {
+  it('does not reuse slot dimensions for a recreated item without a stable key', () => {
     const item = { id: 'item' };
     const recreatedItem = { id: 'item' };
     const registry: ItemDimensionsRegistry<Item> = new Map();
@@ -201,8 +201,65 @@ describe('item dimensions registry', () => {
     expect(registry.has(0)).toBe(true);
     expect(
       resolveItemDimensions({ data: [recreatedItem], getItemDimensions, index: 0, registry }),
-    ).toEqual(dimensions(100, 200));
+    ).toBeUndefined();
     expect(getItemDimensions).toHaveBeenCalledWith(recreatedItem, 0);
+  });
+
+  it('reuses runtime dimensions only when recreated items have the same stable key', () => {
+    const item = { id: 'item' };
+    const recreatedItem = { id: 'item' };
+    const replacement = { id: 'replacement' };
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+    const getItemKey = (currentItem: Item) => currentItem.id;
+
+    expect(
+      registerItemDimensions({
+        data: [item],
+        dimensions: dimensions(100, 200),
+        getItemKey,
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(true);
+    expect(
+      resolveItemDimensions({
+        data: [recreatedItem],
+        getItemKey,
+        index: 0,
+        registry,
+      }),
+    ).toEqual(dimensions(100, 200));
+    expect(
+      registerItemDimensions({
+        data: [recreatedItem],
+        dimensions: dimensions(120, 240),
+        getItemKey,
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(true);
+    expect(registry.get(0)?.item).toBe(recreatedItem);
+    expect(registry.get(0)?.dimensions).toEqual(dimensions(120, 240));
+    expect(
+      resolveItemDimensions({
+        data: [replacement],
+        getItemKey,
+        index: 0,
+        registry,
+      }),
+    ).toBeUndefined();
+    expect(
+      registerItemDimensions({
+        data: [replacement],
+        dimensions: dimensions(300, 400),
+        getItemKey,
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(false);
   });
 
   it('prunes only out-of-range cached indexes', () => {

--- a/src/__tests__/itemDimensions.test.ts
+++ b/src/__tests__/itemDimensions.test.ts
@@ -1,0 +1,181 @@
+import {
+  pruneItemDimensionsRegistry,
+  registerItemDimensions,
+  resolveItemDimensions,
+  type ItemDimensionsRegistry,
+} from '../itemDimensions';
+import { getLoopAdjustedIndex } from '../utils';
+
+type Item = { id: string };
+
+const dimensions = (width: number, height: number) => ({ height, width });
+
+describe('item dimensions registry', () => {
+  it('uses valid external-map getter dimensions and returns undefined for the viewer fallback', () => {
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+    const externalDimensions = new Map<Item, { width: number; height: number }>([
+      [first, dimensions(393, 616)],
+    ]);
+    const getItemDimensions = jest.fn((item: Item) => externalDimensions.get(item));
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+
+    expect(
+      resolveItemDimensions({
+        data: [first, second],
+        getItemDimensions,
+        index: 0,
+        registry,
+      }),
+    ).toEqual(dimensions(393, 616));
+    expect(getItemDimensions).toHaveBeenLastCalledWith(first, 0);
+
+    expect(
+      resolveItemDimensions({
+        data: [first, second],
+        getItemDimensions,
+        index: 1,
+        registry,
+      }),
+    ).toBeUndefined();
+    expect(getItemDimensions).toHaveBeenLastCalledWith(second, 1);
+  });
+
+  it('prefers valid runtime registration, ignores invalid input, and dedupes equal values', () => {
+    const item = { id: 'active' };
+    const data = [item];
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+    const getItemDimensions = jest.fn(() => dimensions(100, 100));
+
+    expect(
+      registerItemDimensions({
+        data,
+        dimensions: { height: 0, width: Number.NaN },
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(false);
+    expect(registry.size).toBe(0);
+
+    expect(
+      registerItemDimensions({
+        data,
+        dimensions: dimensions(393, 616),
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(true);
+    const registered = registry.get(0);
+
+    expect(
+      registerItemDimensions({
+        data,
+        dimensions: dimensions(393, 616),
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(false);
+    expect(registry.get(0)).toBe(registered);
+    expect(resolveItemDimensions({ data, getItemDimensions, index: 0, registry })).toEqual(
+      dimensions(393, 616),
+    );
+    expect(getItemDimensions).not.toHaveBeenCalled();
+  });
+
+  it('keeps the last valid registration when a later callback reports invalid dimensions', () => {
+    const item = { id: 'active' };
+    const data = [item];
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+
+    expect(
+      registerItemDimensions({
+        data,
+        dimensions: dimensions(393, 616),
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(true);
+    expect(
+      registerItemDimensions({
+        data,
+        dimensions: { height: Number.POSITIVE_INFINITY, width: 393 },
+        index: 0,
+        item,
+        registry,
+      }),
+    ).toBe(false);
+
+    expect(resolveItemDimensions({ data, index: 0, registry })).toEqual(dimensions(393, 616));
+  });
+
+  it('keeps inactive dimensions isolated from the active item', () => {
+    const active = { id: 'active' };
+    const inactive = { id: 'inactive' };
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+
+    registerItemDimensions({
+      data: [active, inactive],
+      dimensions: dimensions(200, 400),
+      index: 1,
+      item: inactive,
+      registry,
+    });
+
+    expect(registry.get(1)?.dimensions).toEqual(dimensions(200, 400));
+
+    expect(
+      resolveItemDimensions({
+        data: [active, inactive],
+        getItemDimensions: () => dimensions(100, 300),
+        index: 0,
+        registry,
+      }),
+    ).toEqual(dimensions(100, 300));
+  });
+
+  it('prunes replaced or removed entries while rejecting late stale callbacks', () => {
+    const replaced = { id: 'replaced' };
+    const retained = { id: 'retained' };
+    const next = { id: 'next' };
+    const registry: ItemDimensionsRegistry<Item> = new Map();
+
+    registerItemDimensions({
+      data: [replaced, retained],
+      dimensions: dimensions(100, 200),
+      index: 0,
+      item: replaced,
+      registry,
+    });
+    registerItemDimensions({
+      data: [replaced, retained],
+      dimensions: dimensions(200, 100),
+      index: 1,
+      item: retained,
+      registry,
+    });
+
+    pruneItemDimensionsRegistry(registry, [next, retained]);
+
+    expect(registry.size).toBe(1);
+    expect(registry.get(1)?.item).toBe(retained);
+    expect(
+      registerItemDimensions({
+        data: [next, retained],
+        dimensions: dimensions(100, 200),
+        index: 0,
+        item: replaced,
+        registry,
+      }),
+    ).toBe(false);
+    expect(registry.size).toBe(1);
+  });
+
+  it('maps loop sentinels to their canonical logical items', () => {
+    expect(getLoopAdjustedIndex(0, 2, true).realIndex).toBe(1);
+    expect(getLoopAdjustedIndex(3, 2, true).realIndex).toBe(0);
+  });
+});

--- a/src/__tests__/itemDimensionsLifecycle.test.tsx
+++ b/src/__tests__/itemDimensionsLifecycle.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render } from '@testing-library/react-native';
+import { forwardRef, memo, useImperativeHandle, type ReactElement } from 'react';
+import { Text, View } from 'react-native';
+
+const mockPruneItemDimensionsRegistry = jest.fn();
+
+jest.mock('../itemDimensions', () => {
+  const actual = jest.requireActual('../itemDimensions');
+
+  return {
+    ...actual,
+    pruneItemDimensionsRegistry: (
+      ...args: Parameters<typeof actual.pruneItemDimensionsRegistry>
+    ) => {
+      mockPruneItemDimensionsRegistry(...args);
+
+      return actual.pruneItemDimensionsRegistry(...args);
+    },
+  };
+});
+
+import { GestureViewer } from '../GestureViewer';
+
+type Item = { id: string; width: number; height: number };
+
+type TestListHandle = {
+  scrollToIndex: (params: { animated: boolean; index: number }) => void;
+};
+
+type TestListProps = {
+  data?: readonly Item[];
+  renderItem?: (info: { item: Item; index: number; target?: string }) => ReactElement | null;
+};
+
+const TestList = memo(
+  forwardRef<TestListHandle, TestListProps>(function TestList(props, ref) {
+    useImperativeHandle(ref, () => ({ scrollToIndex: jest.fn() }), []);
+
+    return (
+      <View>
+        {props.data?.map((item, index) => (
+          <View key={item.id}>{props.renderItem?.({ item, index })}</View>
+        ))}
+      </View>
+    );
+  }),
+);
+
+function renderItem(item: Item, index: number) {
+  return <Text>{`${index}:${item.id}`}</Text>;
+}
+
+describe('item dimensions lifecycle', () => {
+  afterEach(async () => {
+    await cleanup();
+    mockPruneItemDimensionsRegistry.mockClear();
+  });
+
+  it('does not prune on getter or viewport rerenders but prunes on new data identity', async () => {
+    const first = { id: 'first', width: 393, height: 616 };
+    const second = { id: 'second', width: 320, height: 480 };
+    const data = [first, second];
+
+    const { rerender } = await render(
+      <GestureViewer
+        data={data}
+        getItemDimensions={(item) => ({ width: item.width, height: item.height })}
+        height={480}
+        id="dimensions-lifecycle"
+        ListComponent={TestList}
+        renderItem={renderItem}
+        width={320}
+      />,
+    );
+
+    expect(mockPruneItemDimensionsRegistry).toHaveBeenCalledTimes(1);
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        getItemDimensions={(item) => ({ width: item.width + 1, height: item.height + 1 })}
+        height={481}
+        id="dimensions-lifecycle"
+        ListComponent={TestList}
+        renderItem={renderItem}
+        width={321}
+      />,
+    );
+
+    expect(mockPruneItemDimensionsRegistry).toHaveBeenCalledTimes(1);
+
+    await rerender(
+      <GestureViewer
+        data={[first, second]}
+        getItemDimensions={(item) => ({ width: item.width, height: item.height })}
+        height={481}
+        id="dimensions-lifecycle"
+        ListComponent={TestList}
+        renderItem={renderItem}
+        width={321}
+      />,
+    );
+
+    expect(mockPruneItemDimensionsRegistry).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/itemDimensionsLifecycle.test.tsx
+++ b/src/__tests__/itemDimensionsLifecycle.test.tsx
@@ -3,6 +3,7 @@ import { forwardRef, memo, useImperativeHandle, type ReactElement } from 'react'
 import { Text, View } from 'react-native';
 
 const mockPruneItemDimensionsRegistry = jest.fn();
+const mockResolveItemDimensions = jest.fn();
 
 jest.mock('../itemDimensions', () => {
   const actual = jest.requireActual('../itemDimensions');
@@ -15,6 +16,11 @@ jest.mock('../itemDimensions', () => {
       mockPruneItemDimensionsRegistry(...args);
 
       return actual.pruneItemDimensionsRegistry(...args);
+    },
+    resolveItemDimensions: (...args: Parameters<typeof actual.resolveItemDimensions>) => {
+      mockResolveItemDimensions(...args);
+
+      return actual.resolveItemDimensions(...args);
     },
   };
 });
@@ -54,6 +60,7 @@ describe('item dimensions lifecycle', () => {
   afterEach(async () => {
     await cleanup();
     mockPruneItemDimensionsRegistry.mockClear();
+    mockResolveItemDimensions.mockClear();
   });
 
   it('does not prune on same-length rerenders but prunes on length changes', async () => {
@@ -118,5 +125,45 @@ describe('item dimensions lifecycle', () => {
 
     expect(mockPruneItemDimensionsRegistry).toHaveBeenCalledTimes(2);
     expect(mockPruneItemDimensionsRegistry).toHaveBeenLastCalledWith(expect.any(Map), 1);
+  });
+
+  it('uses the current stable-key resolver after object items are recreated', async () => {
+    const firstItem = { id: 'photo', width: 393, height: 616 };
+    const recreatedItem = { id: 'photo', width: 393, height: 616 };
+    const firstGetItemKey = jest.fn((item: Item) => item.id);
+    const nextGetItemKey = jest.fn((item: Item) => item.id);
+    const { rerender } = await render(
+      <GestureViewer
+        data={[firstItem]}
+        getItemKey={firstGetItemKey}
+        height={480}
+        id="item-key-lifecycle"
+        ListComponent={TestList}
+        renderItem={renderItem}
+        width={320}
+      />,
+    );
+
+    mockResolveItemDimensions.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={[recreatedItem]}
+        getItemKey={nextGetItemKey}
+        height={480}
+        id="item-key-lifecycle"
+        ListComponent={TestList}
+        renderItem={renderItem}
+        width={320}
+      />,
+    );
+
+    expect(mockResolveItemDimensions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [recreatedItem],
+        getItemKey: nextGetItemKey,
+        index: 0,
+      }),
+    );
   });
 });

--- a/src/__tests__/itemDimensionsLifecycle.test.tsx
+++ b/src/__tests__/itemDimensionsLifecycle.test.tsx
@@ -56,7 +56,7 @@ describe('item dimensions lifecycle', () => {
     mockPruneItemDimensionsRegistry.mockClear();
   });
 
-  it('does not prune on getter or viewport rerenders but prunes on new data identity', async () => {
+  it('does not prune on same-length rerenders but prunes on length changes', async () => {
     const first = { id: 'first', width: 393, height: 616 };
     const second = { id: 'second', width: 320, height: 480 };
     const data = [first, second];
@@ -74,6 +74,7 @@ describe('item dimensions lifecycle', () => {
     );
 
     expect(mockPruneItemDimensionsRegistry).toHaveBeenCalledTimes(1);
+    expect(mockPruneItemDimensionsRegistry).toHaveBeenLastCalledWith(expect.any(Map), 2);
 
     await rerender(
       <GestureViewer
@@ -101,6 +102,21 @@ describe('item dimensions lifecycle', () => {
       />,
     );
 
+    expect(mockPruneItemDimensionsRegistry).toHaveBeenCalledTimes(1);
+
+    await rerender(
+      <GestureViewer
+        data={[first]}
+        getItemDimensions={(item) => ({ width: item.width, height: item.height })}
+        height={481}
+        id="dimensions-lifecycle"
+        ListComponent={TestList}
+        renderItem={renderItem}
+        width={321}
+      />,
+    );
+
     expect(mockPruneItemDimensionsRegistry).toHaveBeenCalledTimes(2);
+    expect(mockPruneItemDimensionsRegistry).toHaveBeenLastCalledWith(expect.any(Map), 1);
   });
 });

--- a/src/__tests__/manager.test.ts
+++ b/src/__tests__/manager.test.ts
@@ -1,4 +1,65 @@
+import type { SharedValue } from 'react-native-reanimated';
+
 import GestureViewerManager from '../GestureViewerManager';
+
+function createSharedValue(initialValue: number): SharedValue<number> {
+  let value = initialValue;
+
+  return {
+    get: () => value,
+    set: (nextValue: number) => {
+      const animatedValue = nextValue as unknown as { current?: number; toValue?: number };
+
+      value = animatedValue.current ?? animatedValue.toValue ?? nextValue;
+    },
+  } as SharedValue<number>;
+}
+
+function configureZoomManager({
+  contentHeight = 616,
+  contentWidth = 393,
+  itemSpacing = 0,
+  scale = 1,
+  translateX = 0,
+  translateY = 426,
+  useContentDimensions = true,
+}: {
+  contentHeight?: number;
+  contentWidth?: number;
+  itemSpacing?: number;
+  scale?: number;
+  translateX?: number;
+  translateY?: number;
+  useContentDimensions?: boolean;
+} = {}) {
+  const manager = new GestureViewerManager();
+  const sharedScale = createSharedValue(scale);
+  const sharedTranslateX = createSharedValue(translateX);
+  const sharedTranslateY = createSharedValue(translateY);
+  const sharedContentWidth = createSharedValue(contentWidth);
+  const sharedContentHeight = createSharedValue(contentHeight);
+
+  manager.setPagingStride(393 + itemSpacing);
+  manager.setViewportWidth(393);
+  manager.setHeight(852);
+  manager.setZoomSharedValues({
+    contentHeight: useContentDimensions ? sharedContentHeight : undefined,
+    contentWidth: useContentDimensions ? sharedContentWidth : undefined,
+    maxZoomScale: 2,
+    scale: sharedScale,
+    translateX: sharedTranslateX,
+    translateY: sharedTranslateY,
+  });
+
+  return {
+    contentHeight: sharedContentHeight,
+    contentWidth: sharedContentWidth,
+    manager,
+    scale: sharedScale,
+    translateX: sharedTranslateX,
+    translateY: sharedTranslateY,
+  };
+}
 
 describe('GestureViewerManager tap events', () => {
   it('emits tap events to tap listeners and supports unsubscribe', () => {
@@ -19,5 +80,63 @@ describe('GestureViewerManager tap events', () => {
     manager.emitTap({ kind: 'single', x: 1, y: 2, index: 0 });
 
     expect(tapListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GestureViewerManager content-aware zoom bounds', () => {
+  it('clamps zoom-in with fitted content dimensions instead of the paging stride', () => {
+    const { manager, scale, translateY } = configureZoomManager({ itemSpacing: 24 });
+
+    manager.zoomIn(1);
+
+    expect(scale.get()).toBe(2);
+    expect(translateY.get()).toBe(190);
+  });
+
+  it('keeps item spacing in navigation while zoom bounds use the true viewport width', () => {
+    const { manager } = configureZoomManager({ itemSpacing: 24 });
+    const scrollTo = jest.fn();
+
+    manager.setDataLength(2);
+    manager.setListRef({ scrollTo });
+    manager.goToIndex(1);
+
+    expect(scrollTo).toHaveBeenCalledWith({ animated: true, x: 417 });
+  });
+
+  it('recenters translations when zooming out to scale one', () => {
+    const { manager, scale, translateX, translateY } = configureZoomManager({
+      scale: 2,
+      translateY: 190,
+    });
+
+    manager.zoomOut(1);
+
+    expect(scale.get()).toBe(1);
+    expect(translateX.get()).toBe(0);
+    expect(translateY.get()).toBe(0);
+  });
+
+  it('recenters an axis when zoom-out makes fitted content smaller than the viewport', () => {
+    const { manager, scale, translateY } = configureZoomManager({
+      scale: 1.4,
+      translateY: 50,
+    });
+
+    manager.zoomOut(0.25);
+
+    expect(scale.get()).toBeCloseTo(1.12);
+    expect(translateY.get()).toBe(0);
+  });
+
+  it('uses viewport-cell bounds when no active content dimensions are registered', () => {
+    const { manager, translateY } = configureZoomManager({
+      translateY: 999,
+      useContentDimensions: false,
+    });
+
+    manager.zoomIn(1);
+
+    expect(translateY.get()).toBe(426);
   });
 });

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -492,6 +492,84 @@ describe('GestureViewer renderItem active state', () => {
     expect(getItemDimensions).not.toHaveBeenCalledWith(first, 0);
   });
 
+  it('resets manager state when a data-length change resets the visible page', async () => {
+    const id = 'data-length-reset';
+    const { rerender } = await renderActiveViewer({ id });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 2));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={['first']}
+        height={480}
+        id={id}
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 0 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
+  });
+
+  it('keeps loop reset positions physical while manager state stays logical', async () => {
+    const id = 'loop-data-length-reset';
+    const { rerender } = await renderActiveViewer({
+      data: ['first', 'second'],
+      enableLoop: true,
+      id,
+    });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 2));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={['first', 'second', 'third']}
+        enableLoop
+        height={480}
+        id={id}
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
+  });
+
   it('supplies a stable item-bound dimensions setter to render callbacks', async () => {
     const data = ['first', 'second'];
     let firstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -7,7 +7,7 @@ import {
   within,
   type RenderResult,
 } from '@testing-library/react-native';
-import { forwardRef, memo, useImperativeHandle, type ReactElement } from 'react';
+import { forwardRef, memo, StrictMode, useImperativeHandle, type ReactElement } from 'react';
 import {
   Text,
   type NativeScrollEvent,
@@ -136,6 +136,55 @@ describe('GestureViewer renderItem active state', () => {
     await renderActiveViewer({ id: 'initial-active', initialIndex: 1 });
 
     expectActiveStates(['inactive', 'active', 'inactive']);
+  });
+
+  it('reschedules a deferred initial scroll after Strict Mode effect replay', async () => {
+    const idleGlobal = globalThis as typeof globalThis & {
+      requestIdleCallback?: (callback: () => void) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+    const originalRequestIdleCallback = idleGlobal.requestIdleCallback;
+    const originalCancelIdleCallback = idleGlobal.cancelIdleCallback;
+    const callbacks = new Map<number, () => void>();
+    let callbackId = 0;
+
+    idleGlobal.requestIdleCallback = (callback) => {
+      callbackId += 1;
+      callbacks.set(callbackId, callback);
+      return callbackId;
+    };
+    idleGlobal.cancelIdleCallback = (handle) => {
+      callbacks.delete(handle);
+    };
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      await render(
+        <StrictMode>
+          <GestureViewer
+            data={['first', 'second']}
+            height={480}
+            id="strict-initial-scroll"
+            initialIndex={1}
+            ListComponent={TestFlashList}
+            renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+            width={PAGE_WIDTH}
+          />
+        </StrictMode>,
+      );
+
+      expect(callbacks.size).toBe(1);
+
+      await act(async () => {
+        callbacks.forEach((callback) => callback());
+      });
+
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    } finally {
+      consoleErrorSpy.mockRestore();
+      idleGlobal.requestIdleCallback = originalRequestIdleCallback;
+      idleGlobal.cancelIdleCallback = originalCancelIdleCallback;
+    }
   });
 
   it('keeps the current cell active until native momentum settles', async () => {
@@ -954,6 +1003,7 @@ describe('GestureViewer renderItem active state', () => {
   it('supplies an item-bound dimensions setter to render callbacks', async () => {
     const data = ['first', 'second'];
     let firstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;
+    const getItemDimensions = jest.fn(() => undefined);
 
     const renderItem = (
       item: string,
@@ -972,6 +1022,7 @@ describe('GestureViewer renderItem active state', () => {
     const { rerender } = await render(
       <GestureViewer
         data={data}
+        getItemDimensions={getItemDimensions}
         height={480}
         id="dimensions-setter"
         ListComponent={TestFlashList}
@@ -985,6 +1036,7 @@ describe('GestureViewer renderItem active state', () => {
     await rerender(
       <GestureViewer
         data={data}
+        getItemDimensions={getItemDimensions}
         height={480}
         id="dimensions-setter"
         ListComponent={TestFlashList}
@@ -996,6 +1048,21 @@ describe('GestureViewer renderItem active state', () => {
     await act(async () => {
       firstSetter?.({ height: 616, width: 393 });
     });
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id="dimensions-setter"
+        ListComponent={TestFlashList}
+        renderItem={renderItem}
+        width={PAGE_WIDTH + 1}
+      />,
+    );
+
+    expect(getItemDimensions).toHaveBeenCalledTimes(1);
+    expect(getItemDimensions).toHaveBeenCalledWith('first', 0);
   });
 
   it('updates rendered loop data when data identity changes', async () => {

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -345,6 +345,46 @@ describe('GestureViewer renderItem active state', () => {
     expect(getItemDimensions).toHaveBeenCalledWith(second, 1);
   });
 
+  it('resyncs dimensions when initialIndex changes to a different aspect ratio', async () => {
+    const first = 'first';
+    const second = 'second';
+    const dimensionsByItem = new Map([
+      [first, { height: 616, width: 393 }],
+      [second, { height: 320, width: 640 }],
+    ]);
+    const getItemDimensions = jest.fn((item: string) => dimensionsByItem.get(item));
+
+    const { rerender } = await render(
+      <GestureViewer
+        data={[first, second]}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id="initial-index-dimensions"
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    getItemDimensions.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={[first, second]}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id="initial-index-dimensions"
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(getItemDimensions).toHaveBeenCalledWith(second, 1);
+  });
+
   it('does not resolve dimensions again while scroll events stay on the same logical item', async () => {
     const first = 'first';
     const second = 'second';
@@ -388,6 +428,68 @@ describe('GestureViewer renderItem active state', () => {
     });
 
     expect(getItemDimensions).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the viewed index when config rerenders with unchanged initialIndex', async () => {
+    const id = 'unchanged-initial-index-rerender';
+    const first = 'first';
+    const second = 'second';
+    const dimensionsByItem = new Map([
+      [first, { height: 616, width: 393 }],
+      [second, { height: 480, width: 320 }],
+    ]);
+    const getItemDimensions = jest.fn((item: string) => dimensionsByItem.get(item));
+
+    const { rerender } = await render(
+      <GestureViewer
+        data={[first, second]}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id={id}
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        maxZoomScale={2}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
+    expect(getItemDimensions).toHaveBeenLastCalledWith(second, 1);
+
+    getItemDimensions.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={[first, second]}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id={id}
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        maxZoomScale={3}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
+    expect(getItemDimensions).not.toHaveBeenCalledWith(first, 0);
   });
 
   it('supplies a stable item-bound dimensions setter to render callbacks', async () => {
@@ -439,5 +541,36 @@ describe('GestureViewer renderItem active state', () => {
     await act(async () => {
       firstSetter?.({ height: 616, width: 393 });
     });
+  });
+
+  it('updates rendered loop data when data identity changes', async () => {
+    const { rerender } = await render(
+      <GestureViewer
+        data={['first', 'second']}
+        enableLoop
+        height={480}
+        id="loop-data-rerender"
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(screen.getByText('1:first')).toBeTruthy();
+
+    await rerender(
+      <GestureViewer
+        data={['third', 'fourth']}
+        enableLoop
+        height={480}
+        id="loop-data-rerender"
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(screen.getByText('1:third')).toBeTruthy();
+    expect(screen.queryByText('1:first')).toBeNull();
   });
 });

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -647,6 +647,64 @@ describe('GestureViewer renderItem active state', () => {
     expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
   });
 
+  it('resets to the empty-state index and reapplies initialIndex when data returns', async () => {
+    const id = 'empty-data-reset';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, id, initialIndex: 1 });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 2));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={[]}
+        height={480}
+        id={id}
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(registry.getManager(id)?.getState()).toEqual(
+      expect.objectContaining({ currentIndex: 0, totalCount: 0 }),
+    );
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        height={480}
+        id={id}
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+    expect(registry.getManager(id)?.getState()).toEqual(
+      expect.objectContaining({ currentIndex: 1, totalCount: 3 }),
+    );
+  });
+
   it('supplies a stable item-bound dimensions setter to render callbacks', async () => {
     const data = ['first', 'second'];
     let firstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -570,6 +570,83 @@ describe('GestureViewer renderItem active state', () => {
     expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
   });
 
+  it('resets manager state when loop mode is enabled', async () => {
+    const id = 'enable-loop-reset';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, id });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 2));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        enableLoop
+        height={480}
+        id={id}
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
+  });
+
+  it('resets the physical and logical indexes when loop mode is disabled', async () => {
+    const id = 'disable-loop-reset';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, enableLoop: true, id });
+
+    await waitFor(() => {
+      expect(registry.getManager(id)).not.toBeNull();
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 3));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 3));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        enableLoop={false}
+        height={480}
+        id={id}
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 0 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
+  });
+
   it('supplies a stable item-bound dimensions setter to render callbacks', async () => {
     const data = ['first', 'second'];
     let firstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -951,10 +951,9 @@ describe('GestureViewer renderItem active state', () => {
     expectActiveStates(['inactive', 'inactive', 'inactive', 'active', 'inactive']);
   });
 
-  it('supplies a stable item-bound dimensions setter to render callbacks', async () => {
+  it('supplies an item-bound dimensions setter to render callbacks', async () => {
     const data = ['first', 'second'];
     let firstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;
-    let latestFirstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;
 
     const renderItem = (
       item: string,
@@ -964,7 +963,6 @@ describe('GestureViewer renderItem active state', () => {
       }: { setItemDimensions: (dimensions: { width: number; height: number }) => void },
     ) => {
       if (index === 0) {
-        latestFirstSetter = setItemDimensions;
         firstSetter ??= setItemDimensions;
       }
 
@@ -994,8 +992,6 @@ describe('GestureViewer renderItem active state', () => {
         width={PAGE_WIDTH}
       />,
     );
-
-    expect(latestFirstSetter).toBe(firstSetter);
 
     await act(async () => {
       firstSetter?.({ height: 616, width: 393 });

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -705,6 +705,252 @@ describe('GestureViewer renderItem active state', () => {
     );
   });
 
+  it('scrolls the mounted list when initialIndex changes to zero', async () => {
+    const id = 'zero-initial-index-reset';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, id, initialIndex: 1 });
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        height={480}
+        id={id}
+        initialIndex={0}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 0 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
+    expectActiveStates(['active', 'inactive', 'inactive']);
+  });
+
+  it('clamps invalid initialIndex updates before synchronizing state and scroll', async () => {
+    const id = 'invalid-initial-index';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, id, initialIndex: 1 });
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        height={480}
+        id={id}
+        initialIndex={99}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 2 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        height={480}
+        id={id}
+        initialIndex={Number.NaN}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 0 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(0);
+  });
+
+  it('renormalizes initialIndex when data shrinks below it', async () => {
+    const id = 'shrinking-initial-index';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, id, initialIndex: 2 });
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 2 });
+    });
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={['first']}
+        height={480}
+        id={id}
+        initialIndex={2}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 0 });
+    });
+    expect(registry.getManager(id)?.getState()).toEqual(
+      expect.objectContaining({ currentIndex: 0, totalCount: 1 }),
+    );
+  });
+
+  it('keeps the viewed item aligned when page width changes', async () => {
+    const id = 'page-width-realignment';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, id, initialIndex: 1 });
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 2));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        height={480}
+        id={id}
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={400}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 2 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    expectActiveStates(['inactive', 'inactive', 'active']);
+  });
+
+  it('restores committed item geometry when width changes during a scroll', async () => {
+    const id = 'in-flight-width-realignment';
+    const data = ['first', 'second', 'third'];
+    const dimensionsByItem = new Map([
+      ['first', { height: 300, width: 300 }],
+      ['second', { height: 480, width: 320 }],
+      ['third', { height: 320, width: 640 }],
+    ]);
+    const getItemDimensions = jest.fn((item: string) => dimensionsByItem.get(item));
+    const { rerender } = await render(
+      <GestureViewer
+        data={data}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id={id}
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 2));
+    });
+
+    expect(getItemDimensions).toHaveBeenLastCalledWith('third', 2);
+    getItemDimensions.mockClear();
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id={id}
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={400}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(1);
+    expect(getItemDimensions).toHaveBeenLastCalledWith('second', 1);
+  });
+
+  it('keeps loop physical and logical indexes aligned when itemSpacing changes', async () => {
+    const id = 'loop-spacing-realignment';
+    const data = ['first', 'second', 'third'];
+    const { rerender } = await renderActiveViewer({ data, enableLoop: true, id });
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 });
+    });
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH * 3));
+      getListProps().onMomentumScrollEnd?.(createScrollEvent(PAGE_WIDTH * 3));
+    });
+
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    scrollToIndex.mockClear();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        enableLoop
+        height={480}
+        id={id}
+        initialIndex={0}
+        itemSpacing={20}
+        ListComponent={TestFlashList}
+        renderItem={(_item, index, { isActive }) => (
+          <ActiveItem index={index} isActive={isActive} />
+        )}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 3 });
+    });
+    expect(registry.getManager(id)?.getState().currentIndex).toBe(2);
+    expectActiveStates(['inactive', 'inactive', 'inactive', 'active', 'inactive']);
+  });
+
   it('supplies a stable item-bound dimensions setter to render callbacks', async () => {
     const data = ['first', 'second'];
     let firstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;

--- a/src/__tests__/renderItemActive.test.tsx
+++ b/src/__tests__/renderItemActive.test.tsx
@@ -300,4 +300,144 @@ describe('GestureViewer renderItem active state', () => {
     expect(screen.getByText('1:second')).toBeTruthy();
     expect(getListProps().extraData).toBe(extraData);
   });
+
+  it('resolves initial dimensions with the logical data item and index', async () => {
+    const first = 'first';
+    const second = 'second';
+    const dimensionsByItem = new Map([[first, { height: 616, width: 393 }]]);
+    const getItemDimensions = jest.fn((item: string) => dimensionsByItem.get(item));
+
+    await render(
+      <GestureViewer
+        data={[first, second]}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id="initial-dimensions"
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(getItemDimensions).toHaveBeenCalledWith(second, 1);
+  });
+
+  it('resolves the canonical logical item when loop mode starts on a sentinel-backed page', async () => {
+    const first = 'first';
+    const second = 'second';
+    const getItemDimensions = jest.fn(() => undefined);
+
+    await render(
+      <GestureViewer
+        data={[first, second]}
+        enableLoop
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id="loop-initial-dimensions"
+        initialIndex={1}
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(getItemDimensions).toHaveBeenCalledWith(second, 1);
+  });
+
+  it('does not resolve dimensions again while scroll events stay on the same logical item', async () => {
+    const first = 'first';
+    const second = 'second';
+    const dimensionsByItem = new Map([
+      [first, { height: 616, width: 393 }],
+      [second, { height: 480, width: 320 }],
+    ]);
+    const getItemDimensions = jest.fn((item: string) => dimensionsByItem.get(item));
+
+    await render(
+      <GestureViewer
+        data={[first, second]}
+        getItemDimensions={getItemDimensions}
+        height={480}
+        id="pending-dimensions-sync"
+        ListComponent={TestFlashList}
+        renderItem={(item, index) => <Text>{`${index}:${item}`}</Text>}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(getItemDimensions).toHaveBeenCalledTimes(1);
+    expect(getItemDimensions).toHaveBeenLastCalledWith(first, 0);
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(0));
+      getListProps().onScroll?.(createScrollEvent(0));
+    });
+
+    expect(getItemDimensions).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH));
+    });
+
+    expect(getItemDimensions).toHaveBeenCalledTimes(2);
+    expect(getItemDimensions).toHaveBeenLastCalledWith(second, 1);
+
+    await act(async () => {
+      getListProps().onScroll?.(createScrollEvent(PAGE_WIDTH));
+    });
+
+    expect(getItemDimensions).toHaveBeenCalledTimes(2);
+  });
+
+  it('supplies a stable item-bound dimensions setter to render callbacks', async () => {
+    const data = ['first', 'second'];
+    let firstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;
+    let latestFirstSetter: ((dimensions: { width: number; height: number }) => void) | undefined;
+
+    const renderItem = (
+      item: string,
+      index: number,
+      {
+        setItemDimensions,
+      }: { setItemDimensions: (dimensions: { width: number; height: number }) => void },
+    ) => {
+      if (index === 0) {
+        latestFirstSetter = setItemDimensions;
+        firstSetter ??= setItemDimensions;
+      }
+
+      return <Text>{`${index}:${item}`}</Text>;
+    };
+
+    const { rerender } = await render(
+      <GestureViewer
+        data={data}
+        height={480}
+        id="dimensions-setter"
+        ListComponent={TestFlashList}
+        renderItem={renderItem}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(firstSetter).toBeDefined();
+
+    await rerender(
+      <GestureViewer
+        data={data}
+        height={480}
+        id="dimensions-setter"
+        ListComponent={TestFlashList}
+        renderItem={(item, index, info) => renderItem(item, index, info)}
+        width={PAGE_WIDTH}
+      />,
+    );
+
+    expect(latestFirstSetter).toBe(firstSetter);
+
+    await act(async () => {
+      firstSetter?.({ height: 616, width: 393 });
+    });
+  });
 });

--- a/src/__tests__/types.test.tsx
+++ b/src/__tests__/types.test.tsx
@@ -1,0 +1,70 @@
+import { FlatList, Text } from 'react-native';
+
+import type {
+  GestureViewerItemDimensions,
+  GestureViewerItemDimensionsResolver,
+  GestureViewerProps,
+} from '../types';
+
+type Photo = {
+  id: string;
+  width?: number;
+  height?: number;
+};
+
+const externalDimensions = new Map<string, GestureViewerItemDimensions>([
+  ['remote://one', { height: 616, width: 393 }],
+]);
+
+describe('public item dimensions types', () => {
+  it('allow string items to resolve dimensions from an external map', () => {
+    const getStringItemDimensions: GestureViewerItemDimensionsResolver<string> = (item) =>
+      externalDimensions.get(item);
+    const props: GestureViewerProps<string, typeof FlatList> = {
+      data: ['remote://one'],
+      getItemDimensions: getStringItemDimensions,
+      ListComponent: FlatList,
+      renderItem: (item) => <Text>{item}</Text>,
+    };
+
+    expect(props.getItemDimensions?.('remote://one', 0)).toEqual({
+      height: 616,
+      width: 393,
+    });
+  });
+
+  it('allow optional item dimensions to fall back until a type guard succeeds', () => {
+    const getPhotoDimensions: GestureViewerItemDimensionsResolver<Photo> = (item) => {
+      if (item.width === undefined || item.height === undefined) {
+        return undefined;
+      }
+
+      return {
+        height: item.height,
+        width: item.width,
+      };
+    };
+    const props: GestureViewerProps<Photo, typeof FlatList> = {
+      data: [{ id: 'unknown' }],
+      getItemDimensions: getPhotoDimensions,
+      ListComponent: FlatList,
+      renderItem: (item, _index, { isActive }) => (
+        <Text>{`${item.id}:${isActive ? 'active' : 'inactive'}`}</Text>
+      ),
+    };
+
+    expect(props.getItemDimensions?.({ id: 'unknown' }, 0)).toBeUndefined();
+  });
+
+  it('keep render callbacks valid when consumers only read the active flag', () => {
+    const renderItem: GestureViewerProps<Photo, typeof FlatList>['renderItem'] = (
+      _item,
+      _index,
+      { isActive },
+    ) => <Text>{isActive ? 'active' : 'inactive'}</Text>;
+
+    expect(
+      renderItem({ id: 'photo' }, 0, { isActive: true, setItemDimensions: jest.fn() }),
+    ).toEqual(expect.any(Object));
+  });
+});

--- a/src/__tests__/types.test.tsx
+++ b/src/__tests__/types.test.tsx
@@ -3,6 +3,7 @@ import { FlatList, Text } from 'react-native';
 import type {
   GestureViewerItemDimensions,
   GestureViewerItemDimensionsResolver,
+  GestureViewerItemKeyResolver,
   GestureViewerProps,
 } from '../types';
 
@@ -54,6 +55,18 @@ describe('public item dimensions types', () => {
     };
 
     expect(props.getItemDimensions?.({ id: 'unknown' }, 0)).toBeUndefined();
+  });
+
+  it('allow stable keys for recreated object items with runtime dimensions', () => {
+    const getItemKey: GestureViewerItemKeyResolver<Photo> = (item) => item.id;
+    const props: GestureViewerProps<Photo, typeof FlatList> = {
+      data: [{ id: 'photo' }],
+      getItemKey,
+      ListComponent: FlatList,
+      renderItem: (item) => <Text>{item.id}</Text>,
+    };
+
+    expect(props.getItemKey?.({ id: 'photo' }, 0)).toBe('photo');
   });
 
   it('keep render callbacks valid when consumers only read the active flag', () => {

--- a/src/__tests__/useGestureViewerPaging.test.tsx
+++ b/src/__tests__/useGestureViewerPaging.test.tsx
@@ -55,7 +55,7 @@ function createArgs(
 }
 
 describe('useGestureViewerPaging native active state', () => {
-  it('resets the active cell when the page layout changes', async () => {
+  it('keeps the settled cell when width changes after mounting away from zero', async () => {
     const { rerender, result } = await renderHook<UseGestureViewerPagingResult, { width: number }>(
       ({ width }) => useGestureViewerPaging(createArgs({ adjustedInitialIndex: 1, width })),
       {
@@ -71,7 +71,30 @@ describe('useGestureViewerPaging native active state', () => {
 
     await rerender({ width: 400 });
 
-    expect(result.current.activeListIndex).toBe(1);
+    expect(result.current.activeListIndex).toBe(2);
+  });
+
+  it('keeps the settled cell when item spacing changes after mounting away from zero', async () => {
+    const { rerender, result } = await renderHook<
+      UseGestureViewerPagingResult,
+      { itemSpacing: number }
+    >(
+      ({ itemSpacing }) =>
+        useGestureViewerPaging(createArgs({ adjustedInitialIndex: 1, itemSpacing })),
+      {
+        initialProps: { itemSpacing: 0 },
+      },
+    );
+
+    await act(async () => {
+      result.current.onMomentumScrollEnd?.(createScrollEvent(640));
+    });
+
+    expect(result.current.activeListIndex).toBe(2);
+
+    await rerender({ itemSpacing: 24 });
+
+    expect(result.current.activeListIndex).toBe(2);
   });
 
   it('keeps the settled cell when a layout change does not reschedule initial scrolling', async () => {

--- a/src/__tests__/useGestureViewerPaging.test.tsx
+++ b/src/__tests__/useGestureViewerPaging.test.tsx
@@ -30,6 +30,8 @@ function createArgs(
     adjustedInitialIndex: 0,
     autoPlay: false,
     autoPlayInterval: 3000,
+    contentHeight: createSharedValue(480),
+    contentWidth: createSharedValue(320),
     currentIndex: 0,
     dataLength: 3,
     enableDoubleTapZoom: true,

--- a/src/__tests__/useGestureViewerPaging.web.test.tsx
+++ b/src/__tests__/useGestureViewerPaging.web.test.tsx
@@ -1,12 +1,19 @@
 import { act, renderHook } from '@testing-library/react-native';
+import type { MouseEvent } from 'react';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 
 import type {
   UseGestureViewerPagingArgs,
   UseGestureViewerPagingResult,
+  WebClickTarget,
 } from '../useGestureViewerPaging.types';
 import { useGestureViewerPaging } from '../useGestureViewerPaging.web';
+import { applyTapZoomAtPoint } from '../utils/tapZoom';
+
+jest.mock('../utils/tapZoom', () => ({
+  applyTapZoomAtPoint: jest.fn(),
+}));
 
 function createScrollEvent(offsetX: number): NativeSyntheticEvent<NativeScrollEvent> {
   return {
@@ -30,6 +37,8 @@ function createArgs(
     adjustedInitialIndex: 0,
     autoPlay: false,
     autoPlayInterval: 3000,
+    contentHeight: createSharedValue(480),
+    contentWidth: createSharedValue(320),
     currentIndex: 0,
     dataLength: 3,
     enableDoubleTapZoom: true,
@@ -55,6 +64,7 @@ function createArgs(
 describe('useGestureViewerPaging web active state', () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.mocked(applyTapZoomAtPoint).mockClear();
   });
 
   afterEach(() => {
@@ -162,5 +172,34 @@ describe('useGestureViewerPaging web active state', () => {
     expect(scrollTo).toHaveBeenCalledWith(2, false);
     expect(syncCurrentIndex).toHaveBeenCalledWith(1);
     expect(result.current.activeListIndex).toBe(2);
+  });
+
+  it('passes active content dimensions to double-click zoom', async () => {
+    const { result } = await renderHook(() =>
+      useGestureViewerPaging(
+        createArgs({
+          contentHeight: createSharedValue(616),
+          contentWidth: createSharedValue(393),
+        }),
+      ),
+    );
+
+    await act(async () => {
+      result.current.onWebClick?.({
+        clientX: 196.5,
+        clientY: 852,
+        currentTarget: {
+          getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        },
+        detail: 2,
+      } as MouseEvent<WebClickTarget>);
+    });
+
+    expect(applyTapZoomAtPoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentHeight: 616,
+        contentWidth: 393,
+      }),
+    );
   });
 });

--- a/src/__tests__/useGestureViewerPaging.web.test.tsx
+++ b/src/__tests__/useGestureViewerPaging.web.test.tsx
@@ -114,6 +114,104 @@ describe('useGestureViewerPaging web active state', () => {
     expect(result.current.activeListIndex).toBe(2);
   });
 
+  it('keeps the last settled cell when width changes after mounting away from zero', async () => {
+    const syncCurrentIndex = jest.fn();
+    const { rerender, result } = await renderHook<UseGestureViewerPagingResult, { width: number }>(
+      ({ width }) =>
+        useGestureViewerPaging(createArgs({ adjustedInitialIndex: 1, syncCurrentIndex, width })),
+      {
+        initialProps: { width: 320 },
+      },
+    );
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(640));
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(result.current.activeListIndex).toBe(2);
+
+    await rerender({ width: 400 });
+
+    expect(result.current.activeListIndex).toBe(2);
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(800));
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(syncCurrentIndex).toHaveBeenLastCalledWith(2);
+    expect(result.current.activeListIndex).toBe(2);
+  });
+
+  it('cancels an in-flight settle and restores the committed cell after width changes', async () => {
+    const syncCurrentIndex = jest.fn();
+    const { rerender, result } = await renderHook<UseGestureViewerPagingResult, { width: number }>(
+      ({ width }) =>
+        useGestureViewerPaging(createArgs({ adjustedInitialIndex: 1, syncCurrentIndex, width })),
+      {
+        initialProps: { width: 320 },
+      },
+    );
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(640));
+    });
+
+    await rerender({ width: 400 });
+
+    expect(result.current.activeListIndex).toBe(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(syncCurrentIndex).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(400));
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(syncCurrentIndex).toHaveBeenLastCalledWith(1);
+    expect(result.current.activeListIndex).toBe(1);
+  });
+
+  it('keeps the last settled cell when item spacing changes after mounting away from zero', async () => {
+    const syncCurrentIndex = jest.fn();
+    const { rerender, result } = await renderHook<
+      UseGestureViewerPagingResult,
+      { itemSpacing: number }
+    >(
+      ({ itemSpacing }) =>
+        useGestureViewerPaging(
+          createArgs({ adjustedInitialIndex: 1, itemSpacing, syncCurrentIndex }),
+        ),
+      {
+        initialProps: { itemSpacing: 0 },
+      },
+    );
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(640));
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(result.current.activeListIndex).toBe(2);
+
+    await rerender({ itemSpacing: 24 });
+
+    expect(result.current.activeListIndex).toBe(2);
+
+    await act(async () => {
+      result.current.onScroll?.(createScrollEvent(688));
+      jest.advanceTimersByTime(180);
+    });
+
+    expect(syncCurrentIndex).toHaveBeenLastCalledWith(2);
+    expect(result.current.activeListIndex).toBe(2);
+  });
+
   it('resets the active cell when the adjusted initial index changes', async () => {
     const { rerender, result } = await renderHook<
       UseGestureViewerPagingResult,

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -3,7 +3,8 @@ import {
   ScrollView as GestureScrollView,
 } from 'react-native-gesture-handler';
 
-import { shouldUseNativeScrollGesture } from '../utils';
+import { clampTranslationToBounds, shouldUseNativeScrollGesture } from '../utils';
+import { getTapZoomTarget } from '../utils/tapZoom';
 import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from '../utils/zoom';
 
 function PlainScrollView() {
@@ -28,6 +29,247 @@ describe('shouldUseNativeScrollGesture', () => {
   it('does not double-apply the workaround to RNGH scrollables', () => {
     expect(shouldUseNativeScrollGesture('ios', GestureScrollView)).toBe(false);
     expect(shouldUseNativeScrollGesture('ios', GestureFlatList)).toBe(false);
+  });
+});
+
+describe('clampTranslationToBounds', () => {
+  it('preserves translation below or at scale one', () => {
+    expect(
+      clampTranslationToBounds({
+        height: 852,
+        scale: 1,
+        translateX: 999,
+        translateY: -999,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: 999,
+      translateY: -999,
+    });
+  });
+
+  it('clamps contain-fitted content to its actual edge', () => {
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: 2,
+        translateX: 0,
+        translateY: 426,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: 0,
+      translateY: 190,
+    });
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: 2,
+        translateX: 0,
+        translateY: -426,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: 0,
+      translateY: -190,
+    });
+  });
+
+  it('keeps an axis centered while scaled content is still smaller than the viewport', () => {
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: 1.2,
+        translateX: 20,
+        translateY: 118,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: 20,
+      translateY: 0,
+    });
+  });
+
+  it('keeps the letterboxed axis centered through the scale threshold', () => {
+    const thresholdScale = 852 / 616;
+
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: thresholdScale - 0.001,
+        translateX: 0,
+        translateY: 20,
+        width: 393,
+      }).translateY,
+    ).toBe(0);
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: thresholdScale,
+        translateX: 0,
+        translateY: 20,
+        width: 393,
+      }).translateY,
+    ).toBe(0);
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: thresholdScale + 0.001,
+        translateX: 0,
+        translateY: 20,
+        width: 393,
+      }).translateY,
+    ).toBeCloseTo(0.308, 3);
+  });
+
+  it('keeps in-range values and clamps both edges symmetrically', () => {
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: 3,
+        translateX: 30,
+        translateY: 400,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: 30,
+      translateY: 400,
+    });
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: 3,
+        translateX: 900,
+        translateY: 900,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: 393,
+      translateY: 498,
+    });
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        scale: 3,
+        translateX: -900,
+        translateY: -900,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: -393,
+      translateY: -498,
+    });
+  });
+
+  it('falls back to viewport-cell bounds when content dimensions are missing or invalid', () => {
+    expect(
+      clampTranslationToBounds({
+        contentHeight: 0,
+        contentWidth: Number.NaN,
+        height: 852,
+        scale: 2,
+        translateX: 999,
+        translateY: 999,
+        width: 393,
+      }),
+    ).toEqual({
+      translateX: 196.5,
+      translateY: 426,
+    });
+  });
+});
+
+describe('getTapZoomTarget', () => {
+  it('keeps existing callers on the viewport-cell fallback', () => {
+    expect(
+      getTapZoomTarget({
+        height: 852,
+        maxZoomScale: 2,
+        scale: 1,
+        width: 393,
+        x: 196.5,
+        y: 852,
+      }),
+    ).toEqual({
+      scale: 2,
+      translateX: 0,
+      translateY: -426,
+    });
+  });
+
+  it('clamps double-tap zoom targets to content-aware bounds', () => {
+    expect(
+      getTapZoomTarget({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        maxZoomScale: 2,
+        scale: 1,
+        width: 393,
+        x: 196.5,
+        y: 852,
+      }),
+    ).toEqual({
+      scale: 2,
+      translateX: 0,
+      translateY: -190,
+    });
+  });
+
+  it('keeps tap zoom centered on an axis until scaled content fills the viewport', () => {
+    expect(
+      getTapZoomTarget({
+        contentHeight: 221,
+        contentWidth: 393,
+        height: 852,
+        maxZoomScale: 2,
+        scale: 1,
+        width: 393,
+        x: 196.5,
+        y: 852,
+      }),
+    ).toEqual({
+      scale: 2,
+      translateX: 0,
+      translateY: 0,
+    });
+  });
+
+  it('resets tap zoom back to centered scale one', () => {
+    expect(
+      getTapZoomTarget({
+        contentHeight: 616,
+        contentWidth: 393,
+        height: 852,
+        maxZoomScale: 2,
+        scale: 2,
+        width: 393,
+        x: 196.5,
+        y: 852,
+      }),
+    ).toEqual({
+      scale: 1,
+      translateX: 0,
+      translateY: 0,
+    });
   });
 });
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   clampIndex,
   clampTranslationToBounds,
   getLoopPhysicalIndex,
+  resolveGeometrySyncTranslationMode,
   shouldUseNativeScrollGesture,
 } from '../utils';
 import { getTapZoomTarget } from '../utils/tapZoom';
@@ -37,6 +38,16 @@ describe('getLoopPhysicalIndex', () => {
     expect(getLoopPhysicalIndex(0, 3, false)).toBe(0);
     expect(getLoopPhysicalIndex(2, 3, true)).toBe(3);
     expect(getLoopPhysicalIndex(0, 1, true)).toBe(0);
+  });
+});
+
+describe('resolveGeometrySyncTranslationMode', () => {
+  it('resets a new item and constrains only an existing zoomed item', () => {
+    expect(resolveGeometrySyncTranslationMode(0, 1, 2)).toBe('reset');
+    expect(resolveGeometrySyncTranslationMode(0, 1, 1)).toBe('reset');
+    expect(resolveGeometrySyncTranslationMode(0, 0, 2)).toBe('constrain');
+    expect(resolveGeometrySyncTranslationMode(null, 0, 2)).toBe('constrain');
+    expect(resolveGeometrySyncTranslationMode(0, 0, 1)).toBe('none');
   });
 });
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -3,7 +3,12 @@ import {
   ScrollView as GestureScrollView,
 } from 'react-native-gesture-handler';
 
-import { clampTranslationToBounds, shouldUseNativeScrollGesture } from '../utils';
+import {
+  clampIndex,
+  clampTranslationToBounds,
+  getLoopPhysicalIndex,
+  shouldUseNativeScrollGesture,
+} from '../utils';
 import { getTapZoomTarget } from '../utils/tapZoom';
 import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from '../utils/zoom';
 
@@ -14,6 +19,26 @@ function PlainScrollView() {
 function PlainFlatList() {
   return null;
 }
+
+describe('clampIndex', () => {
+  it('normalizes initial indexes against the current data length', () => {
+    expect(clampIndex(2, 3)).toBe(2);
+    expect(clampIndex(9, 3)).toBe(2);
+    expect(clampIndex(-2, 3)).toBe(0);
+    expect(clampIndex(1.8, 3)).toBe(1);
+    expect(clampIndex(Number.NaN, 3)).toBe(0);
+    expect(clampIndex(Number.POSITIVE_INFINITY, 3)).toBe(0);
+    expect(clampIndex(2, 0)).toBe(0);
+  });
+});
+
+describe('getLoopPhysicalIndex', () => {
+  it('maps logical indexes only when loop sentinels exist', () => {
+    expect(getLoopPhysicalIndex(0, 3, false)).toBe(0);
+    expect(getLoopPhysicalIndex(2, 3, true)).toBe(3);
+    expect(getLoopPhysicalIndex(0, 1, true)).toBe(0);
+  });
+});
 
 describe('shouldUseNativeScrollGesture', () => {
   it('enables the native scroll workaround for non-RNGH scrollables on iOS', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,8 @@ export type {
   GestureViewerEventCallback,
   GestureViewerEventData,
   GestureViewerEventType,
+  GestureViewerItemDimensions,
+  GestureViewerItemDimensionsResolver,
   GestureViewerProps,
   GestureViewerRenderItemInfo,
   GestureViewerState,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,8 @@ export type {
   GestureViewerEventType,
   GestureViewerItemDimensions,
   GestureViewerItemDimensionsResolver,
+  GestureViewerItemKey,
+  GestureViewerItemKeyResolver,
   GestureViewerProps,
   GestureViewerRenderItemInfo,
   GestureViewerState,

--- a/src/itemDimensions.ts
+++ b/src/itemDimensions.ts
@@ -8,9 +8,10 @@ type ItemDimensionsRegistryEntry<ItemT> = Readonly<{
 export type ItemDimensionsRegistry<ItemT> = Map<number, ItemDimensionsRegistryEntry<ItemT>>;
 
 export const isValidItemDimensions = (
-  dimensions: GestureViewerItemDimensions | undefined,
+  dimensions: GestureViewerItemDimensions | null | undefined,
 ): dimensions is GestureViewerItemDimensions => {
   return (
+    dimensions !== null &&
     dimensions !== undefined &&
     Number.isFinite(dimensions.width) &&
     Number.isFinite(dimensions.height) &&
@@ -21,10 +22,10 @@ export const isValidItemDimensions = (
 
 export const pruneItemDimensionsRegistry = <ItemT>(
   registry: ItemDimensionsRegistry<ItemT>,
-  data: readonly ItemT[],
+  dataLength: number,
 ): void => {
-  for (const [index, entry] of registry) {
-    if (index < 0 || index >= data.length || !Object.is(data[index], entry.item)) {
+  for (const index of registry.keys()) {
+    if (index < 0 || index >= dataLength) {
       registry.delete(index);
     }
   }
@@ -58,7 +59,15 @@ export const resolveItemDimensions = <ItemT>({
 
   const resolved = getItemDimensions?.(item, index);
 
-  return isValidItemDimensions(resolved) ? resolved : undefined;
+  if (isValidItemDimensions(resolved)) {
+    return resolved;
+  }
+
+  if (registered && isValidItemDimensions(registered.dimensions)) {
+    return registered.dimensions;
+  }
+
+  return undefined;
 };
 
 export const registerItemDimensions = <ItemT>({

--- a/src/itemDimensions.ts
+++ b/src/itemDimensions.ts
@@ -80,6 +80,8 @@ export const resolveItemDimensions = <ItemT>({
     return undefined;
   }
 
+  // `as ItemT` restores the viewer's dense-list invariant, which TypeScript cannot infer from
+  // generic indexed access when `noUncheckedIndexedAccess` is enabled.
   const item = data[index] as ItemT;
   const registered = registry.get(index);
   const itemKey = registered ? resolveItemKey(getItemKey, item, index) : undefined;
@@ -120,6 +122,8 @@ export const registerItemDimensions = <ItemT>({
     return false;
   }
 
+  // `as ItemT` restores the viewer's dense-list invariant, which TypeScript cannot infer from
+  // generic indexed access when `noUncheckedIndexedAccess` is enabled.
   const currentItem = data[index] as ItemT;
   const currentItemKey = resolveItemKey(getItemKey, currentItem, index);
   const reportedItemKey = Object.is(currentItem, item)

--- a/src/itemDimensions.ts
+++ b/src/itemDimensions.ts
@@ -1,0 +1,106 @@
+import type { GestureViewerItemDimensions, GestureViewerItemDimensionsResolver } from './types';
+
+type ItemDimensionsRegistryEntry<ItemT> = Readonly<{
+  item: ItemT;
+  dimensions: GestureViewerItemDimensions;
+}>;
+
+export type ItemDimensionsRegistry<ItemT> = Map<number, ItemDimensionsRegistryEntry<ItemT>>;
+
+export const isValidItemDimensions = (
+  dimensions: GestureViewerItemDimensions | undefined,
+): dimensions is GestureViewerItemDimensions => {
+  return (
+    dimensions !== undefined &&
+    Number.isFinite(dimensions.width) &&
+    Number.isFinite(dimensions.height) &&
+    dimensions.width > 0 &&
+    dimensions.height > 0
+  );
+};
+
+export const pruneItemDimensionsRegistry = <ItemT>(
+  registry: ItemDimensionsRegistry<ItemT>,
+  data: readonly ItemT[],
+): void => {
+  for (const [index, entry] of registry) {
+    if (index < 0 || index >= data.length || !Object.is(data[index], entry.item)) {
+      registry.delete(index);
+    }
+  }
+};
+
+export const resolveItemDimensions = <ItemT>({
+  registry,
+  data,
+  index,
+  getItemDimensions,
+}: {
+  registry: ItemDimensionsRegistry<ItemT>;
+  data: readonly ItemT[];
+  index: number;
+  getItemDimensions?: GestureViewerItemDimensionsResolver<ItemT>;
+}): GestureViewerItemDimensions | undefined => {
+  if (index < 0 || index >= data.length) {
+    return undefined;
+  }
+
+  const item = data[index] as ItemT;
+  const registered = registry.get(index);
+
+  if (
+    registered &&
+    Object.is(registered.item, item) &&
+    isValidItemDimensions(registered.dimensions)
+  ) {
+    return registered.dimensions;
+  }
+
+  const resolved = getItemDimensions?.(item, index);
+
+  return isValidItemDimensions(resolved) ? resolved : undefined;
+};
+
+export const registerItemDimensions = <ItemT>({
+  registry,
+  data,
+  index,
+  item,
+  dimensions,
+}: {
+  registry: ItemDimensionsRegistry<ItemT>;
+  data: readonly ItemT[];
+  index: number;
+  item: ItemT;
+  dimensions: GestureViewerItemDimensions;
+}): boolean => {
+  if (
+    index < 0 ||
+    index >= data.length ||
+    !Object.is(data[index], item) ||
+    !isValidItemDimensions(dimensions)
+  ) {
+    return false;
+  }
+
+  const registered = registry.get(index);
+
+  if (
+    registered &&
+    Object.is(registered.item, item) &&
+    registered.dimensions.width === dimensions.width &&
+    registered.dimensions.height === dimensions.height
+  ) {
+    return false;
+  }
+
+  registry.set(index, {
+    item,
+    dimensions: {
+      height: dimensions.height,
+      width: dimensions.width,
+    },
+  });
+
+  return true;
+};

--- a/src/itemDimensions.ts
+++ b/src/itemDimensions.ts
@@ -1,7 +1,13 @@
-import type { GestureViewerItemDimensions, GestureViewerItemDimensionsResolver } from './types';
+import type {
+  GestureViewerItemDimensions,
+  GestureViewerItemDimensionsResolver,
+  GestureViewerItemKey,
+  GestureViewerItemKeyResolver,
+} from './types';
 
 type ItemDimensionsRegistryEntry<ItemT> = Readonly<{
   item: ItemT;
+  itemKey?: GestureViewerItemKey;
   dimensions: GestureViewerItemDimensions;
 }>;
 
@@ -20,6 +26,32 @@ export const isValidItemDimensions = (
   );
 };
 
+const resolveItemKey = <ItemT>(
+  getItemKey: GestureViewerItemKeyResolver<ItemT> | undefined,
+  item: ItemT,
+  index: number,
+): GestureViewerItemKey | undefined => {
+  const itemKey = getItemKey?.(item, index);
+
+  if (typeof itemKey === 'string') {
+    return itemKey;
+  }
+
+  return typeof itemKey === 'number' && Number.isFinite(itemKey) ? itemKey : undefined;
+};
+
+const doesEntryMatchItem = <ItemT>(
+  entry: ItemDimensionsRegistryEntry<ItemT>,
+  item: ItemT,
+  itemKey: GestureViewerItemKey | undefined,
+): boolean => {
+  if (itemKey !== undefined && entry.itemKey !== undefined) {
+    return entry.itemKey === itemKey;
+  }
+
+  return Object.is(entry.item, item);
+};
+
 export const pruneItemDimensionsRegistry = <ItemT>(
   registry: ItemDimensionsRegistry<ItemT>,
   dataLength: number,
@@ -36,11 +68,13 @@ export const resolveItemDimensions = <ItemT>({
   data,
   index,
   getItemDimensions,
+  getItemKey,
 }: {
   registry: ItemDimensionsRegistry<ItemT>;
   data: readonly ItemT[];
   index: number;
   getItemDimensions?: GestureViewerItemDimensionsResolver<ItemT>;
+  getItemKey?: GestureViewerItemKeyResolver<ItemT>;
 }): GestureViewerItemDimensions | undefined => {
   if (index < 0 || index >= data.length) {
     return undefined;
@@ -48,10 +82,11 @@ export const resolveItemDimensions = <ItemT>({
 
   const item = data[index] as ItemT;
   const registered = registry.get(index);
+  const itemKey = registered ? resolveItemKey(getItemKey, item, index) : undefined;
 
   if (
     registered &&
-    Object.is(registered.item, item) &&
+    doesEntryMatchItem(registered, item, itemKey) &&
     isValidItemDimensions(registered.dimensions)
   ) {
     return registered.dimensions;
@@ -63,10 +98,6 @@ export const resolveItemDimensions = <ItemT>({
     return resolved;
   }
 
-  if (registered && isValidItemDimensions(registered.dimensions)) {
-    return registered.dimensions;
-  }
-
   return undefined;
 };
 
@@ -76,19 +107,30 @@ export const registerItemDimensions = <ItemT>({
   index,
   item,
   dimensions,
+  getItemKey,
 }: {
   registry: ItemDimensionsRegistry<ItemT>;
   data: readonly ItemT[];
   index: number;
   item: ItemT;
   dimensions: GestureViewerItemDimensions;
+  getItemKey?: GestureViewerItemKeyResolver<ItemT>;
 }): boolean => {
-  if (
-    index < 0 ||
-    index >= data.length ||
-    !Object.is(data[index], item) ||
-    !isValidItemDimensions(dimensions)
-  ) {
+  if (index < 0 || index >= data.length || !isValidItemDimensions(dimensions)) {
+    return false;
+  }
+
+  const currentItem = data[index] as ItemT;
+  const currentItemKey = resolveItemKey(getItemKey, currentItem, index);
+  const reportedItemKey = Object.is(currentItem, item)
+    ? currentItemKey
+    : resolveItemKey(getItemKey, item, index);
+  const hasMatchingKey =
+    currentItemKey !== undefined &&
+    reportedItemKey !== undefined &&
+    currentItemKey === reportedItemKey;
+
+  if (!Object.is(currentItem, item) && !hasMatchingKey) {
     return false;
   }
 
@@ -96,7 +138,7 @@ export const registerItemDimensions = <ItemT>({
 
   if (
     registered &&
-    Object.is(registered.item, item) &&
+    doesEntryMatchItem(registered, currentItem, currentItemKey) &&
     registered.dimensions.width === dimensions.width &&
     registered.dimensions.height === dimensions.height
   ) {
@@ -104,7 +146,8 @@ export const registerItemDimensions = <ItemT>({
   }
 
   registry.set(index, {
-    item,
+    item: currentItem,
+    itemKey: currentItemKey,
     dimensions: {
       height: dimensions.height,
       width: dimensions.width,

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,13 @@ export type GestureViewerItemDimensionsResolver<ItemT> = (
   index: number,
 ) => GestureViewerItemDimensions | undefined;
 
+export type GestureViewerItemKey = string | number;
+
+export type GestureViewerItemKeyResolver<ItemT> = (
+  item: ItemT,
+  index: number,
+) => GestureViewerItemKey;
+
 export type GestureViewerRenderItemInfo = {
   /**
    * Whether the rendered item is currently active.
@@ -175,6 +182,11 @@ export interface GestureViewerProps<ItemT, LC> {
    * @remarks Return `undefined` while dimensions are unavailable. Invalid dimensions fall back to the viewer cell size.
    */
   getItemDimensions?: GestureViewerItemDimensionsResolver<ItemT>;
+  /**
+   * Returns a stable key used to retain loaded dimensions when equivalent item objects are recreated at the same index.
+   * @remarks Keys must be unique within `data` and change when the rendered content's natural dimensions can change. Do not use the index by itself. This is only needed when object items are recreated and dimensions are reported through `setItemDimensions`.
+   */
+  getItemKey?: GestureViewerItemKeyResolver<ItemT>;
   /**
    * A callback function that is called to render the container.
    * @remarks Useful for composing additional UI (e.g., close button, toolbars) around the viewer.

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,7 @@ export interface GestureViewerProps<ItemT, LC> {
   data: ItemT[];
   /**
    * The index of the item to display in the `GestureViewer` when the component is mounted.
+   * @remarks The value is normalized to the current data: non-finite or negative values use `0`, values above the available range use the last index, and empty data uses `0`. Updating this prop repositions a mounted viewer.
    * @defaultValue 0
    */
   initialIndex?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,12 +82,33 @@ export type GestureViewerSingleTapEvent<ItemT> = {
   item: ItemT;
 };
 
+export type GestureViewerItemDimensions = Readonly<{
+  /**
+   * Natural/source content width. Must be finite and greater than zero.
+   */
+  width: number;
+  /**
+   * Natural/source content height. Must be finite and greater than zero.
+   */
+  height: number;
+}>;
+
+export type GestureViewerItemDimensionsResolver<ItemT> = (
+  item: ItemT,
+  index: number,
+) => GestureViewerItemDimensions | undefined;
+
 export type GestureViewerRenderItemInfo = {
   /**
    * Whether the rendered item is currently active.
    * @remarks The current item remains active during a page transition. When the transition finishes on another item, that item becomes active.
    */
   readonly isActive: boolean;
+  /**
+   * Registers natural/source dimensions for the rendered item after they become available.
+   * @remarks Call this from a committed lifecycle or load callback, not directly while rendering.
+   */
+  readonly setItemDimensions: (dimensions: GestureViewerItemDimensions) => void;
 };
 
 export type GestureViewerDismissDirection = 'down' | 'up' | 'both';
@@ -149,6 +170,11 @@ export interface GestureViewerProps<ItemT, LC> {
    * - Prefer this callback over overlaying a pressable in `renderContainer` for fullscreen tap handling.
    */
   onSingleTap?: (event: GestureViewerSingleTapEvent<ItemT>) => void;
+  /**
+   * Returns natural/source dimensions for an item when they are already known.
+   * @remarks Return `undefined` while dimensions are unavailable. Invalid dimensions fall back to the viewer cell size.
+   */
+  getItemDimensions?: GestureViewerItemDimensionsResolver<ItemT>;
   /**
    * A callback function that is called to render the container.
    * @remarks Useful for composing additional UI (e.g., close button, toolbars) around the viewer.

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,7 @@ export type GestureViewerRenderItemInfo = {
   readonly isActive: boolean;
   /**
    * Registers natural/source dimensions for the rendered item after they become available.
-   * @remarks Call this from a committed lifecycle or load callback, not directly while rendering.
+   * @remarks Call this from an image load/event callback or a passive effect after commit. Do not call it directly while rendering or from descendant layout effects.
    */
   readonly setItemDimensions: (dimensions: GestureViewerItemDimensions) => void;
 };

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Platform, type View, useWindowDimensions } from 'react-native';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import {
@@ -14,10 +14,16 @@ import { scheduleOnRN } from 'react-native-worklets';
 
 import type GestureViewerManager from './GestureViewerManager';
 import { registry } from './GestureViewerRegistry';
+import {
+  type ItemDimensionsRegistry,
+  pruneItemDimensionsRegistry,
+  registerItemDimensions,
+  resolveItemDimensions,
+} from './itemDimensions';
 import { scheduleInitialScroll } from './scheduleInitialScroll';
-import type { GestureViewerProps, TriggerRect } from './types';
+import type { GestureViewerItemDimensions, GestureViewerProps, TriggerRect } from './types';
 import { useGestureViewerPaging } from './useGestureViewerPaging';
-import { createBoundsConstraint, createScrollAction } from './utils';
+import { clampTranslationToBounds, createScrollAction, getLoopAdjustedIndex } from './utils';
 import { getDismissDistance, shouldDismissByDirection } from './utils/dismiss';
 import { applyTapZoomAtPoint } from './utils/tapZoom';
 import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from './utils/zoom';
@@ -53,6 +59,7 @@ export const useGestureViewer = <ItemT, LC>({
   triggerAnimation,
   autoPlay = false,
   autoPlayInterval = 3000,
+  getItemDimensions,
 }: UseGestureViewerProps<ItemT, LC>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const width = customWidth || screenWidth;
@@ -74,7 +81,9 @@ export const useGestureViewer = <ItemT, LC>({
   const onAnimationCompleteRef = useRef(triggerAnimation?.onAnimationComplete);
   const onSingleTapRef = useRef(onSingleTap);
   const dataRef = useRef(data);
+  const getItemDimensionsRef = useRef(getItemDimensions);
   const managerRef = useRef(manager);
+  const itemDimensionsRef = useRef<ItemDimensionsRegistry<ItemT>>(new Map());
 
   const isValidTriggerRect = useCallback((rect: TriggerRect | null): rect is TriggerRect => {
     return !!rect && rect.width > 0 && rect.height > 0;
@@ -89,6 +98,8 @@ export const useGestureViewer = <ItemT, LC>({
   const scale = useSharedValue(1);
   const backdropOpacity = useSharedValue(1);
   const rotation = useSharedValue(0);
+  const contentWidth = useSharedValue(width);
+  const contentHeight = useSharedValue(height);
 
   const triggerScale = useSharedValue(1);
   const triggerTranslateX = useSharedValue(0);
@@ -103,6 +114,132 @@ export const useGestureViewer = <ItemT, LC>({
 
   const dataLength = data?.length || 0;
   const previousDataLengthRef = useRef(dataLength);
+  const viewportRef = useRef({ height, width });
+  const loopConfigRef = useRef({ dataLength, enableLoop });
+  const activeGeometryRef = useRef<{
+    contentHeight: number;
+    contentWidth: number;
+    height: number;
+    width: number;
+  } | null>(null);
+
+  const fitItemDimensions = useCallback(
+    (dimensions: GestureViewerItemDimensions | undefined): GestureViewerItemDimensions => {
+      const viewport = viewportRef.current;
+
+      if (!dimensions) {
+        return viewport;
+      }
+
+      const fitScale = Math.min(
+        viewport.width / dimensions.width,
+        viewport.height / dimensions.height,
+      );
+
+      return {
+        width: dimensions.width * fitScale,
+        height: dimensions.height * fitScale,
+      };
+    },
+    [],
+  );
+
+  const getLogicalIndex = useCallback((listIndex: number) => {
+    const { dataLength: currentDataLength, enableLoop: currentEnableLoop } = loopConfigRef.current;
+
+    if (currentDataLength <= 0) {
+      return listIndex;
+    }
+
+    return getLoopAdjustedIndex(listIndex, currentDataLength, currentEnableLoop).realIndex;
+  }, []);
+
+  const getActiveItemDimensions = useCallback(
+    (logicalIndex: number): GestureViewerItemDimensions | undefined => {
+      return resolveItemDimensions({
+        data: dataRef.current,
+        getItemDimensions: getItemDimensionsRef.current,
+        index: logicalIndex,
+        registry: itemDimensionsRef.current,
+      });
+    },
+    [],
+  );
+
+  const syncActiveContentDimensions = useCallback(
+    (logicalIndex = pendingIndexRef.current) => {
+      const viewport = viewportRef.current;
+      const fitted = fitItemDimensions(getActiveItemDimensions(logicalIndex));
+      const nextGeometry = {
+        contentHeight: fitted.height,
+        contentWidth: fitted.width,
+        height: viewport.height,
+        width: viewport.width,
+      };
+      const previousGeometry = activeGeometryRef.current;
+
+      if (
+        previousGeometry?.contentHeight === nextGeometry.contentHeight &&
+        previousGeometry.contentWidth === nextGeometry.contentWidth &&
+        previousGeometry.height === nextGeometry.height &&
+        previousGeometry.width === nextGeometry.width
+      ) {
+        return;
+      }
+
+      activeGeometryRef.current = nextGeometry;
+
+      if (contentWidth.get() !== fitted.width) {
+        contentWidth.set(fitted.width);
+      }
+      if (contentHeight.get() !== fitted.height) {
+        contentHeight.set(fitted.height);
+      }
+
+      if (scale.get() > 1) {
+        const { translateX: constrainedTranslateX, translateY: constrainedTranslateY } =
+          clampTranslationToBounds({
+            contentHeight: fitted.height,
+            contentWidth: fitted.width,
+            height: viewport.height,
+            scale: scale.get(),
+            translateX: translateX.get(),
+            translateY: translateY.get(),
+            width: viewport.width,
+          });
+
+        translateX.set(withTiming(constrainedTranslateX));
+        translateY.set(withTiming(constrainedTranslateY));
+      }
+    },
+    [
+      contentHeight,
+      contentWidth,
+      fitItemDimensions,
+      getActiveItemDimensions,
+      scale,
+      translateX,
+      translateY,
+    ],
+  );
+
+  const setItemDimensions = useCallback(
+    (listIndex: number, item: ItemT, dimensions: GestureViewerItemDimensions) => {
+      const logicalIndex = getLogicalIndex(listIndex);
+      const didUpdateDimensions = registerItemDimensions({
+        data: dataRef.current,
+        dimensions,
+        index: logicalIndex,
+        item,
+        registry: itemDimensionsRef.current,
+      });
+
+      if (didUpdateDimensions && logicalIndex === pendingIndexRef.current) {
+        syncActiveContentDimensions(logicalIndex);
+      }
+    },
+    [getLogicalIndex, syncActiveContentDimensions],
+  );
 
   const animationConfig = useMemo(
     () => ({
@@ -138,9 +275,29 @@ export const useGestureViewer = <ItemT, LC>({
     return initialIndex;
   }, [enableLoop, dataLength, initialIndex]);
 
-  const constrainTranslation = useMemo(
-    () => createBoundsConstraint({ height, width }),
-    [width, height],
+  const constrainTranslation = useCallback(
+    ({
+      scale: targetScale,
+      translateX: targetTranslateX,
+      translateY: targetTranslateY,
+    }: {
+      translateX: number;
+      translateY: number;
+      scale: number;
+    }) => {
+      'worklet';
+
+      return clampTranslationToBounds({
+        contentHeight: contentHeight.get(),
+        contentWidth: contentWidth.get(),
+        height,
+        scale: targetScale,
+        translateX: targetTranslateX,
+        translateY: targetTranslateY,
+        width,
+      });
+    },
+    [contentHeight, contentWidth, height, width],
   );
 
   const scrollTo = useCallback(
@@ -168,9 +325,14 @@ export const useGestureViewer = <ItemT, LC>({
         return;
       }
 
+      if (nextIndex === pendingIndexRef.current) {
+        return;
+      }
+
       pendingIndexRef.current = nextIndex;
+      syncActiveContentDimensions(nextIndex);
     },
-    [dataLength],
+    [dataLength, syncActiveContentDimensions],
   );
 
   const syncCurrentIndex = useCallback(
@@ -180,6 +342,7 @@ export const useGestureViewer = <ItemT, LC>({
       }
 
       pendingIndexRef.current = nextIndex;
+      syncActiveContentDimensions(nextIndex);
 
       const managerCurrentIndex = manager.getState().currentIndex;
 
@@ -191,7 +354,7 @@ export const useGestureViewer = <ItemT, LC>({
       manager.notifyStateChange();
       resetTransformState();
     },
-    [dataLength, manager, resetTransformState],
+    [dataLength, manager, resetTransformState, syncActiveContentDimensions],
   );
 
   const emitZoomChange = useCallback((currentScale: number, prevScale: number | null) => {
@@ -259,9 +422,17 @@ export const useGestureViewer = <ItemT, LC>({
     manager.setDataLength(dataLength);
     manager.setEnableHorizontalSwipe(enableHorizontalSwipe);
     manager.setCurrentIndex(initialIndex);
-    manager.setWidth(width + itemSpacing);
+    manager.setPagingStride(width + itemSpacing);
+    manager.setViewportWidth(width);
     manager.setHeight(height);
-    manager.setZoomSharedValues(scale, translateX, translateY, maxZoomScale);
+    manager.setZoomSharedValues({
+      contentHeight,
+      contentWidth,
+      maxZoomScale,
+      scale,
+      translateX,
+      translateY,
+    });
     manager.setResetTransformCallback(resetTransformState);
     manager.setRotation(rotation);
     manager.setEnableLoop(enableLoop);
@@ -277,6 +448,8 @@ export const useGestureViewer = <ItemT, LC>({
     enableLoop,
     scale,
     height,
+    contentWidth,
+    contentHeight,
     resetTransformState,
     translateX,
     translateY,
@@ -331,9 +504,18 @@ export const useGestureViewer = <ItemT, LC>({
     onAnimationCompleteRef.current = triggerAnimation?.onAnimationComplete;
   }, [triggerAnimation?.onAnimationComplete]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    // Retained virtualized-cell callbacks read only the most recently committed props.
     dataRef.current = data;
-  }, [data]);
+    getItemDimensionsRef.current = getItemDimensions;
+    viewportRef.current = { height, width };
+    loopConfigRef.current = { dataLength, enableLoop };
+    syncActiveContentDimensions();
+  }, [data, dataLength, enableLoop, getItemDimensions, height, syncActiveContentDimensions, width]);
+
+  useEffect(() => {
+    pruneItemDimensionsRegistry(itemDimensionsRef.current, data);
+  }, [data, dataLength]);
 
   useEffect(() => {
     managerRef.current = manager;
@@ -768,6 +950,8 @@ export const useGestureViewer = <ItemT, LC>({
         .numberOfTaps(2)
         .onEnd((event) => {
           applyTapZoomAtPoint({
+            contentHeight: contentHeight.get(),
+            contentWidth: contentWidth.get(),
             x: event.x,
             y: event.y,
             width,
@@ -778,7 +962,17 @@ export const useGestureViewer = <ItemT, LC>({
             translateY,
           });
         }),
-    [enableDoubleTapZoom, height, maxZoomScale, scale, translateX, translateY, width],
+    [
+      contentHeight,
+      contentWidth,
+      enableDoubleTapZoom,
+      height,
+      maxZoomScale,
+      scale,
+      translateX,
+      translateY,
+      width,
+    ],
   );
 
   const tapGesture = useMemo(
@@ -827,6 +1021,8 @@ export const useGestureViewer = <ItemT, LC>({
       adjustedInitialIndex,
       autoPlay,
       autoPlayInterval,
+      contentHeight,
+      contentWidth,
       currentIndex,
       dataLength,
       enableDoubleTapZoom,
@@ -866,6 +1062,7 @@ export const useGestureViewer = <ItemT, LC>({
     onScroll,
 
     onScrollBeginDrag,
+    setItemDimensions,
     zoomGesture,
   };
 };

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -537,8 +537,9 @@ export const useGestureViewer = <ItemT, LC>({
       didPageStrideChange,
       isInitial: isInitialPositionRender,
     } = getViewerPositionChanges(listPositionSnapshotRef.current, currentPositionSnapshot);
-
-    listPositionSnapshotRef.current = currentPositionSnapshot;
+    const commitPositionSnapshot = () => {
+      listPositionSnapshotRef.current = currentPositionSnapshot;
+    };
 
     const shouldResetToInitialIndex =
       isInitialPositionRender ||
@@ -548,6 +549,7 @@ export const useGestureViewer = <ItemT, LC>({
     const shouldRealignCurrentIndex = didPageStrideChange && !shouldResetToInitialIndex;
 
     if (!shouldResetToInitialIndex && !shouldRealignCurrentIndex) {
+      commitPositionSnapshot();
       return;
     }
 
@@ -559,10 +561,12 @@ export const useGestureViewer = <ItemT, LC>({
     rotation.set(0);
 
     if (dataLength === 0 || !listRef.current) {
+      commitPositionSnapshot();
       return;
     }
 
     if (isInitialPositionRender && adjustedInitialIndex === 0) {
+      commitPositionSnapshot();
       return;
     }
 
@@ -580,11 +584,13 @@ export const useGestureViewer = <ItemT, LC>({
     }
 
     if (shouldRealignCurrentIndex && physicalIndex === 0) {
+      commitPositionSnapshot();
       return;
     }
 
     return scheduleInitialScroll(() => {
       scrollTo(physicalIndex, false);
+      commitPositionSnapshot();
     });
   }, [
     adjustedInitialIndex,

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -406,7 +406,9 @@ export const useGestureViewer = <ItemT, LC>({
     const didDataLengthChange = previousDataLengthRef.current !== dataLength;
     const didLoopLayoutChange = previousUsesLoopSentinelsRef.current !== usesLoopSentinels;
     const hasValidInitialIndex = initialIndex >= 0 && initialIndex < dataLength;
-    const shouldResetForDataLength = didDataLengthChange && hasValidInitialIndex;
+    const targetInitialIndex = dataLength === 0 ? 0 : initialIndex;
+    const shouldResetForDataLength =
+      didDataLengthChange && (dataLength === 0 || hasValidInitialIndex);
     const shouldResetForLoopLayout = didLoopLayoutChange && hasValidInitialIndex;
     const shouldApplyInitialIndex =
       isNewManager ||
@@ -417,7 +419,7 @@ export const useGestureViewer = <ItemT, LC>({
       didInitialIndexPropChange ||
       shouldResetForDataLength ||
       shouldResetForLoopLayout ||
-      activeGeometryIndexRef.current !== initialIndex;
+      activeGeometryIndexRef.current !== targetInitialIndex;
 
     manager.setDataLength(dataLength);
     manager.setEnableHorizontalSwipe(enableHorizontalSwipe);
@@ -437,11 +439,11 @@ export const useGestureViewer = <ItemT, LC>({
     manager.setEnableLoop(enableLoop);
 
     if (shouldApplyInitialIndex) {
-      pendingIndexRef.current = initialIndex;
-      manager.setCurrentIndex(initialIndex);
+      pendingIndexRef.current = targetInitialIndex;
+      manager.setCurrentIndex(targetInitialIndex);
 
       if (shouldSyncInitialIndex) {
-        syncActiveContentDimensions(initialIndex);
+        syncActiveContentDimensions(targetInitialIndex);
       }
     }
 

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -39,6 +39,22 @@ type UseGestureViewerProps<ItemT, LC> = Omit<
   | 'enableSnapMode'
 >;
 
+function fitItemDimensions(
+  dimensions: GestureViewerItemDimensions | undefined,
+  viewport: GestureViewerItemDimensions,
+): GestureViewerItemDimensions {
+  if (!dimensions) {
+    return viewport;
+  }
+
+  const fitScale = Math.min(viewport.width / dimensions.width, viewport.height / dimensions.height);
+
+  return {
+    width: dimensions.width * fitScale,
+    height: dimensions.height * fitScale,
+  };
+}
+
 export const useGestureViewer = <ItemT, LC>({
   data,
   initialIndex = 0,
@@ -83,6 +99,8 @@ export const useGestureViewer = <ItemT, LC>({
   const dataRef = useRef(data);
   const getItemDimensionsRef = useRef(getItemDimensions);
   const managerRef = useRef(manager);
+  const configuredManagerRef = useRef<GestureViewerManager | null>(null);
+  const previousInitialIndexRef = useRef(initialIndex);
   const itemDimensionsRef = useRef<ItemDimensionsRegistry<ItemT>>(new Map());
 
   const isValidTriggerRect = useCallback((rect: TriggerRect | null): rect is TriggerRect => {
@@ -122,54 +140,20 @@ export const useGestureViewer = <ItemT, LC>({
     height: number;
     width: number;
   } | null>(null);
-
-  const fitItemDimensions = useCallback(
-    (dimensions: GestureViewerItemDimensions | undefined): GestureViewerItemDimensions => {
-      const viewport = viewportRef.current;
-
-      if (!dimensions) {
-        return viewport;
-      }
-
-      const fitScale = Math.min(
-        viewport.width / dimensions.width,
-        viewport.height / dimensions.height,
-      );
-
-      return {
-        width: dimensions.width * fitScale,
-        height: dimensions.height * fitScale,
-      };
-    },
-    [],
-  );
-
-  const getLogicalIndex = useCallback((listIndex: number) => {
-    const { dataLength: currentDataLength, enableLoop: currentEnableLoop } = loopConfigRef.current;
-
-    if (currentDataLength <= 0) {
-      return listIndex;
-    }
-
-    return getLoopAdjustedIndex(listIndex, currentDataLength, currentEnableLoop).realIndex;
-  }, []);
-
-  const getActiveItemDimensions = useCallback(
-    (logicalIndex: number): GestureViewerItemDimensions | undefined => {
-      return resolveItemDimensions({
-        data: dataRef.current,
-        getItemDimensions: getItemDimensionsRef.current,
-        index: logicalIndex,
-        registry: itemDimensionsRef.current,
-      });
-    },
-    [],
-  );
+  const activeGeometryIndexRef = useRef<number | null>(null);
 
   const syncActiveContentDimensions = useCallback(
     (logicalIndex = pendingIndexRef.current) => {
       const viewport = viewportRef.current;
-      const fitted = fitItemDimensions(getActiveItemDimensions(logicalIndex));
+      const fitted = fitItemDimensions(
+        resolveItemDimensions({
+          data: dataRef.current,
+          getItemDimensions: getItemDimensionsRef.current,
+          index: logicalIndex,
+          registry: itemDimensionsRef.current,
+        }),
+        viewport,
+      );
       const nextGeometry = {
         contentHeight: fitted.height,
         contentWidth: fitted.width,
@@ -177,6 +161,8 @@ export const useGestureViewer = <ItemT, LC>({
         width: viewport.width,
       };
       const previousGeometry = activeGeometryRef.current;
+
+      activeGeometryIndexRef.current = logicalIndex;
 
       if (
         previousGeometry?.contentHeight === nextGeometry.contentHeight &&
@@ -212,20 +198,17 @@ export const useGestureViewer = <ItemT, LC>({
         translateY.set(withTiming(constrainedTranslateY));
       }
     },
-    [
-      contentHeight,
-      contentWidth,
-      fitItemDimensions,
-      getActiveItemDimensions,
-      scale,
-      translateX,
-      translateY,
-    ],
+    [contentHeight, contentWidth, scale, translateX, translateY],
   );
 
   const setItemDimensions = useCallback(
     (listIndex: number, item: ItemT, dimensions: GestureViewerItemDimensions) => {
-      const logicalIndex = getLogicalIndex(listIndex);
+      const { dataLength: currentDataLength, enableLoop: currentEnableLoop } =
+        loopConfigRef.current;
+      const logicalIndex =
+        currentDataLength <= 0
+          ? listIndex
+          : getLoopAdjustedIndex(listIndex, currentDataLength, currentEnableLoop).realIndex;
       const didUpdateDimensions = registerItemDimensions({
         data: dataRef.current,
         dimensions,
@@ -238,7 +221,7 @@ export const useGestureViewer = <ItemT, LC>({
         syncActiveContentDimensions(logicalIndex);
       }
     },
-    [getLogicalIndex, syncActiveContentDimensions],
+    [syncActiveContentDimensions],
   );
 
   const animationConfig = useMemo(
@@ -267,13 +250,7 @@ export const useGestureViewer = <ItemT, LC>({
     ],
   );
 
-  const adjustedInitialIndex = useMemo(() => {
-    if (enableLoop && dataLength > 1) {
-      return initialIndex + 1;
-    }
-
-    return initialIndex;
-  }, [enableLoop, dataLength, initialIndex]);
+  const adjustedInitialIndex = enableLoop && dataLength > 1 ? initialIndex + 1 : initialIndex;
 
   const constrainTranslation = useCallback(
     ({
@@ -413,15 +390,19 @@ export const useGestureViewer = <ItemT, LC>({
   }, [id]);
 
   useEffect(() => {
-    pendingIndexRef.current = initialIndex;
-
     if (!manager) {
+      configuredManagerRef.current = null;
       return;
     }
 
+    const isNewManager = configuredManagerRef.current !== manager;
+    const didInitialIndexPropChange = previousInitialIndexRef.current !== initialIndex;
+    const shouldApplyInitialIndex = isNewManager || didInitialIndexPropChange;
+    const shouldSyncInitialIndex =
+      didInitialIndexPropChange || activeGeometryIndexRef.current !== initialIndex;
+
     manager.setDataLength(dataLength);
     manager.setEnableHorizontalSwipe(enableHorizontalSwipe);
-    manager.setCurrentIndex(initialIndex);
     manager.setPagingStride(width + itemSpacing);
     manager.setViewportWidth(width);
     manager.setHeight(height);
@@ -436,6 +417,18 @@ export const useGestureViewer = <ItemT, LC>({
     manager.setResetTransformCallback(resetTransformState);
     manager.setRotation(rotation);
     manager.setEnableLoop(enableLoop);
+
+    if (shouldApplyInitialIndex) {
+      pendingIndexRef.current = initialIndex;
+      manager.setCurrentIndex(initialIndex);
+
+      if (shouldSyncInitialIndex) {
+        syncActiveContentDimensions(initialIndex);
+      }
+    }
+
+    configuredManagerRef.current = manager;
+    previousInitialIndexRef.current = initialIndex;
     manager.notifyStateChange();
   }, [
     dataLength,
@@ -451,6 +444,7 @@ export const useGestureViewer = <ItemT, LC>({
     contentWidth,
     contentHeight,
     resetTransformState,
+    syncActiveContentDimensions,
     translateX,
     translateY,
     rotation,
@@ -514,8 +508,8 @@ export const useGestureViewer = <ItemT, LC>({
   }, [data, dataLength, enableLoop, getItemDimensions, height, syncActiveContentDimensions, width]);
 
   useEffect(() => {
-    pruneItemDimensionsRegistry(itemDimensionsRef.current, data);
-  }, [data, dataLength]);
+    pruneItemDimensionsRegistry(itemDimensionsRef.current, dataLength);
+  }, [dataLength]);
 
   useEffect(() => {
     managerRef.current = manager;

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -76,6 +76,7 @@ export const useGestureViewer = <ItemT, LC>({
   autoPlay = false,
   autoPlayInterval = 3000,
   getItemDimensions,
+  getItemKey,
 }: UseGestureViewerProps<ItemT, LC>) => {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const width = customWidth || screenWidth;
@@ -98,6 +99,7 @@ export const useGestureViewer = <ItemT, LC>({
   const onSingleTapRef = useRef(onSingleTap);
   const dataRef = useRef(data);
   const getItemDimensionsRef = useRef(getItemDimensions);
+  const getItemKeyRef = useRef(getItemKey);
   const managerRef = useRef(manager);
   const configuredManagerRef = useRef<GestureViewerManager | null>(null);
   const previousInitialIndexRef = useRef(initialIndex);
@@ -149,6 +151,7 @@ export const useGestureViewer = <ItemT, LC>({
         resolveItemDimensions({
           data: dataRef.current,
           getItemDimensions: getItemDimensionsRef.current,
+          getItemKey: getItemKeyRef.current,
           index: logicalIndex,
           registry: itemDimensionsRef.current,
         }),
@@ -212,6 +215,7 @@ export const useGestureViewer = <ItemT, LC>({
       const didUpdateDimensions = registerItemDimensions({
         data: dataRef.current,
         dimensions,
+        getItemKey: getItemKeyRef.current,
         index: logicalIndex,
         item,
         registry: itemDimensionsRef.current,
@@ -397,9 +401,15 @@ export const useGestureViewer = <ItemT, LC>({
 
     const isNewManager = configuredManagerRef.current !== manager;
     const didInitialIndexPropChange = previousInitialIndexRef.current !== initialIndex;
-    const shouldApplyInitialIndex = isNewManager || didInitialIndexPropChange;
+    const didDataLengthChange = previousDataLengthRef.current !== dataLength;
+    const hasValidInitialIndex = initialIndex >= 0 && initialIndex < dataLength;
+    const shouldResetForDataLength = didDataLengthChange && hasValidInitialIndex;
+    const shouldApplyInitialIndex =
+      isNewManager || didInitialIndexPropChange || shouldResetForDataLength;
     const shouldSyncInitialIndex =
-      didInitialIndexPropChange || activeGeometryIndexRef.current !== initialIndex;
+      didInitialIndexPropChange ||
+      shouldResetForDataLength ||
+      activeGeometryIndexRef.current !== initialIndex;
 
     manager.setDataLength(dataLength);
     manager.setEnableHorizontalSwipe(enableHorizontalSwipe);
@@ -502,10 +512,20 @@ export const useGestureViewer = <ItemT, LC>({
     // Retained virtualized-cell callbacks read only the most recently committed props.
     dataRef.current = data;
     getItemDimensionsRef.current = getItemDimensions;
+    getItemKeyRef.current = getItemKey;
     viewportRef.current = { height, width };
     loopConfigRef.current = { dataLength, enableLoop };
     syncActiveContentDimensions();
-  }, [data, dataLength, enableLoop, getItemDimensions, height, syncActiveContentDimensions, width]);
+  }, [
+    data,
+    dataLength,
+    enableLoop,
+    getItemDimensions,
+    getItemKey,
+    height,
+    syncActiveContentDimensions,
+    width,
+  ]);
 
   useEffect(() => {
     pruneItemDimensionsRegistry(itemDimensionsRef.current, dataLength);

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -29,6 +29,7 @@ import {
   createScrollAction,
   getLoopAdjustedIndex,
   getLoopPhysicalIndex,
+  resolveGeometrySyncTranslationMode,
 } from './utils';
 import { getDismissDistance, shouldDismissByDirection } from './utils/dismiss';
 import { applyTapZoomAtPoint } from './utils/tapZoom';
@@ -196,8 +197,22 @@ export const useGestureViewer = <ItemT, LC>({
         width: viewport.width,
       };
       const previousGeometry = activeGeometryRef.current;
+      const previousGeometryIndex = activeGeometryIndexRef.current;
 
       activeGeometryIndexRef.current = logicalIndex;
+
+      const currentScale = scale.get();
+      const translationMode = resolveGeometrySyncTranslationMode(
+        previousGeometryIndex,
+        logicalIndex,
+        currentScale,
+      );
+
+      if (translationMode === 'reset') {
+        // Complete the page-owned reset before the next item's geometry can reuse the old offset.
+        translateX.set(0);
+        translateY.set(0);
+      }
 
       if (
         previousGeometry?.contentHeight === nextGeometry.contentHeight &&
@@ -217,21 +232,23 @@ export const useGestureViewer = <ItemT, LC>({
         contentHeight.set(fitted.height);
       }
 
-      if (scale.get() > 1) {
-        const { translateX: constrainedTranslateX, translateY: constrainedTranslateY } =
-          clampTranslationToBounds({
-            contentHeight: fitted.height,
-            contentWidth: fitted.width,
-            height: viewport.height,
-            scale: scale.get(),
-            translateX: translateX.get(),
-            translateY: translateY.get(),
-            width: viewport.width,
-          });
-
-        translateX.set(withTiming(constrainedTranslateX));
-        translateY.set(withTiming(constrainedTranslateY));
+      if (translationMode !== 'constrain') {
+        return;
       }
+
+      const { translateX: constrainedTranslateX, translateY: constrainedTranslateY } =
+        clampTranslationToBounds({
+          contentHeight: fitted.height,
+          contentWidth: fitted.width,
+          height: viewport.height,
+          scale: currentScale,
+          translateX: translateX.get(),
+          translateY: translateY.get(),
+          width: viewport.width,
+        });
+
+      translateX.set(withTiming(constrainedTranslateX));
+      translateY.set(withTiming(constrainedTranslateY));
     },
     [contentHeight, contentWidth, scale, translateX, translateY],
   );

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -133,7 +133,9 @@ export const useGestureViewer = <ItemT, LC>({
   const hasActiveFocal = useSharedValue(false);
 
   const dataLength = data?.length || 0;
+  const usesLoopSentinels = enableLoop && dataLength > 1;
   const previousDataLengthRef = useRef(dataLength);
+  const previousUsesLoopSentinelsRef = useRef(usesLoopSentinels);
   const viewportRef = useRef({ height, width });
   const loopConfigRef = useRef({ dataLength, enableLoop });
   const activeGeometryRef = useRef<{
@@ -254,7 +256,7 @@ export const useGestureViewer = <ItemT, LC>({
     ],
   );
 
-  const adjustedInitialIndex = enableLoop && dataLength > 1 ? initialIndex + 1 : initialIndex;
+  const adjustedInitialIndex = usesLoopSentinels ? initialIndex + 1 : initialIndex;
 
   const constrainTranslation = useCallback(
     ({
@@ -402,13 +404,19 @@ export const useGestureViewer = <ItemT, LC>({
     const isNewManager = configuredManagerRef.current !== manager;
     const didInitialIndexPropChange = previousInitialIndexRef.current !== initialIndex;
     const didDataLengthChange = previousDataLengthRef.current !== dataLength;
+    const didLoopLayoutChange = previousUsesLoopSentinelsRef.current !== usesLoopSentinels;
     const hasValidInitialIndex = initialIndex >= 0 && initialIndex < dataLength;
     const shouldResetForDataLength = didDataLengthChange && hasValidInitialIndex;
+    const shouldResetForLoopLayout = didLoopLayoutChange && hasValidInitialIndex;
     const shouldApplyInitialIndex =
-      isNewManager || didInitialIndexPropChange || shouldResetForDataLength;
+      isNewManager ||
+      didInitialIndexPropChange ||
+      shouldResetForDataLength ||
+      shouldResetForLoopLayout;
     const shouldSyncInitialIndex =
       didInitialIndexPropChange ||
       shouldResetForDataLength ||
+      shouldResetForLoopLayout ||
       activeGeometryIndexRef.current !== initialIndex;
 
     manager.setDataLength(dataLength);
@@ -458,6 +466,7 @@ export const useGestureViewer = <ItemT, LC>({
     translateX,
     translateY,
     rotation,
+    usesLoopSentinels,
   ]);
 
   useEffect(() => {
@@ -470,9 +479,11 @@ export const useGestureViewer = <ItemT, LC>({
 
   useEffect(() => {
     const hasDataLengthChanged = previousDataLengthRef.current !== dataLength;
+    const hasLoopLayoutChanged = previousUsesLoopSentinelsRef.current !== usesLoopSentinels;
     const hasValidInitialIndex = initialIndex >= 0 && initialIndex < dataLength;
 
     previousDataLengthRef.current = dataLength;
+    previousUsesLoopSentinelsRef.current = usesLoopSentinels;
     translateY.set(0);
     translateX.set(0);
     scale.set(1);
@@ -482,7 +493,7 @@ export const useGestureViewer = <ItemT, LC>({
 
     if (
       !hasValidInitialIndex ||
-      (!hasDataLengthChanged && adjustedInitialIndex <= 0) ||
+      (!hasDataLengthChanged && !hasLoopLayoutChanged && adjustedInitialIndex <= 0) ||
       !listRef.current
     ) {
       return;
@@ -502,6 +513,7 @@ export const useGestureViewer = <ItemT, LC>({
     startScale,
     rotation,
     scrollTo,
+    usesLoopSentinels,
   ]);
 
   useEffect(() => {

--- a/src/useGestureViewer.ts
+++ b/src/useGestureViewer.ts
@@ -23,7 +23,13 @@ import {
 import { scheduleInitialScroll } from './scheduleInitialScroll';
 import type { GestureViewerItemDimensions, GestureViewerProps, TriggerRect } from './types';
 import { useGestureViewerPaging } from './useGestureViewerPaging';
-import { clampTranslationToBounds, createScrollAction, getLoopAdjustedIndex } from './utils';
+import {
+  clampIndex,
+  clampTranslationToBounds,
+  createScrollAction,
+  getLoopAdjustedIndex,
+  getLoopPhysicalIndex,
+} from './utils';
 import { getDismissDistance, shouldDismissByDirection } from './utils/dismiss';
 import { applyTapZoomAtPoint } from './utils/tapZoom';
 import { calculateFocalPointTranslation, shouldAcceptFocalPoint } from './utils/zoom';
@@ -38,6 +44,27 @@ type UseGestureViewerProps<ItemT, LC> = Omit<
   | 'backdropStyle'
   | 'enableSnapMode'
 >;
+
+type ViewerPositionSnapshot = Readonly<{
+  dataLength: number;
+  initialIndex: number;
+  pageStride: number;
+  usesLoopSentinels: boolean;
+}>;
+
+function getViewerPositionChanges(
+  previous: ViewerPositionSnapshot | null,
+  current: ViewerPositionSnapshot,
+) {
+  return {
+    isInitial: previous === null,
+    didDataLengthChange: previous !== null && previous.dataLength !== current.dataLength,
+    didInitialIndexChange: previous !== null && previous.initialIndex !== current.initialIndex,
+    didLoopLayoutChange:
+      previous !== null && previous.usesLoopSentinels !== current.usesLoopSentinels,
+    didPageStrideChange: previous !== null && previous.pageStride !== current.pageStride,
+  };
+}
 
 function fitItemDimensions(
   dimensions: GestureViewerItemDimensions | undefined,
@@ -102,7 +129,6 @@ export const useGestureViewer = <ItemT, LC>({
   const getItemKeyRef = useRef(getItemKey);
   const managerRef = useRef(manager);
   const configuredManagerRef = useRef<GestureViewerManager | null>(null);
-  const previousInitialIndexRef = useRef(initialIndex);
   const itemDimensionsRef = useRef<ItemDimensionsRegistry<ItemT>>(new Map());
 
   const isValidTriggerRect = useCallback((rect: TriggerRect | null): rect is TriggerRect => {
@@ -134,8 +160,12 @@ export const useGestureViewer = <ItemT, LC>({
 
   const dataLength = data?.length || 0;
   const usesLoopSentinels = enableLoop && dataLength > 1;
-  const previousDataLengthRef = useRef(dataLength);
-  const previousUsesLoopSentinelsRef = useRef(usesLoopSentinels);
+  const pageStride = width + itemSpacing;
+  const adjustedInitialIndex = getLoopPhysicalIndex(initialIndex, dataLength, enableLoop);
+  // Manager setup can rerender before a deferred list scroll runs, so each consumer tracks
+  // the last committed position inputs independently.
+  const managerPositionSnapshotRef = useRef<ViewerPositionSnapshot | null>(null);
+  const listPositionSnapshotRef = useRef<ViewerPositionSnapshot | null>(null);
   const viewportRef = useRef({ height, width });
   const loopConfigRef = useRef({ dataLength, enableLoop });
   const activeGeometryRef = useRef<{
@@ -256,8 +286,6 @@ export const useGestureViewer = <ItemT, LC>({
     ],
   );
 
-  const adjustedInitialIndex = usesLoopSentinels ? initialIndex + 1 : initialIndex;
-
   const constrainTranslation = useCallback(
     ({
       scale: targetScale,
@@ -285,11 +313,11 @@ export const useGestureViewer = <ItemT, LC>({
 
   const scrollTo = useCallback(
     (index: number, animated: boolean) => {
-      const scrollAction = createScrollAction(listRef.current, width + itemSpacing);
+      const scrollAction = createScrollAction(listRef.current, pageStride);
 
       return scrollAction.scrollTo(index, animated);
     },
-    [width, itemSpacing],
+    [pageStride],
   );
 
   const resetTransformState = useCallback(() => {
@@ -396,34 +424,34 @@ export const useGestureViewer = <ItemT, LC>({
   }, [id]);
 
   useEffect(() => {
+    const currentPositionSnapshot = {
+      dataLength,
+      initialIndex,
+      pageStride,
+      usesLoopSentinels,
+    };
+    const { didDataLengthChange, didInitialIndexChange, didLoopLayoutChange } =
+      getViewerPositionChanges(managerPositionSnapshotRef.current, currentPositionSnapshot);
+
+    managerPositionSnapshotRef.current = currentPositionSnapshot;
+
     if (!manager) {
       configuredManagerRef.current = null;
       return;
     }
 
     const isNewManager = configuredManagerRef.current !== manager;
-    const didInitialIndexPropChange = previousInitialIndexRef.current !== initialIndex;
-    const didDataLengthChange = previousDataLengthRef.current !== dataLength;
-    const didLoopLayoutChange = previousUsesLoopSentinelsRef.current !== usesLoopSentinels;
-    const hasValidInitialIndex = initialIndex >= 0 && initialIndex < dataLength;
-    const targetInitialIndex = dataLength === 0 ? 0 : initialIndex;
-    const shouldResetForDataLength =
-      didDataLengthChange && (dataLength === 0 || hasValidInitialIndex);
-    const shouldResetForLoopLayout = didLoopLayoutChange && hasValidInitialIndex;
     const shouldApplyInitialIndex =
-      isNewManager ||
-      didInitialIndexPropChange ||
-      shouldResetForDataLength ||
-      shouldResetForLoopLayout;
+      isNewManager || didInitialIndexChange || didDataLengthChange || didLoopLayoutChange;
     const shouldSyncInitialIndex =
-      didInitialIndexPropChange ||
-      shouldResetForDataLength ||
-      shouldResetForLoopLayout ||
-      activeGeometryIndexRef.current !== targetInitialIndex;
+      didInitialIndexChange ||
+      didDataLengthChange ||
+      didLoopLayoutChange ||
+      activeGeometryIndexRef.current !== initialIndex;
 
     manager.setDataLength(dataLength);
     manager.setEnableHorizontalSwipe(enableHorizontalSwipe);
-    manager.setPagingStride(width + itemSpacing);
+    manager.setPagingStride(pageStride);
     manager.setViewportWidth(width);
     manager.setHeight(height);
     manager.setZoomSharedValues({
@@ -439,24 +467,23 @@ export const useGestureViewer = <ItemT, LC>({
     manager.setEnableLoop(enableLoop);
 
     if (shouldApplyInitialIndex) {
-      pendingIndexRef.current = targetInitialIndex;
-      manager.setCurrentIndex(targetInitialIndex);
+      pendingIndexRef.current = initialIndex;
+      manager.setCurrentIndex(initialIndex);
 
       if (shouldSyncInitialIndex) {
-        syncActiveContentDimensions(targetInitialIndex);
+        syncActiveContentDimensions(initialIndex);
       }
     }
 
     configuredManagerRef.current = manager;
-    previousInitialIndexRef.current = initialIndex;
     manager.notifyStateChange();
   }, [
     dataLength,
     enableHorizontalSwipe,
     initialIndex,
     manager,
+    pageStride,
     width,
-    itemSpacing,
     maxZoomScale,
     enableLoop,
     scale,
@@ -480,12 +507,33 @@ export const useGestureViewer = <ItemT, LC>({
   }, [manager]);
 
   useEffect(() => {
-    const hasDataLengthChanged = previousDataLengthRef.current !== dataLength;
-    const hasLoopLayoutChanged = previousUsesLoopSentinelsRef.current !== usesLoopSentinels;
-    const hasValidInitialIndex = initialIndex >= 0 && initialIndex < dataLength;
+    const currentPositionSnapshot = {
+      dataLength,
+      initialIndex,
+      pageStride,
+      usesLoopSentinels,
+    };
+    const {
+      didDataLengthChange,
+      didInitialIndexChange,
+      didLoopLayoutChange,
+      didPageStrideChange,
+      isInitial: isInitialPositionRender,
+    } = getViewerPositionChanges(listPositionSnapshotRef.current, currentPositionSnapshot);
 
-    previousDataLengthRef.current = dataLength;
-    previousUsesLoopSentinelsRef.current = usesLoopSentinels;
+    listPositionSnapshotRef.current = currentPositionSnapshot;
+
+    const shouldResetToInitialIndex =
+      isInitialPositionRender ||
+      didInitialIndexChange ||
+      didDataLengthChange ||
+      didLoopLayoutChange;
+    const shouldRealignCurrentIndex = didPageStrideChange && !shouldResetToInitialIndex;
+
+    if (!shouldResetToInitialIndex && !shouldRealignCurrentIndex) {
+      return;
+    }
+
     translateY.set(0);
     translateX.set(0);
     scale.set(1);
@@ -493,21 +541,40 @@ export const useGestureViewer = <ItemT, LC>({
     startScale.set(1);
     rotation.set(0);
 
-    if (
-      !hasValidInitialIndex ||
-      (!hasDataLengthChanged && !hasLoopLayoutChanged && adjustedInitialIndex <= 0) ||
-      !listRef.current
-    ) {
+    if (dataLength === 0 || !listRef.current) {
+      return;
+    }
+
+    if (isInitialPositionRender && adjustedInitialIndex === 0) {
+      return;
+    }
+
+    const logicalIndex = shouldResetToInitialIndex
+      ? initialIndex
+      : clampIndex(
+          managerRef.current?.getState().currentIndex ?? pendingIndexRef.current,
+          dataLength,
+        );
+    const physicalIndex = getLoopPhysicalIndex(logicalIndex, dataLength, enableLoop);
+
+    if (shouldRealignCurrentIndex) {
+      pendingIndexRef.current = logicalIndex;
+      syncActiveContentDimensions(logicalIndex);
+    }
+
+    if (shouldRealignCurrentIndex && physicalIndex === 0) {
       return;
     }
 
     return scheduleInitialScroll(() => {
-      scrollTo(adjustedInitialIndex, false);
+      scrollTo(physicalIndex, false);
     });
   }, [
     adjustedInitialIndex,
     dataLength,
+    enableLoop,
     initialIndex,
+    pageStride,
     translateY,
     backdropOpacity,
     translateX,
@@ -515,6 +582,7 @@ export const useGestureViewer = <ItemT, LC>({
     startScale,
     rotation,
     scrollTo,
+    syncActiveContentDimensions,
     usesLoopSentinels,
   ]);
 

--- a/src/useGestureViewerPaging.ts
+++ b/src/useGestureViewerPaging.ts
@@ -25,12 +25,10 @@ export function useGestureViewerPaging({
   width,
 }: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
   const [activeListIndex, setActiveListIndex] = useState(adjustedInitialIndex);
-  const activeResetItemSpacing = adjustedInitialIndex > 0 ? itemSpacing : 0;
-  const activeResetWidth = adjustedInitialIndex > 0 ? width : 0;
 
   useEffect(() => {
     setActiveListIndex(adjustedInitialIndex);
-  }, [adjustedInitialIndex, activeResetItemSpacing, activeResetWidth, dataLength]);
+  }, [adjustedInitialIndex, dataLength]);
 
   useEffect(() => {
     if (

--- a/src/useGestureViewerPaging.types.ts
+++ b/src/useGestureViewerPaging.types.ts
@@ -8,6 +8,8 @@ export type UseGestureViewerPagingArgs = {
   adjustedInitialIndex: number;
   autoPlay: boolean;
   autoPlayInterval: number;
+  contentHeight: SharedValue<number>;
+  contentWidth: SharedValue<number>;
   currentIndex: number;
   dataLength: number;
   enableDoubleTapZoom: boolean;

--- a/src/useGestureViewerPaging.web.ts
+++ b/src/useGestureViewerPaging.web.ts
@@ -53,20 +53,25 @@ export function useGestureViewerPaging({
   width,
 }: UseGestureViewerPagingArgs): UseGestureViewerPagingResult {
   const [activeListIndex, setActiveListIndex] = useState(adjustedInitialIndex);
-  const activeResetItemSpacing = adjustedInitialIndex > 0 ? itemSpacing : 0;
-  const activeResetWidth = adjustedInitialIndex > 0 ? width : 0;
+  const pageStride = width + itemSpacing;
   const webSingleTapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const webScrollRuntimeRef = useRef<WebScrollRuntime>({
     actor: 'idle',
     isAutoplayPausedByUser: false,
     lastSettledPhysicalIndex: adjustedInitialIndex,
-    latestOffsetX: adjustedInitialIndex * (width + itemSpacing),
+    latestOffsetX: adjustedInitialIndex * pageStride,
     latestRawPhysicalIndex: adjustedInitialIndex,
     lastProgrammaticScrollVersion: 0,
     settleTimer: null,
     resumeAutoplayTimer: null,
   });
+  const previousPagingLayoutRef = useRef<{
+    adjustedInitialIndex: number;
+    dataLength: number;
+    manager: typeof manager;
+    pageStride: number;
+  } | null>(null);
 
   const clearWebSingleTapTimer = useCallback(() => {
     if (webSingleTapTimerRef.current) {
@@ -229,37 +234,46 @@ export function useGestureViewerPaging({
 
   useEffect(() => {
     const runtime = webScrollRuntimeRef.current;
+    const previousLayout = previousPagingLayoutRef.current;
+    const shouldResetToInitialIndex =
+      previousLayout === null ||
+      previousLayout.adjustedInitialIndex !== adjustedInitialIndex ||
+      previousLayout.dataLength !== dataLength ||
+      previousLayout.manager !== manager;
+    const didPageStrideChange = previousLayout !== null && previousLayout.pageStride !== pageStride;
+
+    previousPagingLayoutRef.current = {
+      adjustedInitialIndex,
+      dataLength,
+      manager,
+      pageStride,
+    };
+
+    if (!shouldResetToInitialIndex && !didPageStrideChange) {
+      return;
+    }
 
     runtime.actor = 'idle';
     runtime.isAutoplayPausedByUser = false;
-    runtime.lastSettledPhysicalIndex = adjustedInitialIndex;
-    runtime.latestOffsetX = adjustedInitialIndex * (activeResetWidth + activeResetItemSpacing);
-    runtime.latestRawPhysicalIndex = adjustedInitialIndex;
+
+    if (shouldResetToInitialIndex) {
+      runtime.lastSettledPhysicalIndex = adjustedInitialIndex;
+      setActiveListIndex(adjustedInitialIndex);
+    }
+
+    runtime.latestOffsetX = runtime.lastSettledPhysicalIndex * pageStride;
+    runtime.latestRawPhysicalIndex = runtime.lastSettledPhysicalIndex;
     runtime.lastProgrammaticScrollVersion = manager?.getProgrammaticScrollVersion() ?? 0;
-    setActiveListIndex(adjustedInitialIndex);
     clearWebSettleTimer();
     clearWebAutoplayResumeTimer();
   }, [
-    activeResetItemSpacing,
-    activeResetWidth,
     adjustedInitialIndex,
     clearWebAutoplayResumeTimer,
     clearWebSettleTimer,
     dataLength,
     manager,
+    pageStride,
   ]);
-
-  useEffect(() => {
-    const runtime = webScrollRuntimeRef.current;
-
-    runtime.actor = 'idle';
-    runtime.isAutoplayPausedByUser = false;
-    runtime.latestOffsetX = runtime.lastSettledPhysicalIndex * (width + itemSpacing);
-    runtime.latestRawPhysicalIndex = runtime.lastSettledPhysicalIndex;
-    runtime.lastProgrammaticScrollVersion = manager?.getProgrammaticScrollVersion() ?? 0;
-    clearWebSettleTimer();
-    clearWebAutoplayResumeTimer();
-  }, [clearWebAutoplayResumeTimer, clearWebSettleTimer, itemSpacing, manager, width]);
 
   useEffect(() => {
     return () => {

--- a/src/useGestureViewerPaging.web.ts
+++ b/src/useGestureViewerPaging.web.ts
@@ -30,6 +30,8 @@ export function useGestureViewerPaging({
   adjustedInitialIndex,
   autoPlay,
   autoPlayInterval,
+  contentHeight,
+  contentWidth,
   currentIndex,
   dataLength,
   enableDoubleTapZoom,
@@ -405,6 +407,8 @@ export function useGestureViewerPaging({
         scheduleWebAutoplayResume();
 
         applyTapZoomAtPoint({
+          contentHeight: contentHeight.get(),
+          contentWidth: contentWidth.get(),
           x: resolvedX,
           y: resolvedY,
           width,
@@ -430,6 +434,8 @@ export function useGestureViewerPaging({
     },
     [
       clearWebSingleTapTimer,
+      contentHeight,
+      contentWidth,
       enableDoubleTapZoom,
       height,
       maxZoomScale,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -47,34 +47,63 @@ export const shouldUseNativeScrollGesture = (
   return platformOS === 'ios' && component !== GestureScrollView && component !== GestureFlatList;
 };
 
-export const createBoundsConstraint =
-  ({ width, height }: { width: number; height: number }) =>
-  ({
-    scale,
-    translateX,
-    translateY,
-  }: {
-    translateX: number;
-    translateY: number;
-    scale: number;
-  }) => {
-    'worklet';
+const isValidDimension = (value: number): boolean => {
+  'worklet';
 
-    if (scale <= 1) {
-      return {
-        translateX,
-        translateY,
-      };
-    }
+  return Number.isFinite(value) && value > 0;
+};
 
-    const maxTranslateX = (width * scale - width) / 2;
-    const maxTranslateY = (height * scale - height) / 2;
+const clampTranslation = (value: number, max: number): number => {
+  'worklet';
 
+  if (max <= 0) {
+    return 0;
+  }
+
+  const clamped = Math.max(-max, Math.min(max, value));
+
+  return clamped === 0 ? 0 : clamped;
+};
+
+export const clampTranslationToBounds = ({
+  width,
+  height,
+  contentWidth,
+  contentHeight,
+  scale,
+  translateX,
+  translateY,
+}: {
+  width: number;
+  height: number;
+  contentWidth?: number;
+  contentHeight?: number;
+  translateX: number;
+  translateY: number;
+  scale: number;
+}) => {
+  'worklet';
+
+  if (scale <= 1) {
     return {
-      translateX: Math.max(-maxTranslateX, Math.min(maxTranslateX, translateX)),
-      translateY: Math.max(-maxTranslateY, Math.min(maxTranslateY, translateY)),
+      translateX,
+      translateY,
     };
+  }
+
+  const baseContentWidth =
+    contentWidth !== undefined && isValidDimension(contentWidth) ? contentWidth : width;
+  const baseContentHeight =
+    contentHeight !== undefined && isValidDimension(contentHeight) ? contentHeight : height;
+
+  const maxTranslateX = Math.max(0, (baseContentWidth * scale - width) / 2);
+  const maxTranslateY = Math.max(0, (baseContentHeight * scale - height) / 2);
+
+  return {
+    translateX: clampTranslation(translateX, maxTranslateX),
+    translateY: clampTranslation(translateY, maxTranslateY),
   };
+};
 
 export const createLoopData = <T>(dataRef: React.RefObject<T[]>, enableLoop: boolean): T[] => {
   const data = dataRef.current;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,6 +61,18 @@ export const clampIndex = (index: number | undefined, dataLength: number): numbe
   return Math.min(Math.max(Math.trunc(candidateIndex), 0), dataLength - 1);
 };
 
+export const resolveGeometrySyncTranslationMode = (
+  previousIndex: number | null,
+  nextIndex: number,
+  scale: number,
+): 'constrain' | 'none' | 'reset' => {
+  if (previousIndex !== null && previousIndex !== nextIndex) {
+    return 'reset';
+  }
+
+  return scale > 1 ? 'constrain' : 'none';
+};
+
 const isValidDimension = (value: number): boolean => {
   'worklet';
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -105,10 +105,8 @@ export const clampTranslationToBounds = ({
   };
 };
 
-export const createLoopData = <T>(dataRef: React.RefObject<T[]>, enableLoop: boolean): T[] => {
-  const data = dataRef.current;
-
-  if (!enableLoop || !data?.length || data.length <= 1) {
+export const createLoopData = <T>(data: T[], enableLoop: boolean): T[] => {
+  if (!enableLoop || data.length <= 1) {
     return data;
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -47,6 +47,20 @@ export const shouldUseNativeScrollGesture = (
   return platformOS === 'ios' && component !== GestureScrollView && component !== GestureFlatList;
 };
 
+export const clampIndex = (index: number | undefined, dataLength: number): number => {
+  if (dataLength <= 0) {
+    return 0;
+  }
+
+  const candidateIndex = index ?? 0;
+
+  if (!Number.isFinite(candidateIndex)) {
+    return 0;
+  }
+
+  return Math.min(Math.max(Math.trunc(candidateIndex), 0), dataLength - 1);
+};
+
 const isValidDimension = (value: number): boolean => {
   'worklet';
 
@@ -119,6 +133,12 @@ export const createLoopData = <T>(data: T[], enableLoop: boolean): T[] => {
 
   return [lastItem, ...data, firstItem];
 };
+
+export const getLoopPhysicalIndex = (
+  logicalIndex: number,
+  dataLength: number,
+  enableLoop: boolean,
+): number => (enableLoop && dataLength > 1 ? logicalIndex + 1 : logicalIndex);
 
 export const getLoopAdjustedIndex = (
   scrollIndex: number,

--- a/src/utils/tapZoom.ts
+++ b/src/utils/tapZoom.ts
@@ -1,11 +1,62 @@
 import type { SharedValue } from 'react-native-reanimated';
 import { Easing, withTiming } from 'react-native-reanimated';
 
+import { clampTranslationToBounds } from '.';
+
+export const getTapZoomTarget = ({
+  x,
+  y,
+  width,
+  height,
+  contentWidth,
+  contentHeight,
+  maxZoomScale,
+  scale,
+}: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  contentWidth?: number;
+  contentHeight?: number;
+  maxZoomScale: number;
+  scale: number;
+}) => {
+  'worklet';
+
+  const nextScale = scale > 1 ? 1 : maxZoomScale;
+
+  if (nextScale <= 1) {
+    return {
+      scale: nextScale,
+      translateX: 0,
+      translateY: 0,
+    };
+  }
+
+  const centerX = x - width / 2;
+  const centerY = y - height / 2;
+  return {
+    scale: nextScale,
+    ...clampTranslationToBounds({
+      contentHeight,
+      contentWidth,
+      height,
+      scale: nextScale,
+      translateX: -centerX * (nextScale - 1),
+      translateY: -centerY * (nextScale - 1),
+      width,
+    }),
+  };
+};
+
 export const applyTapZoomAtPoint = ({
   x,
   y,
   width,
   height,
+  contentWidth,
+  contentHeight,
   maxZoomScale,
   scale,
   translateX,
@@ -15,6 +66,8 @@ export const applyTapZoomAtPoint = ({
   y: number;
   width: number;
   height: number;
+  contentWidth?: number;
+  contentHeight?: number;
   maxZoomScale: number;
   scale: SharedValue<number>;
   translateX: SharedValue<number>;
@@ -22,23 +75,23 @@ export const applyTapZoomAtPoint = ({
 }) => {
   'worklet';
 
-  const nextScale = scale.get() > 1 ? 1 : maxZoomScale;
+  const target = getTapZoomTarget({
+    contentHeight,
+    contentWidth,
+    height,
+    maxZoomScale,
+    scale: scale.get(),
+    width,
+    x,
+    y,
+  });
   const timingConfig = {
     duration: 300,
     easing: Easing.bezier(0.25, 0.1, 0.25, 1),
   };
 
-  if (nextScale > 1) {
-    const centerX = x - width / 2;
-    const centerY = y - height / 2;
+  translateX.set(withTiming(target.translateX, timingConfig));
+  translateY.set(withTiming(target.translateY, timingConfig));
 
-    // NOTE 확대로 밀려난 거리만큼 반대로 이동해서 탭 지점을 제자리에 유지
-    translateX.set(withTiming(-centerX * (nextScale - 1), timingConfig));
-    translateY.set(withTiming(-centerY * (nextScale - 1), timingConfig));
-  } else {
-    translateX.set(withTiming(0, timingConfig));
-    translateY.set(withTiming(0, timingConfig));
-  }
-
-  scale.set(withTiming(nextScale, timingConfig));
+  scale.set(withTiming(target.scale, timingConfig));
 };


### PR DESCRIPTION
## Summary

- add optional per-item natural dimensions through `getItemDimensions` and `setItemDimensions`
- clamp pinch, pan, double-tap, web, and controller zoom to the rendered content rect
- keep axes centered while scaled content is smaller than the viewport
- add optional `getItemKey` for same-index object recreation without stale replacement reuse
- synchronize manager state when data-length or loop-layout changes reset the visible page
- keep empty viewers at `{ currentIndex: 0, totalCount: 0 }` without scrolling the list
- normalize `initialIndex` before it reaches manager state or native list props
- preserve the committed item across width and spacing changes on native and web
- preserve the existing viewer-cell fallback when current dimensions are unavailable

## Why

`contain`-fitted content can be smaller than its viewer cell. The previous bounds used the full
cell dimensions, so zoomed content could be panned past its visible edge into the backdrop.

This change tracks the active item's natural dimensions, converts them to its fitted content rect,
and uses that geometry consistently for every zoom entry point.

## API

Use `getItemDimensions` when dimensions are already known:

```tsx
const getImageDimensions = (item: ImageItem) => ({
  width: item.width,
  height: item.height,
});

<GestureViewer
  data={images}
  getItemDimensions={getImageDimensions}
  renderItem={(item) => <Image source={{ uri: item.uri }} resizeMode="contain" />}
/>
```

Use `setItemDimensions` when dimensions become available after loading. If equivalent object items
can be recreated at the same index, provide a stable content key as well:

```tsx
<GestureViewer
  data={images}
  getItemKey={(item) => item.uri}
  renderItem={(item, _index, { setItemDimensions }) => (
    <Image
      source={{ uri: item.uri }}
      resizeMode="contain"
      onLoad={({ nativeEvent }) => setItemDimensions(nativeEvent.source)}
    />
  )}
/>
```

All three inputs are optional. `getItemKey` is only needed for load-time dimensions when object
identity is recreated. Without it, runtime dimensions are reused only for the exact item instance;
replaced or reordered items use the viewer-cell fallback until current dimensions are available.

## Documentation

The deployed versioned v2 docs are included in companion PR #196 because the documentation site is
built from `next`. This PR keeps the package README, example, and changeset aligned with the v2 API.

## Validation

- `pnpm test --runInBand` — 13 suites / 107 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm changeset status`
- independent code review: APPROVE

## Deferred / not tested

- rotation-aware content bounds are intentionally deferred to follow-up work
- final reconciliation changes were not re-smoke-tested in an emulator
- the formal architect lane was unavailable because of a model compatibility error
- the reporter's application and device environment

Companion v3 and documentation PR: #196

Closes #191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added content-aware zoom and pan bounds for `contain`-fitted items across gestures and controller actions.
  - Added APIs for providing item dimensions before or after image loading.
  - Added stable item keys to preserve dimensions when items are recreated.
  - Added public types for item dimensions and keys.
  - Improved index normalization and position synchronization across layout, spacing, looping, and data changes.

- **Bug Fixes**
  - Fixed issue `#191`, preventing visible pages from becoming misaligned with viewer state.

- **Documentation**
  - Updated usage examples and added content-dimension guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->